### PR TITLE
ci: QA contract v2 (tiers, SHA policy, flexible step matching)

### DIFF
--- a/.github/qa_contract.yaml
+++ b/.github/qa_contract.yaml
@@ -1,37 +1,61 @@
-version: 1
-contract_name: assay-public-toolkit
-repo_tier: public
+version: 2
+contract_name: assay-qa-contract
+active_tier: public
 
-invariants:
-  required_workflows:
-    - path: .github/workflows/lineage.yml
-      workflow_name: Lineage Check
-      required_jobs:
-        - id: lineage
-          required_step_names:
-            - Check lineage coverage
-        - id: assay-gate
-          required_step_names:
-            - Install assay
-            - Run evidence gate
-            - Upload gate report
-        - id: assay-verify
-          required_step_names:
-            - Install assay
-            - Build and verify proof pack
-            - Upload verify artifacts
-    - path: .github/workflows/proof-check-drift.yml
-      workflow_name: Proof Check Drift Guard
-      required_jobs:
-        - id: drift-guard
-          required_step_names:
-            - Validate proof-check contract
+tiers:
+  public:
+    description: Public baseline for assay-family repositories.
+    checks:
+      required:
+        - lineage
+        - assay-verify
+        - drift-guard
+        - qa-contract
+      advisory:
+        - assay-gate
 
-  required_uses:
-    - actions/checkout@v4
-    - actions/setup-python@v5
-    - actions/upload-artifact@v4
-    - Haserjian/agentmesh-action@v2
+    invariants:
+      required_workflows:
+        - path: .github/workflows/lineage.yml
+          workflow_name: Lineage Check
+          required_jobs:
+            - id: lineage
+              required_steps:
+                - uses: Haserjian/agentmesh-action@v2
+            - id: assay-gate
+              required_steps:
+                - run_contains: assay gate check
+            - id: assay-verify
+              required_steps:
+                - run_contains: assay verify-pack
 
-policy:
-  require_pinned_uses: true
+        - path: .github/workflows/proof-check-drift.yml
+          workflow_name: Proof Check Drift Guard
+          required_jobs:
+            - id: drift-guard
+              required_steps:
+                - name_contains: Validate proof-check contract
+
+        - path: .github/workflows/qa-contract-drift.yml
+          workflow_name: QA Contract Drift
+          required_jobs:
+            - id: qa-contract
+              required_steps:
+                - run_contains: validate_qa_contract.py
+
+      required_uses:
+        - actions/checkout@v4
+        - actions/setup-python@v5
+        - actions/upload-artifact@v4
+        - Haserjian/agentmesh-action@v2
+
+    policy:
+      require_pinned_uses: true
+      require_uses_sha: false
+
+  private_strict:
+    extends: public
+    description: Optional strict tier for private repos with SHA-pinned actions.
+    policy:
+      require_pinned_uses: true
+      require_uses_sha: true

--- a/QA_CONTRACT.md
+++ b/QA_CONTRACT.md
@@ -1,4 +1,4 @@
-# QA Contract (v1)
+# QA Contract (v2)
 
 This repository uses a machine-readable QA contract at [`.github/qa_contract.yaml`](.github/qa_contract.yaml).
 
@@ -12,5 +12,30 @@ Validator:
 CI enforcement:
 - [`.github/workflows/qa-contract-drift.yml`](.github/workflows/qa-contract-drift.yml)
 
-Current tier:
-- `public` toolkit baseline
+## Tier model
+
+The contract now supports multiple tiers under `tiers:`.
+
+- `public` (active tier in this repo)
+  - requires pinned action refs (`@ref`)
+  - supports required/advisory check lists
+- `private_strict` (template tier)
+  - extends `public`
+  - enables `require_uses_sha: true`
+
+Use `--tier` to validate a non-default tier:
+
+```bash
+python scripts/ci/validate_qa_contract.py --tier private_strict
+```
+
+## Less brittle step matching
+
+`required_steps` supports structured matching in addition to exact names:
+
+- `name` (exact)
+- `name_contains`
+- `run_contains`
+- `uses`
+
+This reduces false drift failures from cosmetic step-name edits while preserving contract intent.

--- a/scripts/ci/validate_qa_contract.py
+++ b/scripts/ci/validate_qa_contract.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import argparse
+import copy
+import re
 import sys
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+_SHA_REF_RE = re.compile(r"^[0-9a-fA-F]{40}$")
 
 
 def _load_yaml(path: Path) -> dict[str, Any]:
@@ -30,12 +34,106 @@ def _collect_uses(node: Any, out: set[str] | None = None) -> set[str]:
     return out
 
 
+def _is_local_or_docker(uses_value: str) -> bool:
+    return uses_value.startswith("./") or uses_value.startswith("docker://")
+
+
 def _is_pinned_uses(uses_value: str) -> bool:
-    if uses_value.startswith("./"):
-        return True
-    if uses_value.startswith("docker://"):
+    if _is_local_or_docker(uses_value):
         return True
     return "@" in uses_value
+
+
+def _is_sha_pinned(uses_value: str) -> bool:
+    if _is_local_or_docker(uses_value):
+        return True
+    if "@" not in uses_value:
+        return False
+    _, ref = uses_value.rsplit("@", 1)
+    return bool(_SHA_REF_RE.fullmatch(ref.strip()))
+
+
+def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    out = copy.deepcopy(base)
+    for key, value in override.items():
+        if (
+            key in out
+            and isinstance(out[key], dict)
+            and isinstance(value, dict)
+        ):
+            out[key] = _deep_merge(out[key], value)
+        else:
+            out[key] = copy.deepcopy(value)
+    return out
+
+
+def _resolve_tier(contract: dict[str, Any], tier: str | None) -> tuple[dict[str, Any], str]:
+    tiers = contract.get("tiers")
+    if not isinstance(tiers, dict):
+        # Backward-compatible v1 contract shape.
+        return {
+            "invariants": contract.get("invariants", {}),
+            "policy": contract.get("policy", {}),
+            "checks": contract.get("checks", {}),
+        }, tier or contract.get("repo_tier", "default")
+
+    selected = tier or contract.get("active_tier")
+    if not isinstance(selected, str) or not selected.strip():
+        raise ValueError("contract missing active_tier and no --tier supplied")
+    selected = selected.strip()
+
+    def _resolve(name: str, stack: tuple[str, ...] = ()) -> dict[str, Any]:
+        if name in stack:
+            raise ValueError(f"tier inheritance cycle detected: {' -> '.join(stack + (name,))}")
+        node = tiers.get(name)
+        if not isinstance(node, dict):
+            raise ValueError(f"tier '{name}' not found")
+
+        parent = node.get("extends")
+        if parent is not None and not isinstance(parent, str):
+            raise ValueError(f"tier '{name}' has non-string extends value")
+
+        resolved: dict[str, Any] = {}
+        if isinstance(parent, str) and parent.strip():
+            resolved = _resolve(parent.strip(), stack + (name,))
+
+        node_no_extends = {k: v for k, v in node.items() if k != "extends"}
+        return _deep_merge(resolved, node_no_extends)
+
+    return _resolve(selected), selected
+
+
+def _step_matches_requirement(step: dict[str, Any], requirement: Any) -> bool:
+    name = step.get("name") if isinstance(step.get("name"), str) else ""
+    run = step.get("run") if isinstance(step.get("run"), str) else ""
+    uses = step.get("uses") if isinstance(step.get("uses"), str) else ""
+
+    if isinstance(requirement, str):
+        return name == requirement
+
+    if not isinstance(requirement, dict):
+        return False
+
+    checks: list[bool] = []
+    if "name" in requirement:
+        checks.append(name == str(requirement["name"]))
+    if "name_contains" in requirement:
+        checks.append(str(requirement["name_contains"]) in name)
+    if "run_contains" in requirement:
+        checks.append(str(requirement["run_contains"]) in run)
+    if "uses" in requirement:
+        checks.append(uses == str(requirement["uses"]))
+
+    return bool(checks) and all(checks)
+
+
+def _req_to_label(requirement: Any) -> str:
+    if isinstance(requirement, str):
+        return f"name='{requirement}'"
+    if isinstance(requirement, dict):
+        parts = [f"{k}={v!r}" for k, v in requirement.items()]
+        return "{" + ", ".join(parts) + "}"
+    return repr(requirement)
 
 
 def _validate_workflow(
@@ -43,10 +141,10 @@ def _validate_workflow(
     wf_contract: dict[str, Any],
     policy: dict[str, Any],
     errors: list[str],
-) -> set[str]:
+) -> tuple[set[str], set[str]]:
     if not workflow_path.exists():
         errors.append(f"missing workflow file: {workflow_path}")
-        return set()
+        return set(), set()
 
     workflow = _load_yaml(workflow_path)
     if workflow.get("name") != wf_contract.get("workflow_name"):
@@ -57,7 +155,9 @@ def _validate_workflow(
     jobs = workflow.get("jobs")
     if not isinstance(jobs, dict):
         errors.append(f"{workflow_path}: missing or invalid jobs map")
-        return _collect_uses(workflow)
+        return _collect_uses(workflow), set()
+
+    discovered_checks = set(jobs.keys())
 
     for job_contract in wf_contract.get("required_jobs", []):
         job_id = job_contract.get("id")
@@ -67,16 +167,17 @@ def _validate_workflow(
 
         job = jobs[job_id]
         steps = job.get("steps", []) if isinstance(job, dict) else []
-        step_names = {
-            s.get("name")
-            for s in steps
-            if isinstance(s, dict) and isinstance(s.get("name"), str)
-        }
+        steps = [s for s in steps if isinstance(s, dict)]
 
-        for req_step in job_contract.get("required_step_names", []):
-            if req_step not in step_names:
+        required_steps: list[Any] = []
+        required_steps.extend(job_contract.get("required_steps", []))
+        # Backward-compatible legacy key.
+        required_steps.extend(job_contract.get("required_step_names", []))
+
+        for req_step in required_steps:
+            if not any(_step_matches_requirement(step, req_step) for step in steps):
                 errors.append(
-                    f"{workflow_path}:{job_id}: missing required step '{req_step}'"
+                    f"{workflow_path}:{job_id}: missing required step match {_req_to_label(req_step)}"
                 )
 
         matrix_contract = job_contract.get("required_matrix", {})
@@ -93,11 +194,10 @@ def _validate_workflow(
                 errors.append(
                     f"{workflow_path}:{job_id}: matrix key '{matrix_key}' missing or not a list"
                 )
-            else:
-                if set(str(v) for v in actual_values) != set(str(v) for v in matrix_values):
-                    errors.append(
-                        f"{workflow_path}:{job_id}: matrix '{matrix_key}' mismatch (expected {matrix_values}, got {actual_values})"
-                    )
+            elif set(str(v) for v in actual_values) != set(str(v) for v in matrix_values):
+                errors.append(
+                    f"{workflow_path}:{job_id}: matrix '{matrix_key}' mismatch (expected {matrix_values}, got {actual_values})"
+                )
 
     uses_values = _collect_uses(workflow)
     if policy.get("require_pinned_uses", False):
@@ -105,27 +205,58 @@ def _validate_workflow(
             if not _is_pinned_uses(uses_value):
                 errors.append(f"{workflow_path}: unpinned action/reference '{uses_value}'")
 
-    return uses_values
+    if policy.get("require_uses_sha", False):
+        for uses_value in sorted(uses_values):
+            if not _is_sha_pinned(uses_value):
+                errors.append(f"{workflow_path}: non-SHA action/reference '{uses_value}'")
+
+    return uses_values, discovered_checks
 
 
-def validate_contract(contract_path: Path, repo_root: Path) -> list[str]:
+def _validate_check_sets(checks_cfg: dict[str, Any], discovered: set[str], errors: list[str]) -> None:
+    required = checks_cfg.get("required", []) if isinstance(checks_cfg, dict) else []
+    advisory = checks_cfg.get("advisory", []) if isinstance(checks_cfg, dict) else []
+
+    required_set = set(str(x) for x in required)
+    advisory_set = set(str(x) for x in advisory)
+
+    overlap = required_set & advisory_set
+    if overlap:
+        errors.append(f"checks.required and checks.advisory overlap: {sorted(overlap)}")
+
+    for check in sorted(required_set | advisory_set):
+        if check not in discovered:
+            errors.append(f"contract check '{check}' not found in discovered workflow jobs")
+
+
+def validate_contract(contract_path: Path, repo_root: Path, tier: str | None = None) -> tuple[list[str], str]:
     errors: list[str] = []
 
     if not contract_path.exists():
-        return [f"contract file not found: {contract_path}"]
+        return [f"contract file not found: {contract_path}"], tier or "unknown"
 
     contract = _load_yaml(contract_path)
-    invariants = contract.get("invariants", {})
-    policy = contract.get("policy", {})
+    try:
+        resolved, selected_tier = _resolve_tier(contract, tier)
+    except ValueError as exc:
+        return [f"invalid tier config: {exc}"], tier or "unknown"
+
+    invariants = resolved.get("invariants", {}) if isinstance(resolved, dict) else {}
+    policy = resolved.get("policy", {}) if isinstance(resolved, dict) else {}
+    checks_cfg = resolved.get("checks", {}) if isinstance(resolved, dict) else {}
 
     all_uses: set[str] = set()
+    discovered_checks: set[str] = set()
+
     for wf_contract in invariants.get("required_workflows", []):
         rel_path = wf_contract.get("path")
         if not isinstance(rel_path, str) or not rel_path:
             errors.append("contract has required_workflows entry without valid 'path'")
             continue
         workflow_path = repo_root / rel_path
-        all_uses |= _validate_workflow(workflow_path, wf_contract, policy, errors)
+        uses_values, checks = _validate_workflow(workflow_path, wf_contract, policy, errors)
+        all_uses |= uses_values
+        discovered_checks |= checks
 
     for required_uses in invariants.get("required_uses", []):
         if required_uses not in all_uses:
@@ -133,7 +264,8 @@ def validate_contract(contract_path: Path, repo_root: Path) -> list[str]:
                 f"required action/reference not found in required workflows: '{required_uses}'"
             )
 
-    return errors
+    _validate_check_sets(checks_cfg, discovered_checks, errors)
+    return errors, selected_tier
 
 
 def parse_args() -> argparse.Namespace:
@@ -148,6 +280,11 @@ def parse_args() -> argparse.Namespace:
         default=".",
         help="Repository root (default: current directory)",
     )
+    parser.add_argument(
+        "--tier",
+        default=None,
+        help="Override contract tier selection (default: active_tier)",
+    )
     return parser.parse_args()
 
 
@@ -156,14 +293,14 @@ def main() -> int:
     repo_root = Path(args.repo_root).resolve()
     contract_path = (repo_root / args.contract).resolve()
 
-    errors = validate_contract(contract_path, repo_root)
+    errors, tier = validate_contract(contract_path, repo_root, tier=args.tier)
     if errors:
-        print("QA contract validation: FAIL")
+        print(f"QA contract validation: FAIL (tier={tier})")
         for err in errors:
             print(f"- {err}")
         return 1
 
-    print("QA contract validation: PASS")
+    print(f"QA contract validation: PASS (tier={tier})")
     return 0
 
 


### PR DESCRIPTION
## Summary
- evolve qa contract to v2 with tiered policy model ('tiers', 'active_tier')
- add 'checks.required' and 'checks.advisory' validation against discovered workflow jobs
- add optional strict policy knob: 'require_uses_sha: true'
- reduce brittleness by adding structured 'required_steps' matching ('name', 'name_contains', 'run_contains', 'uses')
- keep backward compatibility with v1 contracts and 'required_step_names'

## Validation
- python3 -m py_compile scripts/ci/validate_qa_contract.py
- python3 scripts/ci/validate_qa_contract.py --contract .github/qa_contract.yaml
- python3 scripts/ci/validate_qa_contract.py --contract .github/qa_contract.yaml --tier public
- python3 scripts/ci/validate_qa_contract.py --contract .github/qa_contract.yaml --tier private_strict (expected FAIL with non-SHA action refs)

## Notes
- This PR is stacked on #24 and should merge after #24.
