### PR TITLE
chore(release): bump to 1.12.1 for pilot subprocess fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "assay-ai"
-version = "1.12.0"
+version = "1.12.1"
 description = "Tamper-evident audit trails for AI systems"
 authors = [
     { name = "Tim Bhaserjian", email = "tim2208@gmail.com" }


### PR DESCRIPTION
## Summary
- bump package version from 1.12.0 to 1.12.1
- make the pilot subprocess fix from #21 consumable as a release marker

## Validation
- isolated venv install with dev deps
- PYTHONPATH=src python -m pytest -q tests/assay/test_pilot_cli.py (27 passed)

## Why now
- ccio migration uses `assay pilot ...` command detection
- version marker should reflect that the CLI subprocess fix is included
