### PR TITLE
feat(pilot): add assay pilot run|verify|closeout CLI wrappers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "assay-ai"
-version = "1.11.1"
+version = "1.12.0"
 description = "Tamper-evident audit trails for AI systems"
 authors = [
     { name = "Tim Bhaserjian", email = "tim2208@gmail.com" }
@@ -33,6 +33,7 @@ dependencies = [
     "jsonschema>=4.17.0",
     "referencing>=0.30.0",
     "packaging>=21.0",
+    "pyyaml>=6.0",
 ]
 
 [project.urls]
@@ -54,7 +55,6 @@ dev = [
     "pytest-asyncio>=0.21.0",
     "hypothesis>=6.0.0",
     "ruff>=0.1.0",
-    "pyyaml>=6.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/src/assay/commands.py
+++ b/src/assay/commands.py
@@ -7843,6 +7843,228 @@ def policy_recommend_cmd(
     raise typer.Exit(exit_code)
 
 
+# ---------------------------------------------------------------------------
+# Pilot orchestration
+# ---------------------------------------------------------------------------
+
+pilot_app = typer.Typer(
+    name="pilot",
+    help="End-to-end pilot run, verify, and closeout",
+    no_args_is_help=True,
+)
+assay_app.add_typer(pilot_app, name="pilot")
+
+
+@pilot_app.command("run")
+def pilot_run_cmd(
+    repo: str = typer.Argument(".", help="Repository directory"),
+    config: Optional[str] = typer.Option(None, "--config", "-c", help="Path to pilot.yaml"),
+    test_cmd: Optional[str] = typer.Option(None, "--test-cmd", "-t", help="Test command (overrides config)"),
+    mode: Optional[str] = typer.Option(None, "--mode", "-m", help="Scan mode: high-only or high+medium"),
+    output: str = typer.Option("pilot_bundle", "--output", "-o", help="Bundle output directory"),
+    allow_empty: bool = typer.Option(False, "--allow-empty", help="Allow empty receipt packs"),
+    allow_dirty: bool = typer.Option(False, "--allow-dirty", help="Allow dirty working tree"),
+    patch: bool = typer.Option(False, "--patch", help="Run assay patch before test"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Simulate without executing"),
+    resume: bool = typer.Option(False, "--resume", help="Resume from last checkpoint"),
+    output_json: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Run the 9-step pilot pipeline: scan, score, run, verify, bundle.
+
+    Reads pilot.yaml for configuration. CLI flags override config values.
+
+    Examples:
+      assay pilot run . --test-cmd "pytest tests/ -q"
+      assay pilot run /path/to/repo --config pilot.yaml --json
+      assay pilot run . --dry-run
+    """
+    from pathlib import Path
+
+    from assay.pilot import PilotError, load_pilot_config, run_pilot
+
+    repo_path = Path(repo).resolve()
+    if not repo_path.is_dir():
+        if output_json:
+            _output_json({"command": "pilot run", "status": "error", "error": f"Directory not found: {repo}"}, exit_code=3)
+        console.print(f"[red]Error:[/] Directory not found: {repo}")
+        raise typer.Exit(3)
+
+    cli_overrides: dict = {}
+    if test_cmd is not None:
+        cli_overrides["test_cmd"] = test_cmd
+    if mode is not None:
+        cli_overrides["mode"] = mode
+    if output != "pilot_bundle":
+        cli_overrides["output"] = output
+    if allow_empty:
+        cli_overrides["allow_empty"] = True
+    if allow_dirty:
+        cli_overrides["allow_dirty"] = True
+    if patch:
+        cli_overrides["patch"] = True
+
+    try:
+        pilot_config = load_pilot_config(config, repo_path, cli_overrides=cli_overrides)
+    except PilotError as e:
+        if output_json:
+            _output_json({"command": "pilot run", "status": "error", "error": str(e)}, exit_code=1)
+        console.print(f"[red]Error:[/] {e}")
+        raise typer.Exit(1)
+
+    # Apply output override
+    if output != "pilot_bundle":
+        pilot_config.output = output
+
+    try:
+        result = run_pilot(repo_path, pilot_config, dry_run=dry_run, resume=resume)
+    except PilotError as e:
+        if output_json:
+            _output_json({"command": "pilot run", "status": "error", "error": str(e)}, exit_code=1)
+        console.print(f"[red]Error:[/] {e}")
+        raise typer.Exit(1)
+
+    if output_json:
+        _output_json({
+            "command": "pilot run",
+            "status": "ok",
+            "output_dir": result["output_dir"],
+            "steps_completed": result["steps_completed"],
+            "dry_run": dry_run,
+        })
+
+    console.print(f"[green]Pilot run complete.[/] Bundle: {result['output_dir']}")
+    console.print(f"Steps: {', '.join(result['steps_completed'])}")
+    raise typer.Exit(0)
+
+
+@pilot_app.command("verify")
+def pilot_verify_cmd(
+    bundle: str = typer.Argument(..., help="Path to pilot bundle directory"),
+    profile: Optional[str] = typer.Option(None, "--profile", help="Verification profile: score-delta, integrity-only, otel-bridge"),
+    self_test: bool = typer.Option(False, "--self-test", help="Run tamper self-test"),
+    output_json: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Verify a pilot bundle's integrity and claims.
+
+    Three verification layers: structural, integrity (SHA256), claims (profile-aware).
+
+    Exit codes: 0=pass, 1=claims_fail, 2=integrity_fail, 3=malformed.
+
+    Examples:
+      assay pilot verify pilot_bundle/
+      assay pilot verify pilot_bundle/ --profile otel-bridge
+      assay pilot verify pilot_bundle/ --self-test --json
+    """
+    from pathlib import Path
+
+    from assay.pilot import CLAIM_HINTS, _run_self_test, verify_pilot_bundle
+
+    bundle_path = Path(bundle).resolve()
+    if not bundle_path.is_dir():
+        if output_json:
+            _output_json({"command": "pilot verify", "status": "error", "error": "Bundle path does not exist"}, exit_code=3)
+        console.print(f"[red]Error:[/] Bundle path does not exist: {bundle}")
+        raise typer.Exit(3)
+
+    exit_code, errors = verify_pilot_bundle(bundle_path, profile=profile)
+
+    if output_json:
+        status_map = {0: "ok", 1: "claims_fail", 2: "integrity_fail", 3: "malformed"}
+        payload = {
+            "command": "pilot verify",
+            "status": status_map.get(exit_code, "error"),
+            "exit_code": exit_code,
+            "errors": errors,
+            "profile": profile,
+        }
+        if self_test and exit_code == 0:
+            st_code, st_errors = _run_self_test(bundle_path)
+            payload["self_test"] = {"exit_code": st_code, "errors": st_errors}
+        _output_json(payload, exit_code=exit_code)
+
+    if exit_code == 0:
+        console.print("[green]VERIFY_PASS:[/] bundle integrity and claims verified")
+    elif exit_code == 1:
+        console.print(f"[yellow]VERIFY_CLAIMS_FAIL:[/] {','.join(errors)}")
+        for code in errors:
+            hint = CLAIM_HINTS.get(code)
+            if hint:
+                console.print(f"  HINT({code}): {hint}")
+    else:
+        for err in errors:
+            console.print(f"[red]{err}[/]")
+        labels = {2: "INTEGRITY_FAIL", 3: "MALFORMED"}
+        console.print(f"[red]VERIFY_{labels.get(exit_code, 'FAIL')}:[/] exit {exit_code}")
+
+    if self_test and exit_code == 0:
+        st_code, st_errors = _run_self_test(bundle_path)
+        if st_code != 0:
+            for err in st_errors:
+                console.print(f"SELF_TEST: {err}")
+            console.print("[red]SELF_TEST_FAIL[/]")
+        else:
+            console.print("[green]SELF_TEST_PASS:[/] all mutation checks passed")
+
+    raise typer.Exit(exit_code)
+
+
+@pilot_app.command("closeout")
+def pilot_closeout_cmd(
+    bundle: str = typer.Argument(..., help="Path to pilot bundle directory"),
+    repo: Optional[str] = typer.Option(None, "--repo", help="Repository identifier"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Validate without writing logs"),
+    json_output_path: Optional[str] = typer.Option(None, "--json-output", help="Write closeout row JSON to this path"),
+    log_path: Optional[str] = typer.Option(None, "--log", help="JSONL replication log path"),
+    output_json: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Run closeout pipeline: verify, self-test, build closeout row.
+
+    Extracts metadata from bundle, verifies integrity, runs self-test,
+    and optionally writes to a JSONL replication log.
+
+    Examples:
+      assay pilot closeout pilot_bundle/ --dry-run
+      assay pilot closeout pilot_bundle/ --json-output closeout.json
+      assay pilot closeout pilot_bundle/ --log replication.jsonl --json
+    """
+    from pathlib import Path
+
+    from assay.pilot import PilotError, run_pilot_closeout
+
+    bundle_path = Path(bundle).resolve()
+
+    try:
+        row = run_pilot_closeout(
+            bundle_path,
+            repo=repo,
+            dry_run=dry_run,
+            json_output=Path(json_output_path) if json_output_path else None,
+            log_path=Path(log_path) if log_path else None,
+        )
+    except PilotError as e:
+        if output_json:
+            _output_json({"command": "pilot closeout", "status": "error", "error": str(e)}, exit_code=1)
+        console.print(f"[red]Error:[/] {e}")
+        raise typer.Exit(1)
+
+    if output_json:
+        _output_json({
+            "command": "pilot closeout",
+            "status": "ok",
+            **row,
+        })
+
+    delta_str = f"{row.get('score_delta', 'N/A'):+.1f}" if isinstance(row.get("score_delta"), (int, float)) else "N/A"
+    tamper_str = str(row.get("tamper_exit", "N/A"))
+    console.print(
+        f"[green]CLOSEOUT_OK:[/] {row.get('repo', 'unknown')} "
+        f"| verify={row.get('verify_exit', '?')} "
+        f"| tamper={tamper_str} "
+        f"| delta={delta_str}"
+    )
+    raise typer.Exit(0)
+
+
 def main():
     """Entrypoint for assay CLI."""
     assay_app()

--- a/src/assay/pilot.py
+++ b/src/assay/pilot.py
@@ -1,0 +1,1259 @@
+"""Pilot orchestration — run, verify, and closeout for evidence assessment.
+
+Ports the ccio pilot pipeline as self-contained assay CLI commands.
+No ccio imports; calls assay subcommands via subprocess.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+BUNDLE_SCHEMA_VERSION = "pilot_bundle_manifest.v1"
+
+REQUIRED_PACK_FILES = frozenset({
+    "pack_manifest.json",
+    "pack_signature.sig",
+    "receipt_pack.jsonl",
+    "verify_report.json",
+    "verify_transcript.md",
+})
+
+STEPS = [
+    "preflight",
+    "scan",
+    "score_before",
+    "patch",
+    "run",
+    "verify_pack",
+    "tamper_test",
+    "score_after",
+    "write_bundle",
+]
+
+# --- Claim codes (v1 taxonomy) ---
+C_PACK_VERIFY_NOT_PASS = "C_PACK_VERIFY_NOT_PASS"
+C_SCORE_BEFORE_MISSING = "C_SCORE_BEFORE_MISSING"
+C_SCORE_AFTER_MISSING = "C_SCORE_AFTER_MISSING"
+C_SCORE_DELTA_UNAVAILABLE = "C_SCORE_DELTA_UNAVAILABLE"
+C_NO_RECEIPTS = "C_NO_RECEIPTS"
+
+CLAIM_HINTS: dict[str, str] = {
+    C_PACK_VERIFY_NOT_PASS: "Run assay verify-pack and ensure exit 0",
+    C_SCORE_BEFORE_MISSING: "Run assay score before patching (score/before.json)",
+    C_SCORE_AFTER_MISSING: "Run assay score after patching (score/after.json)",
+    C_SCORE_DELTA_UNAVAILABLE: "Ensure score/delta.json exists with before/after/delta fields",
+    C_NO_RECEIPTS: "Emit at least one receipt (model_call or completeness proof)",
+}
+
+VERIFY_PROFILES: dict[str, dict[str, bool]] = {
+    "score-delta": {
+        "require_pack_verify_pass": True,
+        "require_score_files": True,
+        "require_score_delta": True,
+        "require_receipts": False,
+    },
+    "integrity-only": {
+        "require_pack_verify_pass": False,
+        "require_score_files": False,
+        "require_score_delta": False,
+        "require_receipts": False,
+    },
+    "otel-bridge": {
+        "require_pack_verify_pass": False,
+        "require_score_files": False,
+        "require_score_delta": False,
+        "require_receipts": True,
+    },
+}
+
+_DEFAULT_PROFILE_REQS: dict[str, bool] = {
+    "require_pack_verify_pass": True,
+    "require_score_files": True,
+    "require_score_delta": True,
+    "require_receipts": False,
+}
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+class PilotError(RuntimeError):
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+@dataclass
+class PilotConfig:
+    test_cmd: str
+    mode: str = "high-only"
+    allow_empty: bool = False
+    allow_dirty: bool = False
+    patch: bool = False
+    output: str = "pilot_bundle"
+
+
+@dataclass
+class CommandResult:
+    command: list[str]
+    returncode: int
+    stdout: str
+    stderr: str
+    dry_run: bool = False
+
+    def to_dict(self, *, step: str = "") -> dict[str, Any]:
+        return {
+            "command": self.command,
+            "returncode": self.returncode,
+            "stdout_tail": self.stdout[-1200:] if self.stdout else "",
+            "stderr_tail": self.stderr[-1200:] if self.stderr else "",
+            "dry_run": self.dry_run,
+            "step": step,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Config loader
+# ---------------------------------------------------------------------------
+
+_CONFIG_KEYS: frozenset[str] = frozenset({
+    "mode", "test_cmd", "allow_empty", "allow_dirty",
+    "patch", "assay_bin", "output", "repo",
+})
+
+_CONFIG_BOOL_KEYS: frozenset[str] = frozenset({
+    "allow_empty", "allow_dirty", "patch",
+})
+
+_CONFIG_STR_KEYS: frozenset[str] = frozenset({
+    "mode", "test_cmd", "assay_bin", "output", "repo",
+})
+
+
+def load_pilot_config(
+    config_path: str | None,
+    repo_dir: Path,
+    *,
+    cli_overrides: dict[str, Any] | None = None,
+) -> PilotConfig:
+    """Load and validate a pilot.yaml config file.
+
+    Precedence: cli_overrides > YAML config > defaults.
+    Raises PilotError on invalid config.
+    """
+    if config_path is not None:
+        path = Path(config_path)
+        if not path.exists():
+            raise PilotError(f"Config file not found: {config_path}")
+    else:
+        path = repo_dir / "pilot.yaml"
+        if not path.exists():
+            # No config file — require test_cmd from CLI
+            test_cmd = (cli_overrides or {}).get("test_cmd")
+            if not test_cmd:
+                raise PilotError(
+                    "--test-cmd is required when no pilot.yaml exists"
+                )
+            overrides = dict(cli_overrides) if cli_overrides else {}
+            return PilotConfig(**{
+                k: v for k, v in overrides.items()
+                if k in PilotConfig.__dataclass_fields__ and v is not None
+            })
+
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise PilotError(f"Config file must be a YAML mapping: {path}")
+
+    version = raw.pop("version", None)
+    if isinstance(version, int):
+        version = str(version)
+    if version != "1":
+        raise PilotError(
+            f"Unsupported config version: {version!r} (expected '1')"
+        )
+
+    unknown = set(raw.keys()) - _CONFIG_KEYS
+    if unknown:
+        raise PilotError(f"Unknown config keys: {unknown}")
+
+    # Type validation
+    for key in _CONFIG_BOOL_KEYS:
+        if key in raw and not isinstance(raw[key], bool):
+            raise PilotError(
+                f"Config key {key!r} must be boolean (got {type(raw[key]).__name__})"
+            )
+    for key in _CONFIG_STR_KEYS:
+        if key in raw and not isinstance(raw[key], str):
+            raise PilotError(
+                f"Config key {key!r} must be string (got {type(raw[key]).__name__})"
+            )
+
+    # Validate mode
+    mode = raw.get("mode", "high-only")
+    if mode not in ("high-only", "high+medium"):
+        raise PilotError(
+            f"Invalid mode {mode!r} — must be 'high-only' or 'high+medium'"
+        )
+
+    # Merge: CLI > YAML > defaults
+    merged: dict[str, Any] = {}
+    for f_name in PilotConfig.__dataclass_fields__:
+        cli_val = (cli_overrides or {}).get(f_name)
+        if cli_val is not None:
+            merged[f_name] = cli_val
+        elif f_name in raw:
+            merged[f_name] = raw[f_name]
+
+    if "test_cmd" not in merged:
+        raise PilotError(
+            "--test-cmd is required (via CLI, config file, or YAML)"
+        )
+
+    return PilotConfig(**{
+        k: v for k, v in merged.items()
+        if k in PilotConfig.__dataclass_fields__
+    })
+
+
+# ---------------------------------------------------------------------------
+# Subprocess helpers
+# ---------------------------------------------------------------------------
+
+def _run_assay(
+    args: list[str],
+    *,
+    cwd: Path,
+    dry_run: bool = False,
+    timeout: int | None = None,
+) -> CommandResult:
+    """Run an assay subcommand via subprocess."""
+    command = [sys.executable, "-m", "assay"] + args
+    if dry_run:
+        return CommandResult(
+            command=command,
+            returncode=0,
+            stdout="[dry-run] command not executed",
+            stderr="",
+            dry_run=True,
+        )
+    env = {**os.environ, "PYTHONPATH": ""}
+    try:
+        proc = subprocess.run(
+            command,
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return CommandResult(
+            command=command,
+            returncode=-1,
+            stdout="",
+            stderr=f"TIMEOUT: command exceeded {timeout}s limit",
+        )
+    return CommandResult(
+        command=command,
+        returncode=proc.returncode,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+    )
+
+
+def _run_cmd(
+    command: list[str],
+    *,
+    cwd: Path,
+    dry_run: bool = False,
+    env: dict[str, str] | None = None,
+) -> CommandResult:
+    """Run an arbitrary command via subprocess."""
+    if dry_run:
+        return CommandResult(
+            command=command,
+            returncode=0,
+            stdout="[dry-run] command not executed",
+            stderr="",
+            dry_run=True,
+        )
+    try:
+        proc = subprocess.run(
+            command,
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+        )
+    except FileNotFoundError:
+        return CommandResult(
+            command=command,
+            returncode=127,
+            stdout="",
+            stderr=f"command not found: {command[0]}",
+        )
+    return CommandResult(
+        command=command,
+        returncode=proc.returncode,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Git helpers
+# ---------------------------------------------------------------------------
+
+def _git_is_dirty(repo: Path) -> bool:
+    unstaged = subprocess.run(
+        ["git", "diff", "--quiet", "HEAD"],
+        cwd=str(repo),
+        capture_output=True,
+        check=False,
+    )
+    staged = subprocess.run(
+        ["git", "diff", "--quiet", "--staged"],
+        cwd=str(repo),
+        capture_output=True,
+        check=False,
+    )
+    return unstaged.returncode != 0 or staged.returncode != 0
+
+
+def _git_branch(repo: Path) -> str:
+    proc = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return (proc.stdout or "").strip() or "unknown"
+
+
+def _git_short_commit(repo: Path) -> str:
+    proc = subprocess.run(
+        ["git", "rev-parse", "--short", "HEAD"],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return (proc.stdout or "").strip() or "0000000"
+
+
+# ---------------------------------------------------------------------------
+# SHA256 and bundle writing
+# ---------------------------------------------------------------------------
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _copy_if_exists(src: Path | None, dest: Path) -> bool:
+    if src is None or not src.exists():
+        return False
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(src.read_bytes())
+    return True
+
+
+def _collect_artifacts(output_dir: Path) -> list[dict[str, Any]]:
+    artifacts = []
+    for path in sorted(output_dir.rglob("*")):
+        if path.is_dir():
+            continue
+        rel = path.relative_to(output_dir)
+        name = str(rel)
+        if name.startswith("."):
+            continue
+        if name == "manifest.json":
+            continue
+        artifacts.append({
+            "name": name,
+            "sha256": sha256_file(path),
+            "bytes": path.stat().st_size,
+        })
+    return artifacts
+
+
+def _compute_score_delta(
+    before_path: Path, after_path: Path
+) -> dict[str, Any]:
+    before = json.loads(before_path.read_text(encoding="utf-8"))
+    after = json.loads(after_path.read_text(encoding="utf-8"))
+
+    before_raw = before["score"]["raw_score"]
+    after_raw = after["score"]["raw_score"]
+
+    breakdown: dict[str, Any] = {}
+    for key in before.get("score", {}).get("breakdown", {}):
+        bp = before["score"]["breakdown"][key]["points"]
+        ap = after.get("score", {}).get("breakdown", {}).get(key, {}).get("points", bp)
+        breakdown[key] = {"before": bp, "after": ap, "delta": round(ap - bp, 4)}
+
+    return {
+        "before": before_raw,
+        "after": after_raw,
+        "delta": round(after_raw - before_raw, 4),
+        "breakdown": breakdown,
+    }
+
+
+def _env_fingerprint() -> dict[str, Any]:
+    uname = os.uname()
+    fp: dict[str, Any] = {
+        "python_version": sys.version,
+        "platform": platform.platform(),
+        "uname": {
+            "sysname": uname.sysname,
+            "nodename": uname.nodename,
+            "release": uname.release,
+            "version": uname.version,
+            "machine": uname.machine,
+        },
+    }
+    try:
+        freeze = subprocess.run(
+            [sys.executable, "-m", "pip", "freeze"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        fp["pip_freeze_sha256"] = hashlib.sha256(
+            freeze.stdout.encode()
+        ).hexdigest()
+    except FileNotFoundError:
+        fp["pip_freeze_sha256"] = "unavailable"
+    return fp
+
+
+def _write_bundle(
+    output_dir: Path,
+    *,
+    repo: Path,
+    config: PilotConfig,
+    scan_json: Path | None,
+    scan_html: Path | None,
+    score_before: Path | None,
+    score_after: Path | None,
+    pack_dir: Path | None,
+    verify_summary: dict[str, Any],
+    commands_run: list[dict[str, Any]],
+    completed: list[str],
+    dirty_tree: bool,
+) -> Path:
+    """Write a complete pilot bundle to output_dir."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # env fingerprint
+    fp = _env_fingerprint()
+    (output_dir / "env_fingerprint.json").write_text(
+        json.dumps(fp, indent=2) + "\n", encoding="utf-8"
+    )
+
+    # scan/
+    scan_dir = output_dir / "scan"
+    scan_dir.mkdir(parents=True, exist_ok=True)
+    _copy_if_exists(scan_json, scan_dir / "gap_report.json")
+    _copy_if_exists(scan_html, scan_dir / "gap_report.html")
+
+    # score/
+    score_dir = output_dir / "score"
+    score_dir.mkdir(parents=True, exist_ok=True)
+    _copy_if_exists(score_before, score_dir / "before.json")
+    _copy_if_exists(score_after, score_dir / "after.json")
+
+    score_delta: dict[str, Any] | None = None
+    if (
+        score_before and score_before.exists()
+        and score_after and score_after.exists()
+    ):
+        try:
+            score_delta = _compute_score_delta(score_before, score_after)
+            (score_dir / "delta.json").write_text(
+                json.dumps(score_delta, indent=2) + "\n", encoding="utf-8"
+            )
+        except (json.JSONDecodeError, KeyError):
+            pass
+
+    # proof/ (copy pack)
+    proof_dir = output_dir / "proof"
+    proof_dir.mkdir(parents=True, exist_ok=True)
+    if pack_dir and pack_dir.exists():
+        for item in pack_dir.iterdir():
+            if item.is_file():
+                (proof_dir / item.name).write_bytes(item.read_bytes())
+
+    # verification/
+    verify_dir = output_dir / "verification"
+    verify_dir.mkdir(parents=True, exist_ok=True)
+    (verify_dir / "summary.json").write_text(
+        json.dumps(verify_summary, indent=2) + "\n", encoding="utf-8"
+    )
+
+    # replay/
+    replay_dir = output_dir / "replay"
+    replay_dir.mkdir(parents=True, exist_ok=True)
+    replay_lines = ["#!/usr/bin/env bash", "set -euo pipefail", ""]
+    for cmd_entry in commands_run:
+        cmd_str = " ".join(cmd_entry.get("command", []))
+        if cmd_str:
+            replay_lines.append(f"# step: {cmd_entry.get('step', 'unknown')}")
+            replay_lines.append(cmd_str)
+            replay_lines.append("")
+    (replay_dir / "replay.sh").write_text(
+        "\n".join(replay_lines) + "\n", encoding="utf-8"
+    )
+    (replay_dir / "replay.sh").chmod(0o755)
+
+    # Collect artifacts for manifest
+    artifacts = _collect_artifacts(output_dir)
+
+    # Pack root sha256
+    pack_root_sha256 = ""
+    pack_manifest_path = proof_dir / "pack_manifest.json"
+    if pack_manifest_path.exists():
+        try:
+            pm = json.loads(pack_manifest_path.read_text(encoding="utf-8"))
+            pack_root_sha256 = pm.get("pack_root_sha256", "")
+        except (json.JSONDecodeError, KeyError):
+            pass
+
+    # Build manifest
+    now = datetime.now(timezone.utc)
+    timestamp = now.strftime("%Y%m%dT%H%M%S")
+    commit = _git_short_commit(repo)
+    short_hash = commit[:7] if commit else "0000000"
+    bundle_id = f"pilot_{timestamp}_{short_hash}"
+
+    manifest: dict[str, Any] = {
+        "schema_version": BUNDLE_SCHEMA_VERSION,
+        "bundle_id": bundle_id,
+        "created_at_utc": now.isoformat(),
+        "repo": str(repo),
+        "commit": commit,
+        "branch": _git_branch(repo),
+        "mode": config.mode,
+        "assay_version": f"assay-ai (python -m assay)",
+        "dirty_tree": dirty_tree,
+        "allow_empty": config.allow_empty,
+        "steps_completed": completed,
+        "artifacts": artifacts,
+        "pack_root_sha256": pack_root_sha256,
+        "score_delta": score_delta or {},
+    }
+
+    (output_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    # Write final state
+    _write_state(output_dir, completed, "complete")
+
+    return output_dir
+
+
+def _write_state(
+    output_dir: Path, completed_steps: list[str], current_step: str
+) -> None:
+    state = {
+        "completed_steps": completed_steps,
+        "current_step": current_step,
+        "updated_at_utc": datetime.now(timezone.utc).isoformat(),
+    }
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / ".state.json").write_text(
+        json.dumps(state, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def _read_state(output_dir: Path) -> dict[str, Any]:
+    state_path = output_dir / ".state.json"
+    if not state_path.exists():
+        return {"completed_steps": [], "current_step": ""}
+    return json.loads(state_path.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# run_pilot — 9-step pipeline
+# ---------------------------------------------------------------------------
+
+def run_pilot(
+    repo: str | Path,
+    config: PilotConfig,
+    *,
+    dry_run: bool = False,
+    resume: bool = False,
+) -> dict[str, Any]:
+    """Execute the 9-step pilot pipeline. Returns summary dict."""
+    repo_path = Path(repo).resolve()
+    output_dir = Path(config.output).resolve()
+
+    command_log: list[dict[str, Any]] = []
+    completed: list[str] = []
+
+    # Resume support
+    if resume:
+        state = _read_state(output_dir)
+        completed = list(state.get("completed_steps", []))
+
+    def should_skip(step: str) -> bool:
+        return step in completed
+
+    def record(result: CommandResult, step: str) -> CommandResult:
+        command_log.append(result.to_dict(step=step))
+        return result
+
+    # Artifact paths
+    scan_json: Path | None = None
+    scan_html: Path | None = None
+    score_before_path: Path | None = None
+    score_after_path: Path | None = None
+    pack_dir: Path | None = None
+    verify_summary: dict[str, Any] = {}
+
+    work_dir = output_dir / ".work"
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    # --- Step 1: preflight ---
+    if not should_skip("preflight"):
+        _write_state(output_dir, completed, "preflight")
+        if not dry_run:
+            try:
+                dirty = _git_is_dirty(repo_path)
+                if dirty and not config.allow_dirty:
+                    raise PilotError(
+                        "Working tree is dirty. Use --allow-dirty to proceed."
+                    )
+            except FileNotFoundError:
+                pass  # not a git repo — skip dirty check
+
+        res = record(
+            _run_assay(["--help"], cwd=repo_path, dry_run=dry_run),
+            "preflight",
+        )
+        if not dry_run and res.returncode != 0:
+            raise PilotError("assay is not available")
+        completed.append("preflight")
+        _write_state(output_dir, completed, "preflight")
+
+    dirty_tree = False
+    if not dry_run:
+        try:
+            dirty_tree = _git_is_dirty(repo_path)
+        except (FileNotFoundError, Exception):
+            pass
+
+    # --- Step 2: scan ---
+    if not should_skip("scan"):
+        _write_state(output_dir, completed, "scan")
+        res = record(
+            _run_assay(
+                ["scan", str(repo_path), "--report"],
+                cwd=repo_path,
+                dry_run=dry_run,
+            ),
+            "scan",
+        )
+        if not dry_run and res.returncode != 0 and not config.allow_empty:
+            raise PilotError(f"assay scan failed with exit {res.returncode}")
+
+        gap_json = repo_path / "evidence_gap_report.json"
+        gap_html = repo_path / "evidence_gap_report.html"
+        if gap_json.exists():
+            scan_json = gap_json
+        if gap_html.exists():
+            scan_html = gap_html
+
+        completed.append("scan")
+        _write_state(output_dir, completed, "scan")
+
+    # --- Step 3: score_before ---
+    if not should_skip("score_before"):
+        _write_state(output_dir, completed, "score_before")
+        record(
+            _run_assay(
+                ["score", str(repo_path)],
+                cwd=repo_path,
+                dry_run=dry_run,
+            ),
+            "score_before",
+        )
+        score_src = repo_path / "evidence_readiness_report.json"
+        if score_src.exists():
+            score_before_path = work_dir / "before.json"
+            shutil.copy2(score_src, score_before_path)
+
+        completed.append("score_before")
+        _write_state(output_dir, completed, "score_before")
+
+    # --- Step 4: patch (optional) ---
+    if not should_skip("patch"):
+        if config.patch:
+            _write_state(output_dir, completed, "patch")
+            res = record(
+                _run_assay(
+                    ["patch", str(repo_path), "--yes"],
+                    cwd=repo_path,
+                    dry_run=dry_run,
+                    timeout=120,
+                ),
+                "patch",
+            )
+            if not dry_run and res.returncode != 0:
+                patch_applied = "Patched " in (res.stdout or "") or "Patched " in (res.stderr or "")
+                if res.returncode == -1:
+                    raise PilotError("assay patch timed out (120s)")
+                if not patch_applied:
+                    raise PilotError(f"assay patch failed with exit {res.returncode}")
+
+        completed.append("patch")
+        _write_state(output_dir, completed, "patch")
+
+    # --- Step 5: run ---
+    if not should_skip("run"):
+        _write_state(output_dir, completed, "run")
+        pack_output = work_dir / "proof_pack"
+        run_args = [
+            "run",
+            "-c", "receipt_completeness",
+            "-o", str(pack_output),
+        ]
+        if config.allow_empty:
+            run_args.append("--allow-empty")
+        run_args.append("--")
+        run_args.extend(shlex.split(config.test_cmd))
+        res = record(
+            _run_assay(run_args, cwd=repo_path, dry_run=dry_run),
+            "run",
+        )
+        if not dry_run and res.returncode != 0:
+            raise PilotError(f"assay run failed with exit {res.returncode}")
+        if pack_output.exists():
+            pack_dir = pack_output
+
+        completed.append("run")
+        _write_state(output_dir, completed, "run")
+
+    # --- Step 6: verify_pack ---
+    if not should_skip("verify_pack"):
+        _write_state(output_dir, completed, "verify_pack")
+        verify_target = pack_dir or work_dir / "proof_pack"
+        res = record(
+            _run_assay(
+                ["verify-pack", str(verify_target)],
+                cwd=repo_path,
+                dry_run=dry_run,
+            ),
+            "verify_pack",
+        )
+        verify_summary = {
+            "pack_verify_exit": res.returncode,
+            "status": "PASS" if res.returncode == 0 else "FAIL",
+            "stdout_tail": res.stdout[-500:] if res.stdout else "",
+        }
+
+        completed.append("verify_pack")
+        _write_state(output_dir, completed, "verify_pack")
+
+    # --- Step 7: tamper_test ---
+    if not should_skip("tamper_test"):
+        _write_state(output_dir, completed, "tamper_test")
+        canonical_pack = pack_dir or work_dir / "proof_pack"
+        if not dry_run and canonical_pack.exists():
+            with tempfile.TemporaryDirectory(prefix="pilot_tamper_") as tmp:
+                tampered = Path(tmp) / "tampered_pack"
+                shutil.copytree(canonical_pack, tampered)
+                receipt_jsonl = tampered / "receipt_pack.jsonl"
+                if receipt_jsonl.exists():
+                    with receipt_jsonl.open("a", encoding="utf-8") as f:
+                        f.write('\n{"tampered":true}\n')
+                res = record(
+                    _run_assay(
+                        ["verify-pack", str(tampered)],
+                        cwd=repo_path,
+                    ),
+                    "tamper_test",
+                )
+                if res.returncode != 2:
+                    raise PilotError(
+                        f"Tamper test expected exit 2, got {res.returncode}"
+                    )
+        else:
+            record(
+                _run_assay(
+                    ["verify-pack", "tampered_dry_run"],
+                    cwd=repo_path,
+                    dry_run=True,
+                ),
+                "tamper_test",
+            )
+
+        completed.append("tamper_test")
+        _write_state(output_dir, completed, "tamper_test")
+
+    # --- Step 8: score_after ---
+    if not should_skip("score_after"):
+        _write_state(output_dir, completed, "score_after")
+        record(
+            _run_assay(
+                ["score", str(repo_path)],
+                cwd=repo_path,
+                dry_run=dry_run,
+            ),
+            "score_after",
+        )
+        score_src = repo_path / "evidence_readiness_report.json"
+        if score_src.exists():
+            score_after_path = work_dir / "after.json"
+            shutil.copy2(score_src, score_after_path)
+
+        completed.append("score_after")
+        _write_state(output_dir, completed, "score_after")
+
+    # --- Step 9: write_bundle ---
+    if not should_skip("write_bundle"):
+        _write_state(output_dir, completed, "write_bundle")
+
+        if not dry_run:
+            _write_bundle(
+                output_dir,
+                repo=repo_path,
+                config=config,
+                scan_json=scan_json,
+                scan_html=scan_html,
+                score_before=score_before_path,
+                score_after=score_after_path,
+                pack_dir=pack_dir,
+                verify_summary=verify_summary,
+                commands_run=command_log,
+                completed=completed,
+                dirty_tree=dirty_tree,
+            )
+
+        completed.append("write_bundle")
+        _write_state(output_dir, completed, "write_bundle")
+
+    return {
+        "output_dir": str(output_dir),
+        "steps_completed": completed,
+        "commands": command_log,
+        "dirty_tree": dirty_tree,
+    }
+
+
+# ---------------------------------------------------------------------------
+# verify_pilot_bundle — profile-aware bundle verification
+# ---------------------------------------------------------------------------
+
+def _load_manifest(bundle_path: Path) -> tuple[dict[str, Any] | None, list[str]]:
+    manifest_path = bundle_path / "manifest.json"
+    if not manifest_path.exists():
+        return None, ["E_MANIFEST_MISSING"]
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None, ["E_SCHEMA_INVALID"]
+    if data.get("schema_version") != BUNDLE_SCHEMA_VERSION:
+        return None, ["E_SCHEMA_INVALID"]
+    return data, []
+
+
+def _check_integrity(
+    bundle_path: Path, manifest: dict[str, Any]
+) -> list[str]:
+    errors: list[str] = []
+    for artifact in manifest.get("artifacts", []):
+        name = artifact["name"]
+        expected_sha = artifact["sha256"]
+        artifact_path = bundle_path / name
+        if not artifact_path.exists():
+            errors.append("E_MANIFEST_TAMPER")
+            continue
+        actual_sha = sha256_file(artifact_path)
+        if actual_sha != expected_sha:
+            errors.append("E_MANIFEST_TAMPER")
+
+    proof_dir = bundle_path / "proof"
+    for required_file in REQUIRED_PACK_FILES:
+        if not (proof_dir / required_file).exists():
+            errors.append(f"E_REQUIRED_FILE_MISSING:{required_file}")
+
+    return errors
+
+
+def _count_receipt_lines(bundle_path: Path) -> int:
+    receipt_path = bundle_path / "proof" / "receipt_pack.jsonl"
+    if not receipt_path.exists():
+        return 0
+    count = 0
+    for line in receipt_path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            count += 1
+    return count
+
+
+def _check_claims(
+    bundle_path: Path, *, profile: str | None = None
+) -> list[str]:
+    reqs = VERIFY_PROFILES.get(profile, _DEFAULT_PROFILE_REQS) if profile else _DEFAULT_PROFILE_REQS
+    codes: list[str] = []
+
+    if reqs["require_pack_verify_pass"]:
+        summary_path = bundle_path / "verification" / "summary.json"
+        failed = False
+        if not summary_path.exists():
+            failed = True
+        else:
+            try:
+                summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                failed = True
+            else:
+                if summary.get("pack_verify_exit") != 0:
+                    failed = True
+        if failed:
+            codes.append(C_PACK_VERIFY_NOT_PASS)
+
+    if reqs.get("require_score_files"):
+        if not (bundle_path / "score" / "before.json").exists():
+            codes.append(C_SCORE_BEFORE_MISSING)
+        if not (bundle_path / "score" / "after.json").exists():
+            codes.append(C_SCORE_AFTER_MISSING)
+
+    if reqs["require_score_delta"]:
+        delta_path = bundle_path / "score" / "delta.json"
+        if not delta_path.exists():
+            codes.append(C_SCORE_DELTA_UNAVAILABLE)
+        else:
+            try:
+                json.loads(delta_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                codes.append(C_SCORE_DELTA_UNAVAILABLE)
+
+    if reqs["require_receipts"]:
+        if _count_receipt_lines(bundle_path) == 0:
+            codes.append(C_NO_RECEIPTS)
+
+    return codes
+
+
+def verify_pilot_bundle(
+    bundle_path: Path, *, profile: str | None = None
+) -> tuple[int, list[str]]:
+    """Verify a pilot bundle. Returns (exit_code, error_codes).
+
+    Exit codes:
+        0 — integrity pass + claims pass
+        1 — integrity pass + claims fail
+        2 — integrity/tamper fail
+        3 — malformed input
+    """
+    # Layer 1: Structural
+    manifest, structural_errors = _load_manifest(bundle_path)
+    if structural_errors:
+        return 3, structural_errors
+
+    assert manifest is not None
+
+    # Layer 2: Integrity
+    integrity_errors = _check_integrity(bundle_path, manifest)
+    if integrity_errors:
+        return 2, integrity_errors
+
+    # Layer 3: Claims (profile-aware)
+    claims_errors = _check_claims(bundle_path, profile=profile)
+    if claims_errors:
+        return 1, claims_errors
+
+    return 0, []
+
+
+def _run_self_test(bundle_path: Path) -> tuple[int, list[str]]:
+    """Copy bundle to temp, mutate critical files, verify detection."""
+    mutations = [
+        "manifest.json",
+        "proof/receipt_pack.jsonl",
+        "proof/pack_manifest.json",
+        "verification/summary.json",
+    ]
+    failures: list[str] = []
+
+    for target in mutations:
+        with tempfile.TemporaryDirectory(prefix="pilot_selftest_") as tmp:
+            tmp_bundle = Path(tmp) / "bundle"
+            shutil.copytree(bundle_path, tmp_bundle)
+
+            target_path = tmp_bundle / target
+            if not target_path.exists():
+                failures.append(f"SKIP:{target} (not present)")
+                continue
+
+            with target_path.open("a", encoding="utf-8") as f:
+                f.write('\n{"selftest_tamper": true}\n')
+
+            exit_code, _errors = verify_pilot_bundle(tmp_bundle)
+            if target == "manifest.json":
+                if exit_code not in (2, 3):
+                    failures.append(
+                        f"FAIL:{target} expected exit 2 or 3, got {exit_code}"
+                    )
+            else:
+                if exit_code != 2:
+                    failures.append(
+                        f"FAIL:{target} expected exit 2, got {exit_code}"
+                    )
+
+    if failures:
+        return 1, failures
+    return 0, []
+
+
+# ---------------------------------------------------------------------------
+# run_pilot_closeout — closeout orchestration
+# ---------------------------------------------------------------------------
+
+_SEMVER_RE = re.compile(r"\d+\.\d+(?:\.\d+)?")
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else None
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+
+
+def _extract_bundle_id(bundle_path: Path) -> str:
+    manifest = _load_json(bundle_path / "manifest.json")
+    if manifest and isinstance(manifest.get("bundle_id"), str) and manifest["bundle_id"].strip():
+        return manifest["bundle_id"]
+    pack_manifest = _load_json(bundle_path / "proof" / "pack_manifest.json")
+    if pack_manifest and isinstance(pack_manifest.get("pack_id"), str) and pack_manifest["pack_id"].strip():
+        return pack_manifest["pack_id"]
+    return "unknown"
+
+
+def _extract_scores(bundle_path: Path) -> tuple[float | None, float | None, float | None]:
+    before_score: float | None = None
+    after_score: float | None = None
+    delta_score: float | None = None
+
+    before_path = bundle_path / "score" / "before.json"
+    if before_path.exists():
+        try:
+            data = json.loads(before_path.read_text(encoding="utf-8"))
+            before_score = data.get("score", {}).get("raw_score")
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            pass
+
+    after_path = bundle_path / "score" / "after.json"
+    if after_path.exists():
+        try:
+            data = json.loads(after_path.read_text(encoding="utf-8"))
+            after_score = data.get("score", {}).get("raw_score")
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            pass
+
+    delta_path = bundle_path / "score" / "delta.json"
+    if delta_path.exists():
+        try:
+            data = json.loads(delta_path.read_text(encoding="utf-8"))
+            delta_score = data.get("delta")
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            pass
+
+    return before_score, after_score, delta_score
+
+
+def _extract_verify(bundle_path: Path) -> tuple[str, int | None]:
+    summary_path = bundle_path / "verification" / "summary.json"
+    if not summary_path.exists():
+        return "unknown", None
+    try:
+        data = json.loads(summary_path.read_text(encoding="utf-8"))
+        exit_code = data.get("pack_verify_exit")
+        status = data.get("status", "unknown")
+        return status, exit_code
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return "unknown", None
+
+
+def _verify_exit_to_status(exit_code: int | None) -> str:
+    if exit_code is None:
+        return "unknown"
+    if exit_code == 0:
+        return "pass"
+    if exit_code == 1:
+        return "claims_fail"
+    if exit_code == 2:
+        return "integrity_fail"
+    return "malformed"
+
+
+def run_pilot_closeout(
+    bundle_path: Path,
+    *,
+    repo: str | None = None,
+    dry_run: bool = False,
+    json_output: Path | None = None,
+    log_path: Path | None = None,
+) -> dict[str, Any]:
+    """Execute the closeout pipeline. Returns closeout row dict.
+
+    Raises PilotError on integrity/structural failures.
+    """
+    bundle_path = bundle_path.resolve()
+    if not bundle_path.is_dir():
+        raise PilotError(f"Bundle path does not exist: {bundle_path}")
+
+    # --- Extract metadata ---
+    manifest = _load_json(bundle_path / "manifest.json")
+    has_manifest = (bundle_path / "manifest.json").exists()
+
+    bundle_id = _extract_bundle_id(bundle_path)
+    before_score, after_score, delta_score = _extract_scores(bundle_path)
+    verify_status_str, verify_exit_extracted = _extract_verify(bundle_path)
+    receipt_count = _count_receipt_lines(bundle_path)
+
+    # Determine pilot type
+    if before_score is not None or after_score is not None:
+        pilot_type = "score-delta"
+    elif receipt_count > 0:
+        pilot_type = "otel-bridge"
+    else:
+        pilot_type = "integrity-only"
+
+    # Repo fallback
+    if not repo:
+        if manifest and isinstance(manifest.get("repo"), str) and manifest["repo"].strip():
+            repo = manifest["repo"]
+        else:
+            repo = "unknown"
+
+    commit = None
+    if manifest and isinstance(manifest.get("commit"), str) and manifest["commit"].strip():
+        commit = manifest["commit"]
+
+    mode = None
+    if manifest and isinstance(manifest.get("mode"), str):
+        mode = manifest["mode"]
+
+    # Assay version
+    assay_version = "unknown"
+    if manifest and isinstance(manifest.get("assay_version"), str):
+        m = _SEMVER_RE.search(manifest["assay_version"])
+        assay_version = m.group(0) if m else manifest["assay_version"]
+
+    # --- Verify (profile-aware) ---
+    verify_exit: int
+    claim_codes: list[str] = []
+    if has_manifest:
+        verify_exit, verify_errors = verify_pilot_bundle(bundle_path, profile=pilot_type)
+        if verify_exit in (2, 3):
+            raise PilotError(
+                f"Bundle verification failed (exit {verify_exit}): {', '.join(verify_errors)}"
+            )
+        if verify_exit == 1:
+            claim_codes = verify_errors
+    else:
+        verify_exit = verify_exit_extracted if verify_exit_extracted is not None else 0
+
+    # --- Self-test ---
+    tamper_exit: int | None = None
+    if has_manifest:
+        st_code, _st_errors = _run_self_test(bundle_path)
+        tamper_exit = st_code
+
+    # --- Build row ---
+    row: dict[str, Any] = {
+        "repo": repo,
+        "bundle_id": bundle_id,
+        "pilot_type": pilot_type,
+        "commit": commit,
+        "mode": mode,
+        "verify_exit": verify_exit,
+        "verify_status": _verify_exit_to_status(verify_exit),
+        "verify_claim_codes": claim_codes if claim_codes else None,
+        "verify_claim_count": len(claim_codes) if claim_codes else 0,
+        "tamper_exit": tamper_exit,
+        "score_before": before_score,
+        "score_after": after_score,
+        "score_delta": delta_score,
+        "receipt_count": receipt_count,
+        "assay_version": assay_version,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+    # Write row as JSON for downstream consumers
+    if json_output is not None:
+        json_output.parent.mkdir(parents=True, exist_ok=True)
+        tmp = json_output.with_suffix(".tmp")
+        tmp.write_text(json.dumps(row, indent=2) + "\n", encoding="utf-8")
+        os.replace(tmp, json_output)
+
+    # --- JSONL log ---
+    if log_path and not dry_run:
+        _upsert_jsonl(log_path, row)
+
+    return row
+
+
+def _upsert_jsonl(log_path: Path, row: dict[str, Any]) -> None:
+    """Upsert a row into a JSONL file by bundle_id."""
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    rows: list[dict[str, Any]] = []
+    if log_path.exists():
+        for line in log_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                try:
+                    rows.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+
+    # Upsert by bundle_id
+    bundle_id = row.get("bundle_id", "")
+    found = False
+    for i, existing in enumerate(rows):
+        if existing.get("bundle_id") == bundle_id:
+            rows[i] = row
+            found = True
+            break
+    if not found:
+        rows.append(row)
+
+    log_path.write_text(
+        "\n".join(json.dumps(r) for r in rows) + "\n",
+        encoding="utf-8",
+    )

--- a/tests/assay/test_pilot_cli.py
+++ b/tests/assay/test_pilot_cli.py
@@ -1,0 +1,419 @@
+"""Tests for assay pilot run/verify/closeout CLI commands."""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from assay.commands import assay_app
+from assay.pilot import (
+    BUNDLE_SCHEMA_VERSION,
+    PilotConfig,
+    PilotError,
+    _run_self_test,
+    load_pilot_config,
+    run_pilot_closeout,
+    verify_pilot_bundle,
+)
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _write_pilot_yaml(
+    path: Path,
+    *,
+    test_cmd: str = "echo ok",
+    version: str = "1",
+    **overrides: object,
+) -> Path:
+    """Write a minimal pilot.yaml config file."""
+    import yaml
+
+    data: dict = {"version": version, "test_cmd": test_cmd}
+    data.update(overrides)
+    yaml_path = path / "pilot.yaml"
+    yaml_path.write_text(yaml.dump(data), encoding="utf-8")
+    return yaml_path
+
+
+def _write_pilot_bundle(
+    tmp_path: Path,
+    *,
+    with_proof: bool = True,
+    with_score: bool = True,
+    with_receipts: int = 0,
+    verify_exit: int = 0,
+) -> Path:
+    """Write a minimal pilot bundle directory for testing."""
+    bundle = tmp_path / "pilot_bundle"
+    bundle.mkdir(parents=True, exist_ok=True)
+
+    # proof/
+    if with_proof:
+        proof = bundle / "proof"
+        proof.mkdir(parents=True, exist_ok=True)
+        (proof / "pack_manifest.json").write_text('{"pack_id": "test"}', encoding="utf-8")
+        (proof / "pack_signature.sig").write_text("sig", encoding="utf-8")
+        receipt_lines = []
+        for i in range(with_receipts):
+            receipt_lines.append(json.dumps({"receipt_id": f"r_{i}", "type": "model_call"}))
+        (proof / "receipt_pack.jsonl").write_text(
+            "\n".join(receipt_lines) + ("\n" if receipt_lines else ""),
+            encoding="utf-8",
+        )
+        (proof / "verify_report.json").write_text('{"status":"pass"}', encoding="utf-8")
+        (proof / "verify_transcript.md").write_text("# Verify\nPASS", encoding="utf-8")
+
+    # score/
+    if with_score:
+        score = bundle / "score"
+        score.mkdir(parents=True, exist_ok=True)
+        (score / "before.json").write_text(
+            json.dumps({"score": {"raw_score": 10.0, "breakdown": {}}}),
+            encoding="utf-8",
+        )
+        (score / "after.json").write_text(
+            json.dumps({"score": {"raw_score": 45.0, "breakdown": {}}}),
+            encoding="utf-8",
+        )
+        (score / "delta.json").write_text(
+            json.dumps({"before": 10.0, "after": 45.0, "delta": 35.0}),
+            encoding="utf-8",
+        )
+
+    # verification/
+    verify = bundle / "verification"
+    verify.mkdir(parents=True, exist_ok=True)
+    (verify / "summary.json").write_text(
+        json.dumps({"pack_verify_exit": verify_exit, "status": "PASS" if verify_exit == 0 else "FAIL"}),
+        encoding="utf-8",
+    )
+
+    # replay/
+    replay = bundle / "replay"
+    replay.mkdir(parents=True, exist_ok=True)
+    (replay / "replay.sh").write_text("#!/bin/bash\necho replay\n", encoding="utf-8")
+
+    # Collect artifacts and build manifest
+    artifacts = []
+    for path in sorted(bundle.rglob("*")):
+        if path.is_dir():
+            continue
+        rel = str(path.relative_to(bundle))
+        if rel.startswith(".") or rel == "manifest.json":
+            continue
+        artifacts.append({
+            "name": rel,
+            "sha256": _sha256(path.read_bytes()),
+            "bytes": path.stat().st_size,
+        })
+
+    manifest = {
+        "schema_version": BUNDLE_SCHEMA_VERSION,
+        "bundle_id": "test_bundle_001",
+        "created_at_utc": "2026-03-02T00:00:00+00:00",
+        "repo": str(tmp_path),
+        "commit": "abc1234",
+        "branch": "main",
+        "mode": "high-only",
+        "assay_version": "1.11.1",
+        "dirty_tree": False,
+        "allow_empty": False,
+        "steps_completed": ["preflight", "scan", "score_before", "run", "verify_pack", "write_bundle"],
+        "artifacts": artifacts,
+        "pack_root_sha256": "",
+        "score_delta": {"before": 10.0, "after": 45.0, "delta": 35.0} if with_score else {},
+    }
+
+    (bundle / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    return bundle
+
+
+# ---------------------------------------------------------------------------
+# Config loading tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoadConfig:
+    def test_load_config_valid(self, tmp_path: Path) -> None:
+        _write_pilot_yaml(tmp_path, test_cmd="pytest -q", mode="high+medium")
+        config = load_pilot_config(
+            str(tmp_path / "pilot.yaml"),
+            tmp_path,
+        )
+        assert isinstance(config, PilotConfig)
+        assert config.test_cmd == "pytest -q"
+        assert config.mode == "high+medium"
+        assert config.allow_empty is False
+
+    def test_load_config_missing_version(self, tmp_path: Path) -> None:
+        yaml_path = tmp_path / "pilot.yaml"
+        yaml_path.write_text("test_cmd: echo ok\n", encoding="utf-8")
+        with pytest.raises(PilotError, match="Unsupported config version"):
+            load_pilot_config(str(yaml_path), tmp_path)
+
+    def test_load_config_unknown_keys(self, tmp_path: Path) -> None:
+        _write_pilot_yaml(tmp_path, test_cmd="echo ok", bogus_key="bad")
+        with pytest.raises(PilotError, match="Unknown config keys"):
+            load_pilot_config(str(tmp_path / "pilot.yaml"), tmp_path)
+
+    def test_load_config_type_mismatch(self, tmp_path: Path) -> None:
+        yaml_path = tmp_path / "pilot.yaml"
+        yaml_path.write_text(
+            "version: '1'\ntest_cmd: echo ok\nallow_empty: not_a_bool\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(PilotError, match="must be boolean"):
+            load_pilot_config(str(yaml_path), tmp_path)
+
+    def test_load_config_cli_overrides(self, tmp_path: Path) -> None:
+        _write_pilot_yaml(tmp_path, test_cmd="echo yaml", mode="high-only")
+        config = load_pilot_config(
+            str(tmp_path / "pilot.yaml"),
+            tmp_path,
+            cli_overrides={"test_cmd": "echo cli", "mode": "high+medium"},
+        )
+        assert config.test_cmd == "echo cli"
+        assert config.mode == "high+medium"
+
+
+# ---------------------------------------------------------------------------
+# CLI help tests
+# ---------------------------------------------------------------------------
+
+
+class TestPilotHelp:
+    def test_pilot_no_args_shows_help(self) -> None:
+        result = runner.invoke(assay_app, ["pilot"])
+        # Typer's no_args_is_help exits with code 0 or 2 depending on version
+        assert result.exit_code in (0, 2)
+        assert "run" in result.output
+        assert "verify" in result.output
+        assert "closeout" in result.output
+
+    def test_pilot_run_help(self) -> None:
+        result = runner.invoke(assay_app, ["pilot", "run", "--help"])
+        assert result.exit_code == 0
+        assert "--test-cmd" in result.output
+        assert "--dry-run" in result.output
+
+    def test_pilot_verify_help(self) -> None:
+        result = runner.invoke(assay_app, ["pilot", "verify", "--help"])
+        assert result.exit_code == 0
+        assert "--profile" in result.output
+        assert "--self-test" in result.output
+
+    def test_pilot_closeout_help(self) -> None:
+        result = runner.invoke(assay_app, ["pilot", "closeout", "--help"])
+        assert result.exit_code == 0
+        assert "--dry-run" in result.output
+        assert "--json-output" in result.output
+
+
+# ---------------------------------------------------------------------------
+# CLI run tests
+# ---------------------------------------------------------------------------
+
+
+class TestPilotRunCLI:
+    def test_pilot_run_missing_repo(self) -> None:
+        result = runner.invoke(
+            assay_app,
+            ["pilot", "run", "/nonexistent/path", "--test-cmd", "echo ok", "--json"],
+        )
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["status"] == "error"
+
+    def test_pilot_run_no_config_no_testcmd(self, tmp_path: Path) -> None:
+        result = runner.invoke(
+            assay_app,
+            ["pilot", "run", str(tmp_path), "--json"],
+        )
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# Verify tests (unit)
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyPilotBundle:
+    def test_verify_pass(self, tmp_path: Path) -> None:
+        bundle = _write_pilot_bundle(tmp_path, with_score=True, verify_exit=0)
+        exit_code, errors = verify_pilot_bundle(bundle)
+        assert exit_code == 0
+        assert errors == []
+
+    def test_verify_claims_fail_missing_score(self, tmp_path: Path) -> None:
+        bundle = _write_pilot_bundle(tmp_path, with_score=False, verify_exit=0)
+        exit_code, errors = verify_pilot_bundle(bundle)
+        assert exit_code == 1
+        assert "C_SCORE_BEFORE_MISSING" in errors
+        assert "C_SCORE_AFTER_MISSING" in errors
+
+    def test_verify_integrity_fail(self, tmp_path: Path) -> None:
+        bundle = _write_pilot_bundle(tmp_path)
+        # Corrupt a file to trigger integrity failure
+        receipt_path = bundle / "proof" / "receipt_pack.jsonl"
+        receipt_path.write_text('{"tampered": true}\n', encoding="utf-8")
+        exit_code, errors = verify_pilot_bundle(bundle)
+        assert exit_code == 2
+        assert any("E_MANIFEST_TAMPER" in e for e in errors)
+
+    def test_verify_malformed_no_manifest(self, tmp_path: Path) -> None:
+        bundle = tmp_path / "empty_bundle"
+        bundle.mkdir()
+        exit_code, errors = verify_pilot_bundle(bundle)
+        assert exit_code == 3
+        assert "E_MANIFEST_MISSING" in errors
+
+    def test_verify_otel_bridge_profile(self, tmp_path: Path) -> None:
+        bundle = _write_pilot_bundle(
+            tmp_path,
+            with_score=False,
+            with_receipts=3,
+            verify_exit=0,
+        )
+        # otel-bridge profile: requires receipts, not scores
+        exit_code, errors = verify_pilot_bundle(bundle, profile="otel-bridge")
+        assert exit_code == 0
+        assert errors == []
+
+    def test_verify_otel_bridge_no_receipts(self, tmp_path: Path) -> None:
+        bundle = _write_pilot_bundle(
+            tmp_path,
+            with_score=False,
+            with_receipts=0,
+            verify_exit=0,
+        )
+        exit_code, errors = verify_pilot_bundle(bundle, profile="otel-bridge")
+        assert exit_code == 1
+        assert "C_NO_RECEIPTS" in errors
+
+
+# ---------------------------------------------------------------------------
+# Verify CLI tests
+# ---------------------------------------------------------------------------
+
+
+class TestPilotVerifyCLI:
+    def test_verify_pass_json(self, tmp_path: Path) -> None:
+        bundle = _write_pilot_bundle(tmp_path)
+        result = runner.invoke(
+            assay_app,
+            ["pilot", "verify", str(bundle), "--json"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["status"] == "ok"
+        assert data["exit_code"] == 0
+
+    def test_verify_claims_fail_json(self, tmp_path: Path) -> None:
+        bundle = _write_pilot_bundle(tmp_path, with_score=False)
+        result = runner.invoke(
+            assay_app,
+            ["pilot", "verify", str(bundle), "--json"],
+        )
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["status"] == "claims_fail"
+
+    def test_verify_malformed_json(self, tmp_path: Path) -> None:
+        bundle = tmp_path / "empty_bundle"
+        bundle.mkdir()
+        result = runner.invoke(
+            assay_app,
+            ["pilot", "verify", str(bundle), "--json"],
+        )
+        assert result.exit_code == 3
+        data = json.loads(result.output)
+        assert data["status"] == "malformed"
+
+
+# ---------------------------------------------------------------------------
+# Self-test tests
+# ---------------------------------------------------------------------------
+
+
+class TestSelfTest:
+    def test_self_test_detects_tamper(self, tmp_path: Path) -> None:
+        bundle = _write_pilot_bundle(tmp_path)
+        st_code, st_errors = _run_self_test(bundle)
+        assert st_code == 0
+        assert st_errors == []
+
+
+# ---------------------------------------------------------------------------
+# Closeout tests
+# ---------------------------------------------------------------------------
+
+
+class TestCloseout:
+    def test_closeout_dry_run(self, tmp_path: Path) -> None:
+        bundle = _write_pilot_bundle(tmp_path)
+        row = run_pilot_closeout(bundle, dry_run=True)
+        assert isinstance(row, dict)
+        assert row["bundle_id"] == "test_bundle_001"
+        assert row["pilot_type"] == "score-delta"
+        assert row["verify_exit"] == 0
+
+    def test_closeout_json_output(self, tmp_path: Path) -> None:
+        bundle = _write_pilot_bundle(tmp_path)
+        json_out = tmp_path / "closeout.json"
+        row = run_pilot_closeout(bundle, json_output=json_out)
+        assert json_out.exists()
+        written = json.loads(json_out.read_text(encoding="utf-8"))
+        assert written["bundle_id"] == row["bundle_id"]
+
+    def test_closeout_jsonl_log(self, tmp_path: Path) -> None:
+        bundle = _write_pilot_bundle(tmp_path)
+        log_path = tmp_path / "replication.jsonl"
+        row = run_pilot_closeout(bundle, log_path=log_path)
+        assert log_path.exists()
+        lines = [
+            json.loads(l)
+            for l in log_path.read_text(encoding="utf-8").splitlines()
+            if l.strip()
+        ]
+        assert len(lines) == 1
+        assert lines[0]["bundle_id"] == row["bundle_id"]
+
+    def test_closeout_cli_dry_run(self, tmp_path: Path) -> None:
+        bundle = _write_pilot_bundle(tmp_path)
+        result = runner.invoke(
+            assay_app,
+            ["pilot", "closeout", str(bundle), "--dry-run", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["status"] == "ok"
+        assert data["bundle_id"] == "test_bundle_001"
+
+    def test_closeout_otel_bridge_type(self, tmp_path: Path) -> None:
+        bundle = _write_pilot_bundle(
+            tmp_path,
+            with_score=False,
+            with_receipts=3,
+        )
+        row = run_pilot_closeout(bundle, dry_run=True)
+        assert row["pilot_type"] == "otel-bridge"
+        assert row["receipt_count"] == 3


### PR DESCRIPTION
## Summary
- Expose pilot pipeline as first-class `assay pilot run|verify|closeout` CLI commands
- New `src/assay/pilot.py` module (~700 lines): config loader, 9-step pipeline, profile-aware verifier, closeout orchestrator
- Same `pilot.yaml` format, `pilot_bundle_manifest.v1` schema, and `C_*` claim codes as ccio — bundles are cross-tool compatible
- Bumps `assay-ai` from 1.11.1 → 1.12.0; moves `pyyaml` from dev to main deps
- 26 new tests, 1469 total pass, zero regressions

## CLI surface

```
assay pilot run .  --test-cmd "pytest -q" [--dry-run] [--json]
assay pilot verify pilot_bundle/ [--profile otel-bridge] [--self-test] [--json]
assay pilot closeout pilot_bundle/ [--dry-run] [--json-output closeout.json] [--json]
```

## Test plan
- [x] 26 new pilot tests pass (config, CLI help, run, verify × 6 profiles, closeout, self-test)
- [x] Full suite: 1469 passed, 20 skipped, 0 failed
- [ ] Post-merge: `pip install assay-ai==1.12.0 && assay pilot run --help`
- [ ] Post-merge: ccio follow-up PR to consume new CLI wrappers

🤖 Generated with [Claude Code](https://claude.com/claude-code)