### PR TITLE
feat: score guidance layer (grade tiers, point estimates, fastest path)

### DIFF
--- a/src/assay/commands.py
+++ b/src/assay/commands.py
@@ -1830,14 +1830,23 @@ def score_cmd(
         "F": "red",
     }.get(score["grade"], "white")
 
+    grade_desc = score.get("grade_description", "")
+    desc_line = f'\n         [dim]"{grade_desc}"[/]' if grade_desc else ""
+
     header = (
         f"[bold]Evidence Readiness Score[/]\n\n"
         f"Repo:    {root}\n"
         f"Score:   [bold]{score['score']:.1f}[/] / 100\n"
-        f"Grade:   [{grade_style}][bold]{score['grade']}[/]\n"
+        f"Grade:   [{grade_style}][bold]{score['grade']}[/]{desc_line}\n"
         f"Version: {score['score_version']}"
     )
     console.print(Panel.fit(header, title="assay score", border_style="blue"))
+
+    # Build a lookup from component -> action detail for inline hints.
+    action_by_comp: dict = {}
+    for ad in score.get("next_actions_detail", []):
+        if ad.get("component"):
+            action_by_comp.setdefault(ad["component"], ad)
 
     table = Table(show_header=True, header_style="bold", box=None)
     table.add_column("Component")
@@ -1847,12 +1856,16 @@ def score_cmd(
     table.add_column("Note")
     for key in ("coverage", "lockfile", "ci_gate", "receipts", "key_setup"):
         comp = score["breakdown"][key]
+        note = comp["note"]
+        ad = action_by_comp.get(key)
+        if ad and ad["points_est"] > 0:
+            note += f" [dim]→ {ad['command']} (+{ad['points_est']:.0f} pts est.)[/]"
         table.add_row(
             key,
             f"{comp['points']:.1f}",
             str(comp["weight"]),
             comp["status"],
-            comp["note"],
+            note,
         )
     console.print(table)
 
@@ -1864,9 +1877,17 @@ def score_cmd(
             )
         console.print(Panel("\n".join(caps_lines), title="Caps Applied", border_style="yellow"))
 
+    fp = score.get("fastest_path")
+    if fp:
+        console.print(
+            f"\n[bold]Fastest path to {fp['target_grade']} ({fp['target_score']}+):[/] "
+            f"{fp['command']} [dim](+{fp['points_est']:.0f} → ~{fp['projected_score']:.0f})[/]"
+        )
+
     console.print("\n[bold]Next actions:[/]")
-    for idx, action in enumerate(score["next_actions"], 1):
-        console.print(f"  {idx}. {action}")
+    for idx, ad in enumerate(score.get("next_actions_detail", []), 1):
+        pts = f" [dim](+{ad['points_est']:.0f} pts est.)[/]" if ad["points_est"] > 0 else ""
+        console.print(f"  {idx}. {ad['action']}: {ad['command']}{pts}")
 
     console.print(f"\n[dim]{score['disclaimer']}[/]\n")
 

--- a/src/assay/score.py
+++ b/src/assay/score.py
@@ -31,6 +31,16 @@ WEIGHTS: Dict[str, int] = {
     "key_setup": 10,
 }
 
+# Grade tier descriptions shown to users.
+GRADE_TIERS: Dict[str, Tuple[str, str]] = {
+    # grade -> (range_label, description)
+    "A": ("90-100", "Full evidence pipeline with signed packs and ledger."),
+    "B": ("80-89", "Strong pipeline with baseline tracking."),
+    "C": ("70-79", "Active receipts and CI gate in place."),
+    "D": ("60-69", "Basic lockfile and some instrumentation."),
+    "F": ("<60", "No evidence pipeline -- most repos start here."),
+}
+
 
 def gather_score_facts(repo_path: Path) -> Dict[str, Any]:
     """Collect readiness facts for a repository path."""
@@ -269,17 +279,27 @@ def compute_evidence_readiness_score(facts: Dict[str, Any]) -> Dict[str, Any]:
             )
         score, grade = capped_score, capped_grade
 
-    next_actions = _build_next_actions(facts, breakdown)
+    actions_detail = _build_next_actions(facts, breakdown)
+    # Backward-compatible plain-string list.
+    next_actions = [
+        f"{a['action']}: {a['command']}" if a["command"] else a["action"]
+        for a in actions_detail
+    ]
+    fastest_path = _compute_fastest_path(score, grade, actions_detail)
+    tier_range, tier_desc = GRADE_TIERS.get(grade, ("", ""))
 
     return {
         "score_version": SCORE_VERSION,
         "score": score,
         "grade": grade,
+        "grade_description": tier_desc,
         "raw_score": raw_score,
         "raw_grade": raw_grade,
         "caps_applied": caps_applied,
         "breakdown": breakdown,
         "next_actions": next_actions,
+        "next_actions_detail": actions_detail,
+        "fastest_path": fastest_path,
         "disclaimer": (
             "Evidence Readiness Score is a readiness signal, not a security guarantee."
         ),
@@ -367,34 +387,109 @@ def _apply_grade_cap(score: float, grade: str, max_grade: str) -> Tuple[float, s
     return min(score, max_score_by_grade[max_grade]), max_grade
 
 
-def _build_next_actions(facts: Dict[str, Any], breakdown: Dict[str, Dict[str, Any]]) -> List[str]:
-    actions: List[str] = []
+def _build_next_actions(
+    facts: Dict[str, Any], breakdown: Dict[str, Dict[str, Any]]
+) -> List[Dict[str, Any]]:
+    """Build prioritised next-actions with estimated point gains.
+
+    Each action is ``{"action": str, "command": str, "component": str,
+    "points_est": float}`` where *points_est* is the gap between the
+    component's current points and its weight (i.e. max possible gain).
+    """
+    actions: List[Dict[str, Any]] = []
     scan = facts.get("scan", {})
     lock = facts.get("lockfile", {})
     ci = facts.get("ci", {})
     rec = facts.get("receipts", {})
     keys = facts.get("keys", {})
 
+    def _gap(component: str) -> float:
+        comp = breakdown.get(component, {})
+        return round(comp.get("weight", 0) - comp.get("points", 0), 1)
+
     if int(scan.get("uninstrumented", 0) or 0) > 0:
-        actions.append("Instrument gaps: assay patch .")
+        actions.append({
+            "action": "Instrument gaps",
+            "command": "assay patch .",
+            "component": "coverage",
+            "points_est": _gap("coverage"),
+        })
     if int(rec.get("repo_receipt_files", 0) or 0) == 0:
-        actions.append("Generate first evidence pack: assay run -c receipt_completeness -- python your_app.py")
+        actions.append({
+            "action": "Generate first evidence pack",
+            "command": 'assay run -c receipt_completeness -- python your_app.py',
+            "component": "receipts",
+            "points_est": _gap("receipts"),
+        })
     if not lock.get("present"):
-        actions.append("Create lockfile: assay lock init")
+        actions.append({
+            "action": "Create lockfile",
+            "command": "assay lock init",
+            "component": "lockfile",
+            "points_est": _gap("lockfile"),
+        })
     elif not lock.get("valid"):
-        actions.append("Repair stale lockfile: assay lock check && assay lock write --cards receipt_completeness -o assay.lock")
+        actions.append({
+            "action": "Repair stale lockfile",
+            "command": "assay lock check && assay lock write --cards receipt_completeness -o assay.lock",
+            "component": "lockfile",
+            "points_est": _gap("lockfile"),
+        })
     if not (ci.get("has_run") and ci.get("has_verify") and ci.get("has_lock")):
-        actions.append("Harden CI gate: assay ci init github --run-command \"python your_app.py\"")
+        actions.append({
+            "action": "Harden CI gate",
+            "command": 'assay ci init github --run-command "python your_app.py"',
+            "component": "ci_gate",
+            "points_est": _gap("ci_gate"),
+        })
     if int(keys.get("signer_count", 0) or 0) == 0:
-        actions.append("Initialize signer key: assay run --allow-empty -- python -c \"pass\"")
+        actions.append({
+            "action": "Initialize signer key",
+            "command": 'assay run --allow-empty -- python -c "pass"',
+            "component": "key_setup",
+            "points_est": _gap("key_setup"),
+        })
 
     if not actions:
-        actions.append("Ready: enforce regression budgets in CI with assay diff --gate-*.")
+        actions.append({
+            "action": "Ready",
+            "command": "assay diff --gate-*",
+            "component": "",
+            "points_est": 0.0,
+        })
 
+    # Sort by largest gain first.
+    actions.sort(key=lambda a: a["points_est"], reverse=True)
     return actions
 
 
+def _compute_fastest_path(
+    score: float, grade: str, next_actions: List[Dict[str, Any]]
+) -> Dict[str, Any] | None:
+    """Find the single action that gets closest to the next grade threshold."""
+    if grade == "A" or not next_actions:
+        return None
+
+    thresholds = {"F": ("D", 60), "D": ("C", 70), "C": ("B", 80), "B": ("A", 90)}
+    target_grade, target_score = thresholds.get(grade, ("A", 90))
+
+    # Pick the action with the highest estimated gain.
+    best = max(next_actions, key=lambda a: a["points_est"])
+    if best["points_est"] <= 0:
+        return None
+
+    projected = round(score + best["points_est"], 1)
+    return {
+        "target_grade": target_grade,
+        "target_score": target_score,
+        "command": best["command"],
+        "points_est": best["points_est"],
+        "projected_score": projected,
+    }
+
+
 __all__ = [
+    "GRADE_TIERS",
     "SCORE_VERSION",
     "WEIGHTS",
     "gather_score_facts",

--- a/tests/assay/test_score.py
+++ b/tests/assay/test_score.py
@@ -8,7 +8,7 @@ from typing import Any, Dict
 from typer.testing import CliRunner
 
 from assay.commands import assay_app
-from assay.score import SCORE_VERSION, compute_evidence_readiness_score, gather_score_facts
+from assay.score import GRADE_TIERS, SCORE_VERSION, compute_evidence_readiness_score, gather_score_facts
 
 runner = CliRunner()
 
@@ -148,4 +148,115 @@ class TestScoreCLI:
         assert result.exit_code == 3, result.output
         data = json.loads(result.output)
         assert data["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# Guidance layer: grade tiers, point estimation, fastest path
+# ---------------------------------------------------------------------------
+
+
+class TestGuidanceLayer:
+    def test_grade_description_present(self) -> None:
+        result = compute_evidence_readiness_score(_facts())
+        assert "grade_description" in result
+        assert result["grade_description"] == GRADE_TIERS["A"][1]
+
+    def test_grade_description_for_f(self) -> None:
+        result = compute_evidence_readiness_score(
+            _facts(
+                sites_total=0, instrumented=0, uninstrumented=0,
+                lock_present=False, lock_valid=False,
+                has_assay_ref=False, has_run=False, has_verify=False, has_lock=False,
+                repo_receipt_files=0, signer_count=0,
+            )
+        )
+        assert result["grade"] == "F"
+        assert result["grade_description"] == GRADE_TIERS["F"][1]
+
+    def test_next_actions_detail_structure(self) -> None:
+        result = compute_evidence_readiness_score(
+            _facts(lock_present=False, lock_valid=False)
+        )
+        detail = result["next_actions_detail"]
+        assert isinstance(detail, list)
+        assert len(detail) >= 1
+        for ad in detail:
+            assert "action" in ad
+            assert "command" in ad
+            assert "component" in ad
+            assert "points_est" in ad
+            assert isinstance(ad["points_est"], float)
+
+    def test_next_actions_detail_has_lockfile_estimate(self) -> None:
+        result = compute_evidence_readiness_score(
+            _facts(lock_present=False, lock_valid=False)
+        )
+        lock_actions = [
+            a for a in result["next_actions_detail"] if a["component"] == "lockfile"
+        ]
+        assert len(lock_actions) == 1
+        assert lock_actions[0]["points_est"] == 15.0
+        assert "assay lock init" in lock_actions[0]["command"]
+
+    def test_next_actions_backward_compat_strings(self) -> None:
+        result = compute_evidence_readiness_score(
+            _facts(lock_present=False, lock_valid=False)
+        )
+        # next_actions is still a list of strings.
+        assert isinstance(result["next_actions"], list)
+        assert all(isinstance(s, str) for s in result["next_actions"])
+        assert any("assay lock init" in s for s in result["next_actions"])
+
+    def test_next_actions_sorted_by_points(self) -> None:
+        result = compute_evidence_readiness_score(
+            _facts(
+                lock_present=False, lock_valid=False,
+                repo_receipt_files=0, signer_count=0,
+            )
+        )
+        detail = result["next_actions_detail"]
+        points = [a["points_est"] for a in detail]
+        assert points == sorted(points, reverse=True)
+
+    def test_fastest_path_present_when_not_a(self) -> None:
+        result = compute_evidence_readiness_score(
+            _facts(lock_present=False, lock_valid=False)
+        )
+        assert result["grade"] != "A"
+        fp = result["fastest_path"]
+        assert fp is not None
+        assert "target_grade" in fp
+        assert "target_score" in fp
+        assert "command" in fp
+        assert "points_est" in fp
+        assert "projected_score" in fp
+        assert fp["projected_score"] == round(result["score"] + fp["points_est"], 1)
+
+    def test_fastest_path_none_when_a(self) -> None:
+        result = compute_evidence_readiness_score(_facts())
+        assert result["grade"] == "A"
+        assert result["fastest_path"] is None
+
+    def test_perfect_score_has_ready_action(self) -> None:
+        result = compute_evidence_readiness_score(_facts())
+        detail = result["next_actions_detail"]
+        assert len(detail) == 1
+        assert detail[0]["action"] == "Ready"
+        assert detail[0]["points_est"] == 0.0
+
+    def test_json_output_includes_guidance_fields(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        Path("app.py").write_text(
+            "import openai\n"
+            "client = openai.OpenAI()\n"
+            "client.chat.completions.create(model='gpt-4', messages=[])\n",
+            encoding="utf-8",
+        )
+        result = runner.invoke(assay_app, ["score", ".", "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert "grade_description" in data
+        assert "next_actions_detail" in data
+        # fastest_path may be None or dict -- just check key exists
+        assert "fastest_path" in data
 


### PR DESCRIPTION
## Summary
- Grade tier descriptions in score output header (e.g. "No evidence pipeline -- most repos start here")
- Point estimates on each next_action ("assay lock init → +15 pts est.")
- `fastest_path` summary line ("Fastest path to D (60+): assay lock init (+15 → ~64)")
- New `next_actions_detail` and `fastest_path` fields in JSON output
- Backward-compatible: `next_actions` remains a list of strings

Turns diagnostic into prescription. Pilot customers can now see *what to fix* and *how much it helps*.

## Test plan
- [x] 10 new tests in `TestGuidanceLayer` (grade descriptions, point estimates, fastest path, backward compat, sorting, JSON contract)
- [x] All 20 score tests pass
- [x] All 31 gate tests pass (backward compat)
- [x] Full suite: 1402 passed, 11 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)