### PR TITLE
ci: add trusted publisher PyPI release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build
+        run: |
+          pip install build
+          python -m build
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: "dist/*"
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- add a release-driven trusted publisher workflow for `assay`
- build sdist/wheel on GitHub-hosted runner
- emit GitHub build provenance attestations for `dist/*`
- publish via `pypa/gh-action-pypi-publish` using OIDC (`environment: pypi`)

## Why
Assay is currently consumed from a git tag in downstream CI. This unblocks normal PyPI installs and removes the `git+tag` workaround.

## Trigger model
- automatic on GitHub Release `published`
- manual `workflow_dispatch` for controlled dry-runs/debugging

## Follow-up after merge
1. Configure PyPI trusted publisher for `Haserjian/assay` + workflow `.github/workflows/publish.yml`.
2. Cut/publish the next release (for example `v1.10.1`) and verify on PyPI.
