### PR TITLE
fix(pilot): use assay.cli subprocess module for pilot flows

### DIFF
--- a/src/assay/pilot.py
+++ b/src/assay/pilot.py
@@ -248,7 +248,8 @@ def _run_assay(
     timeout: int | None = None,
 ) -> CommandResult:
     """Run an assay subcommand via subprocess."""
-    command = [sys.executable, "-m", "assay"] + args
+    # Use assay.cli module directly; `python -m assay` fails without assay.__main__.
+    command = [sys.executable, "-m", "assay.cli"] + args
     if dry_run:
         return CommandResult(
             command=command,
@@ -562,7 +563,7 @@ def _write_bundle(
         "commit": commit,
         "branch": _git_branch(repo),
         "mode": config.mode,
-        "assay_version": f"assay-ai (python -m assay)",
+        "assay_version": "assay-ai (python -m assay.cli)",
         "dirty_tree": dirty_tree,
         "allow_empty": config.allow_empty,
         "steps_completed": completed,

--- a/tests/assay/test_pilot_cli.py
+++ b/tests/assay/test_pilot_cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -14,6 +15,7 @@ from assay.pilot import (
     PilotConfig,
     PilotError,
     _run_self_test,
+    _run_assay,
     load_pilot_config,
     run_pilot_closeout,
     verify_pilot_bundle,
@@ -249,6 +251,10 @@ class TestPilotRunCLI:
         assert result.exit_code != 0
         data = json.loads(result.output)
         assert data["status"] == "error"
+
+    def test_run_assay_uses_assay_cli_module(self, tmp_path: Path) -> None:
+        result = _run_assay(["--help"], cwd=tmp_path, dry_run=True)
+        assert result.command[:3] == [sys.executable, "-m", "assay.cli"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- fix `assay.pilot._run_assay()` to invoke `python -m assay.cli` instead of `python -m assay`
- update manifest note from `python -m assay` to `python -m assay.cli`
- add regression test to lock command construction (`test_run_assay_uses_assay_cli_module`)

## Why
`python -m assay` fails when `assay.__main__` is absent, which caused:
- `assay pilot run` preflight to fail with `assay is not available`
- downstream pilot orchestration to abort despite CLI entrypoint being installed

## Validation
- `PYTHONPATH=src /Users/timmymacbookpro/.local/pipx/venvs/assay-ai/bin/python -m pytest -q tests/assay/test_pilot_cli.py` (27 passed)
- manual smoke:
  - `PYTHONPATH=src ... python -m assay.cli pilot run <temp_repo> --test-cmd 'echo noop' --allow-empty --allow-dirty --output <bundle> --json`
  - returns `status=ok` and completes all 9 pilot steps
