### PR TITLE
ci: add machine-readable QA contract + drift validator

### DIFF
--- a/.github/qa_contract.yaml
+++ b/.github/qa_contract.yaml
@@ -1,0 +1,37 @@
+version: 1
+contract_name: assay-public-toolkit
+repo_tier: public
+
+invariants:
+  required_workflows:
+    - path: .github/workflows/lineage.yml
+      workflow_name: Lineage Check
+      required_jobs:
+        - id: lineage
+          required_step_names:
+            - Check lineage coverage
+        - id: assay-gate
+          required_step_names:
+            - Install assay
+            - Run evidence gate
+            - Upload gate report
+        - id: assay-verify
+          required_step_names:
+            - Install assay
+            - Build and verify proof pack
+            - Upload verify artifacts
+    - path: .github/workflows/proof-check-drift.yml
+      workflow_name: Proof Check Drift Guard
+      required_jobs:
+        - id: drift-guard
+          required_step_names:
+            - Validate proof-check contract
+
+  required_uses:
+    - actions/checkout@v4
+    - actions/setup-python@v5
+    - actions/upload-artifact@v4
+    - Haserjian/agentmesh-action@v2
+
+policy:
+  require_pinned_uses: true

--- a/.github/workflows/qa-contract-drift.yml
+++ b/.github/workflows/qa-contract-drift.yml
@@ -1,0 +1,27 @@
+name: QA Contract Drift
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  qa-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install validator dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pyyaml
+
+      - name: Validate QA contract drift
+        run: |
+          python scripts/ci/validate_qa_contract.py --contract .github/qa_contract.yaml

--- a/QA_CONTRACT.md
+++ b/QA_CONTRACT.md
@@ -1,0 +1,16 @@
+# QA Contract (v1)
+
+This repository uses a machine-readable QA contract at [`.github/qa_contract.yaml`](.github/qa_contract.yaml).
+
+Purpose:
+- Keep core CI invariants stable.
+- Catch accidental workflow drift before merge.
+
+Validator:
+- [`scripts/ci/validate_qa_contract.py`](scripts/ci/validate_qa_contract.py)
+
+CI enforcement:
+- [`.github/workflows/qa-contract-drift.yml`](.github/workflows/qa-contract-drift.yml)
+
+Current tier:
+- `public` toolkit baseline

--- a/scripts/ci/validate_qa_contract.py
+++ b/scripts/ci/validate_qa_contract.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Validate repository workflows against .github/qa_contract.yaml."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return data if isinstance(data, dict) else {}
+
+
+def _collect_uses(node: Any, out: set[str] | None = None) -> set[str]:
+    if out is None:
+        out = set()
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "uses" and isinstance(value, str):
+                out.add(value)
+            else:
+                _collect_uses(value, out)
+    elif isinstance(node, list):
+        for item in node:
+            _collect_uses(item, out)
+    return out
+
+
+def _is_pinned_uses(uses_value: str) -> bool:
+    if uses_value.startswith("./"):
+        return True
+    if uses_value.startswith("docker://"):
+        return True
+    return "@" in uses_value
+
+
+def _validate_workflow(
+    workflow_path: Path,
+    wf_contract: dict[str, Any],
+    policy: dict[str, Any],
+    errors: list[str],
+) -> set[str]:
+    if not workflow_path.exists():
+        errors.append(f"missing workflow file: {workflow_path}")
+        return set()
+
+    workflow = _load_yaml(workflow_path)
+    if workflow.get("name") != wf_contract.get("workflow_name"):
+        errors.append(
+            f"{workflow_path}: workflow name mismatch (expected '{wf_contract.get('workflow_name')}', got '{workflow.get('name')}')"
+        )
+
+    jobs = workflow.get("jobs")
+    if not isinstance(jobs, dict):
+        errors.append(f"{workflow_path}: missing or invalid jobs map")
+        return _collect_uses(workflow)
+
+    for job_contract in wf_contract.get("required_jobs", []):
+        job_id = job_contract.get("id")
+        if job_id not in jobs:
+            errors.append(f"{workflow_path}: missing required job '{job_id}'")
+            continue
+
+        job = jobs[job_id]
+        steps = job.get("steps", []) if isinstance(job, dict) else []
+        step_names = {
+            s.get("name")
+            for s in steps
+            if isinstance(s, dict) and isinstance(s.get("name"), str)
+        }
+
+        for req_step in job_contract.get("required_step_names", []):
+            if req_step not in step_names:
+                errors.append(
+                    f"{workflow_path}:{job_id}: missing required step '{req_step}'"
+                )
+
+        matrix_contract = job_contract.get("required_matrix", {})
+        matrix_key = matrix_contract.get("key")
+        matrix_values = matrix_contract.get("values", [])
+        if matrix_key:
+            actual_matrix = (
+                job.get("strategy", {}).get("matrix", {})
+                if isinstance(job, dict)
+                else {}
+            )
+            actual_values = actual_matrix.get(matrix_key)
+            if not isinstance(actual_values, list):
+                errors.append(
+                    f"{workflow_path}:{job_id}: matrix key '{matrix_key}' missing or not a list"
+                )
+            else:
+                if set(str(v) for v in actual_values) != set(str(v) for v in matrix_values):
+                    errors.append(
+                        f"{workflow_path}:{job_id}: matrix '{matrix_key}' mismatch (expected {matrix_values}, got {actual_values})"
+                    )
+
+    uses_values = _collect_uses(workflow)
+    if policy.get("require_pinned_uses", False):
+        for uses_value in sorted(uses_values):
+            if not _is_pinned_uses(uses_value):
+                errors.append(f"{workflow_path}: unpinned action/reference '{uses_value}'")
+
+    return uses_values
+
+
+def validate_contract(contract_path: Path, repo_root: Path) -> list[str]:
+    errors: list[str] = []
+
+    if not contract_path.exists():
+        return [f"contract file not found: {contract_path}"]
+
+    contract = _load_yaml(contract_path)
+    invariants = contract.get("invariants", {})
+    policy = contract.get("policy", {})
+
+    all_uses: set[str] = set()
+    for wf_contract in invariants.get("required_workflows", []):
+        rel_path = wf_contract.get("path")
+        if not isinstance(rel_path, str) or not rel_path:
+            errors.append("contract has required_workflows entry without valid 'path'")
+            continue
+        workflow_path = repo_root / rel_path
+        all_uses |= _validate_workflow(workflow_path, wf_contract, policy, errors)
+
+    for required_uses in invariants.get("required_uses", []):
+        if required_uses not in all_uses:
+            errors.append(
+                f"required action/reference not found in required workflows: '{required_uses}'"
+            )
+
+    return errors
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--contract",
+        default=".github/qa_contract.yaml",
+        help="Path to qa contract yaml (default: .github/qa_contract.yaml)",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="Repository root (default: current directory)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(args.repo_root).resolve()
+    contract_path = (repo_root / args.contract).resolve()
+
+    errors = validate_contract(contract_path, repo_root)
+    if errors:
+        print("QA contract validation: FAIL")
+        for err in errors:
+            print(f"- {err}")
+        return 1
+
+    print("QA contract validation: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add machine-readable QA contract at '.github/qa_contract.yaml'
- add validator script 'scripts/ci/validate_qa_contract.py'
- add CI workflow '.github/workflows/qa-contract-drift.yml' to enforce contract drift checks
- add 'QA_CONTRACT.md' for operator-facing contract docs

## Why
This establishes one auditable CI contract surface and catches accidental workflow drift before merge.

## Validation
- python3 -m py_compile scripts/ci/validate_qa_contract.py
- python3 scripts/ci/validate_qa_contract.py --contract .github/qa_contract.yaml
