### PR TITLE
feat: add gate check report file output

### DIFF
--- a/src/assay/commands.py
+++ b/src/assay/commands.py
@@ -4112,6 +4112,7 @@ def gate_check_cmd(
     min_score: Optional[float] = typer.Option(None, "--min-score", help="Minimum passing score (0-100)"),
     fail_on_regression: bool = typer.Option(False, "--fail-on-regression", help="Fail if score dropped below baseline"),
     baseline: Optional[str] = typer.Option(None, "--baseline", help="Path to score-baseline.json (default: .assay/score-baseline.json)"),
+    save_report: Optional[str] = typer.Option(None, "--save-report", help="Write gate JSON report to file"),
     output_json: bool = typer.Option(False, "--json", help="Output as JSON"),
 ):
     """Enforce minimum score and/or regression policy.
@@ -4204,9 +4205,27 @@ def gate_check_cmd(
     )
 
     exit_code = 0 if report["result"] == "PASS" else 1
+    payload: Dict[str, Any] = {**report, "status": "ok" if exit_code == 0 else "blocked"}
+
+    report_path = None
+    if save_report:
+        report_path = P(save_report)
+        payload = {**payload, "report_file": str(report_path)}
+        try:
+            report_path.parent.mkdir(parents=True, exist_ok=True)
+            report_path.write_text(json.dumps(payload, indent=2, default=str) + "\n", encoding="utf-8")
+        except OSError as e:
+            msg = f"Cannot write report: {e}"
+            if output_json:
+                _output_json(
+                    {"command": "assay gate", "status": "error", "error": msg},
+                    exit_code=3,
+                )
+            console.print(f"[red]Error:[/] {msg}")
+            raise typer.Exit(3)
 
     if output_json:
-        _output_json({**report, "status": "ok" if exit_code == 0 else "blocked"}, exit_code=exit_code)
+        _output_json(payload, exit_code=exit_code)
 
     # Console output
     color = "green" if report["result"] == "PASS" else "red"
@@ -4229,6 +4248,8 @@ def gate_check_cmd(
     console.print()
     console.print(Panel.fit("\n".join(lines), title="assay gate"))
     console.print()
+    if report_path is not None:
+        console.print(f"Report: [bold]{report_path}[/]")
 
     if exit_code == 0:
         console.print("Next: [bold]assay gate save-baseline[/] to lock in this score")

--- a/tests/assay/test_gate.py
+++ b/tests/assay/test_gate.py
@@ -246,6 +246,51 @@ class TestGateCheckCLI:
         assert data["status"] == "error"
         assert "Invalid baseline score" in data["error"]
 
+    def test_save_report_json_pass(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        Path("app.py").write_text("x = 1\n", encoding="utf-8")
+        out = tmp_path / ".assay" / "gate-report.json"
+        result = runner.invoke(
+            assay_app,
+            ["gate", "check", ".", "--min-score", "0", "--save-report", str(out), "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["status"] == "ok"
+        assert data["report_file"] == str(out)
+        assert out.exists()
+        written = json.loads(out.read_text(encoding="utf-8"))
+        assert written["result"] == "PASS"
+        assert written["status"] == "ok"
+        assert written["report_file"] == str(out)
+
+    def test_save_report_non_json_fail(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        Path("app.py").write_text("x = 1\n", encoding="utf-8")
+        out = tmp_path / ".assay" / "gate-report-fail.json"
+        result = runner.invoke(
+            assay_app,
+            ["gate", "check", ".", "--min-score", "100", "--save-report", str(out)],
+        )
+        assert result.exit_code == 1, result.output
+        assert out.exists()
+        written = json.loads(out.read_text(encoding="utf-8"))
+        assert written["result"] == "FAIL"
+        assert written["status"] == "blocked"
+        assert written["report_file"] == str(out)
+
+    def test_save_report_write_failure_exit_3(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        Path("app.py").write_text("x = 1\n", encoding="utf-8")
+        result = runner.invoke(
+            assay_app,
+            ["gate", "check", ".", "--save-report", "/dev/null/impossible.json", "--json"],
+        )
+        assert result.exit_code == 3, result.output
+        data = json.loads(result.output)
+        assert data["status"] == "error"
+        assert "Cannot write report" in data["error"]
+
 
 # ---------------------------------------------------------------------------
 # CLI tests: assay gate save-baseline


### PR DESCRIPTION
## Summary\n- add `--save-report` to `assay gate check`\n- write a structured JSON gate report file on both PASS and FAIL outcomes\n- include `report_file` in emitted JSON payload when enabled\n\n## Why\nCurrent CI/docs rely on piping `--json` through shell `tee`.\nThis feature makes gate artifact persistence first-class in CLI/output, reducing shell coupling.\n\n## Behavior\n- `assay gate check ... --save-report path.json` writes report file\n- works with and without `--json`\n- write failures fail closed with exit code 3\n\n## Tests\n- added 3 CLI tests for save-report pass/fail/write-error paths\n- `uv run pytest tests/assay/test_gate.py -q`\n- `uv run pytest tests/ -q`\n\n## Pilot\nThis is pilot PR 3/5 in the Assay self-dogfood lane (small feature in CLI/report output).