### PR TITLE
feat: add .assayignore support to scanner

### DIFF
--- a/.assayignore
+++ b/.assayignore
@@ -1,0 +1,2 @@
+# Scan study clones (third-party repos, not our code)
+scripts/scan_study/clones/*

--- a/src/assay/scanner.py
+++ b/src/assay/scanner.py
@@ -474,6 +474,27 @@ def scan_file(filepath: Path) -> tuple[List[CallSite], bool]:
     return sites, visitor.has_instrumentation
 
 
+def _load_assayignore(root: Path) -> List[str]:
+    """Load exclusion patterns from .assayignore at the repo root.
+
+    Returns an empty list if the file is missing.
+    """
+    ignore_file = root / ".assayignore"
+    if not ignore_file.is_file():
+        return []
+    try:
+        text = ignore_file.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    patterns: List[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        patterns.append(stripped)
+    return patterns
+
+
 def scan_directory(
     root: Path,
     *,
@@ -493,6 +514,12 @@ def scan_directory(
     root = Path(root).resolve()
     result = ScanResult()
 
+    # Load .assayignore patterns
+    ignore_patterns = _load_assayignore(root)
+
+    # Merge caller-supplied excludes with .assayignore patterns
+    all_exclude = (exclude or []) + ignore_patterns
+
     # Default excludes
     default_exclude = {
         ".venv", "venv", "node_modules", ".git", "__pycache__",
@@ -502,6 +529,10 @@ def scan_directory(
     }
 
     for dirpath, dirnames, filenames in os.walk(root):
+        rel_dir = os.path.relpath(dirpath, root)
+        if rel_dir == ".":
+            rel_dir = ""
+
         # Skip excluded directories (including assay-generated proof_pack_* dirs)
         dirnames[:] = [
             d for d in dirnames
@@ -509,6 +540,16 @@ def scan_directory(
             and not d.startswith(".")
             and not d.startswith("proof_pack_")
         ]
+
+        # Prune directories matching .assayignore / caller-supplied patterns
+        if all_exclude:
+            dirnames[:] = [
+                d for d in dirnames
+                if not any(
+                    fnmatch(os.path.join(rel_dir, d) if rel_dir else d, pat)
+                    for pat in all_exclude
+                )
+            ]
 
         for filename in filenames:
             if not filename.endswith(".py"):
@@ -520,7 +561,7 @@ def scan_directory(
             except ValueError:
                 rel_path = filepath
 
-            if not _should_scan(rel_path, include, exclude):
+            if not _should_scan(rel_path, include, all_exclude or None):
                 continue
 
             sites, _has_instrumentation = scan_file(filepath)

--- a/tests/assay/test_scanner.py
+++ b/tests/assay/test_scanner.py
@@ -12,6 +12,7 @@ from assay.scanner import (
     Confidence,
     ScanResult,
     _LLMCallVisitor,
+    _load_assayignore,
     _suggest_fix,
     scan_directory,
     scan_file,
@@ -792,3 +793,84 @@ class TestEdgeCases:
         sites, _ = scan_file(f)
         assert len(sites) == 1
         assert sites[0].line == 6
+
+
+# ---------------------------------------------------------------------------
+# .assayignore support
+# ---------------------------------------------------------------------------
+
+class TestLoadAssayignore:
+    def test_missing_file(self, tmp_path):
+        assert _load_assayignore(tmp_path) == []
+
+    def test_basic_patterns(self, tmp_path):
+        (tmp_path / ".assayignore").write_text("vendor/*\nthird_party/*\n")
+        assert _load_assayignore(tmp_path) == ["vendor/*", "third_party/*"]
+
+    def test_comments_and_blanks(self, tmp_path):
+        content = "# comment\n\nvendor/*\n  \n# another\ndata/*\n"
+        (tmp_path / ".assayignore").write_text(content)
+        assert _load_assayignore(tmp_path) == ["vendor/*", "data/*"]
+
+
+def _mkwrite(base: Path, rel: str, code: str) -> Path:
+    """Create parent dirs and write a file under base."""
+    p = base / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(code)
+    return p
+
+
+_LLM_CALL = "import openai\nclient = openai.OpenAI()\nclient.chat.completions.create(model='gpt-4', messages=[])\n"
+
+
+class TestAssayignore:
+    def test_excludes_directory(self, tmp_path):
+        """Files under a matched directory are not scanned."""
+        _mkwrite(tmp_path, "src/app.py", _LLM_CALL)
+        _mkwrite(tmp_path, "vendor/lib.py", _LLM_CALL)
+        (tmp_path / ".assayignore").write_text("vendor/*\n")
+
+        result = scan_directory(tmp_path)
+        paths = {f.path for f in result.findings}
+        assert any("src" in p for p in paths)
+        assert not any("vendor" in p for p in paths), f"vendor excluded, got {paths}"
+
+    def test_missing_file_no_crash(self, tmp_path):
+        """No .assayignore -> normal scan."""
+        _write(tmp_path, "app.py", _LLM_CALL)
+        result = scan_directory(tmp_path)
+        assert len(result.findings) > 0
+
+    def test_multiple_patterns(self, tmp_path):
+        _mkwrite(tmp_path, "vendor/a.py", _LLM_CALL)
+        _mkwrite(tmp_path, "data/b.py", _LLM_CALL)
+        _mkwrite(tmp_path, "src/main.py", _LLM_CALL)
+        (tmp_path / ".assayignore").write_text("vendor/*\ndata/*\n")
+
+        result = scan_directory(tmp_path)
+        paths = {f.path for f in result.findings}
+        assert any("src" in p for p in paths)
+        assert not any("vendor" in p for p in paths)
+        assert not any("data" in p for p in paths)
+
+    def test_does_not_affect_other_files(self, tmp_path):
+        _write(tmp_path, "app.py", _LLM_CALL)
+        _mkwrite(tmp_path, "lib/helpers.py", _LLM_CALL)
+        (tmp_path / ".assayignore").write_text("vendor/*\n")
+
+        result = scan_directory(tmp_path)
+        paths = {f.path for f in result.findings}
+        assert "app.py" in paths
+        assert any("helpers" in p for p in paths)
+
+    def test_nested_directory(self, tmp_path):
+        """Pattern matching a nested path prunes the subtree."""
+        _mkwrite(tmp_path, "scripts/study/clones/repo/main.py", _LLM_CALL)
+        _mkwrite(tmp_path, "src/app.py", _LLM_CALL)
+        (tmp_path / ".assayignore").write_text("scripts/study/clones/*\n")
+
+        result = scan_directory(tmp_path)
+        paths = {f.path for f in result.findings}
+        assert any("src" in p for p in paths)
+        assert not any("clones" in p for p in paths), f"clones excluded, got {paths}"


### PR DESCRIPTION
## Summary

- Scanner now loads `.assayignore` from repo root (fnmatch patterns, one per line, `#` comments, blank lines ignored)
- Matched directories are pruned from `os.walk()` so large excluded trees are never traversed
- Ships `.assayignore` excluding `scripts/scan_study/clones/*`, fixing self-score from 49 (F) to 79 (C)

## Test plan

- [x] 8 new tests: load missing file, basic patterns, comments/blanks, directory exclusion, nested paths, multiple patterns, no effect on non-matching files
- [x] Full suite green (1414 passed, 11 skipped)
- [x] `assay score .` confirms 49 → 79

## Future enhancement (not in scope)

Score output should show "X patterns excluded via .assayignore" for transparency when patterns accidentally exclude too much.

🤖 Generated with [Claude Code](https://claude.com/claude-code)