### PR TITLE
fix: validate gate threshold and baseline score inputs

### DIFF
--- a/src/assay/commands.py
+++ b/src/assay/commands.py
@@ -4132,6 +4132,7 @@ def gate_check_cmd(
         DEFAULT_BASELINE_PATH,
         evaluate_gate,
         load_score_baseline,
+        normalize_score_value,
     )
     from assay.score import compute_evidence_readiness_score, gather_score_facts
 
@@ -4144,6 +4145,19 @@ def gate_check_cmd(
             )
         console.print(f"[red]Error:[/] Directory not found: {path}")
         raise typer.Exit(3)
+
+    validated_min_score = None
+    if min_score is not None:
+        validated_min_score = normalize_score_value(min_score)
+        if validated_min_score is None:
+            msg = "--min-score must be a finite number between 0 and 100"
+            if output_json:
+                _output_json(
+                    {"command": "assay gate", "status": "error", "error": msg},
+                    exit_code=3,
+                )
+            console.print(f"[red]Error:[/] {msg}")
+            raise typer.Exit(3)
 
     # Compute current score
     try:
@@ -4163,18 +4177,28 @@ def gate_check_cmd(
     if fail_on_regression:
         bp = P(baseline) if baseline else root / DEFAULT_BASELINE_PATH
         baseline_score = load_score_baseline(bp)
-        if baseline_score is None and baseline:
+        if baseline_score is None and bp.exists():
+            msg = f"Invalid baseline score in: {bp}"
             if output_json:
                 _output_json(
-                    {"command": "assay gate", "status": "error", "error": f"Baseline not found: {baseline}"},
+                    {"command": "assay gate", "status": "error", "error": msg},
                     exit_code=3,
                 )
-            console.print(f"[red]Error:[/] Baseline not found: {baseline}")
+            console.print(f"[red]Error:[/] {msg}")
+            raise typer.Exit(3)
+        if baseline_score is None and baseline:
+            msg = f"Baseline not found: {baseline}"
+            if output_json:
+                _output_json(
+                    {"command": "assay gate", "status": "error", "error": msg},
+                    exit_code=3,
+                )
+            console.print(f"[red]Error:[/] {msg}")
             raise typer.Exit(3)
 
     report = evaluate_gate(
         current_score=current,
-        min_score=min_score,
+        min_score=validated_min_score,
         fail_on_regression=fail_on_regression,
         baseline_score=baseline_score,
     )
@@ -4191,8 +4215,8 @@ def gate_check_cmd(
         "",
         f"Score:    {report['current_score']:.1f} ({report['current_grade']})",
     ]
-    if min_score is not None:
-        lines.append(f"Min:      {min_score:.1f}")
+    if validated_min_score is not None:
+        lines.append(f"Min:      {validated_min_score:.1f}")
     if baseline_score is not None:
         lines.append(f"Baseline: {baseline_score:.1f}")
     if report["regression_detected"]:

--- a/src/assay/gate.py
+++ b/src/assay/gate.py
@@ -12,6 +12,7 @@ Exit codes follow the CLI convention:
 from __future__ import annotations
 
 import json
+import math
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -71,10 +72,23 @@ def load_score_baseline(path: Path) -> Optional[float]:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
         if isinstance(data, dict) and "score" in data:
-            return float(data["score"])
+            return normalize_score_value(data["score"])
     except (json.JSONDecodeError, OSError, TypeError, ValueError):
         pass
     return None
+
+
+def normalize_score_value(value: Any) -> Optional[float]:
+    """Normalize a score value to a finite float in [0, 100]."""
+    try:
+        score = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(score):
+        return None
+    if score < 0 or score > 100:
+        return None
+    return score
 
 
 def save_score_baseline(score_data: Dict[str, Any], path: Path) -> Path:

--- a/tests/assay/test_gate.py
+++ b/tests/assay/test_gate.py
@@ -142,6 +142,16 @@ class TestBaselinePersistence:
         bf.write_text('{"grade": "A"}', encoding="utf-8")
         assert load_score_baseline(bf) is None
 
+    def test_load_out_of_range_score_returns_none(self, tmp_path: Path) -> None:
+        bf = tmp_path / "bad-range.json"
+        bf.write_text('{"score": 123.4}', encoding="utf-8")
+        assert load_score_baseline(bf) is None
+
+    def test_load_non_finite_score_returns_none(self, tmp_path: Path) -> None:
+        bf = tmp_path / "bad-nan.json"
+        bf.write_text('{"score": "nan"}', encoding="utf-8")
+        assert load_score_baseline(bf) is None
+
     def test_save_creates_parent_dirs(self, tmp_path: Path) -> None:
         bf = tmp_path / "deep" / "nested" / "baseline.json"
         save_score_baseline(_score(90), bf)
@@ -183,6 +193,22 @@ class TestGateCheckCLI:
         result = runner.invoke(assay_app, ["gate", "check", "/no/such/path", "--json"])
         assert result.exit_code == 3
 
+    def test_invalid_min_score_high_exit_3(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(assay_app, ["gate", "check", ".", "--min-score", "101", "--json"])
+        assert result.exit_code == 3, result.output
+        data = json.loads(result.output)
+        assert data["status"] == "error"
+        assert "between 0 and 100" in data["error"]
+
+    def test_invalid_min_score_non_finite_exit_3(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(assay_app, ["gate", "check", ".", "--min-score", "nan", "--json"])
+        assert result.exit_code == 3, result.output
+        data = json.loads(result.output)
+        assert data["status"] == "error"
+        assert "between 0 and 100" in data["error"]
+
     def test_regression_with_baseline_file(self, tmp_path: Path, monkeypatch) -> None:
         monkeypatch.chdir(tmp_path)
         Path("app.py").write_text("x = 1\n", encoding="utf-8")
@@ -207,6 +233,18 @@ class TestGateCheckCLI:
         # No baseline file exists, so regression check is skipped -> PASS (on regression dimension)
         data = json.loads(result.output)
         assert data["regression_detected"] is False
+
+    def test_regression_invalid_default_baseline_exit_3(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        Path("app.py").write_text("x = 1\n", encoding="utf-8")
+        bad = tmp_path / ".assay" / "score-baseline.json"
+        bad.parent.mkdir(parents=True, exist_ok=True)
+        bad.write_text('{"score": 500}', encoding="utf-8")
+        result = runner.invoke(assay_app, ["gate", "check", ".", "--fail-on-regression", "--json"])
+        assert result.exit_code == 3, result.output
+        data = json.loads(result.output)
+        assert data["status"] == "error"
+        assert "Invalid baseline score" in data["error"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary\n- validate `assay gate check --min-score` as finite 0..100\n- fail closed when regression mode sees an invalid baseline score file\n- keep missing default baseline behavior unchanged (still skips regression check)\n\n## Why\n`--min-score` was documented as 0-100 but accepted invalid values (negative, >100, NaN/Inf).\nRegression mode could also silently skip malformed baseline score files.\n\n## Changes\n- added `normalize_score_value()` in `src/assay/gate.py`\n- used normalization in `load_score_baseline()`\n- added input validation + fail-closed baseline handling in `gate_check_cmd`\n\n## Tests\n- `uv run pytest tests/assay/test_gate.py -q`\n- `uv run pytest tests/ -q`\n\n## Pilot\nThis is pilot PR 2/5 in the Assay self-dogfood lane (real code + tests).