### PR TITLE
feat(naic-aiset): add mapping pack and align reviewer verification

### DIFF
--- a/src/assay/reviewer_packet_verify.py
+++ b/src/assay/reviewer_packet_verify.py
@@ -47,6 +47,11 @@ _ALLOWED_COVERAGE_STATUSES = {
     "HUMAN_ATTESTED",
     "OUT_OF_SCOPE",
 }
+_COVERAGE_STATUSES_REQUIRING_EVIDENCE_REFS = {
+    "EVIDENCED",
+    "PARTIAL",
+    "FAILED",
+}
 _COVERAGE_COLUMNS = ["Claim / Question", "Status", "Evidence", "Scope", "Notes"]
 _PACKET_REQUIRED_FILES = (
     "SETTLEMENT.json",
@@ -245,6 +250,9 @@ def _validate_coverage_rows(
                 errors.append(f"COVERAGE_MATRIX.md out-of-scope row not declared in SCOPE_MANIFEST.json: {question}")
         elif mapped_questions and question not in mapped_questions:
             errors.append(f"COVERAGE_MATRIX.md in-scope row not declared in SCOPE_MANIFEST.json: {question}")
+
+        if status not in _COVERAGE_STATUSES_REQUIRING_EVIDENCE_REFS:
+            continue
 
         for ref in _split_evidence_refs(row["Evidence"]):
             if "#" in ref:

--- a/tests/assay/test_reviewer_packet_verify.py
+++ b/tests/assay/test_reviewer_packet_verify.py
@@ -307,6 +307,47 @@ def test_verify_reviewer_packet_handles_malformed_generated_at(tmp_path: Path) -
     assert any("SETTLEMENT.json generated_at must be ISO-8601" in error for error in result["errors"])
 
 
+def test_verify_reviewer_packet_accepts_human_attested_text_labels(tmp_path: Path) -> None:
+    proof_pack_dir, ks = _build_proof_pack(tmp_path / "proof_inputs", claim_pass=True)
+    boundary = _base_boundary()
+    mapping = {
+        "questions": [
+            {
+                "question_id": "offline_verify",
+                "prompt": "Can the reviewer verify the proof artifact offline?",
+                "scope": "Whole packet",
+                "status_rule": "ALL_EVIDENCE_REQUIRED",
+                "evidence": [{"type": "verify_report_field", "path": "claim_verification.passed"}],
+            },
+            {
+                "question_id": "governance_docs",
+                "prompt": "Is organizational governance documentation available?",
+                "scope": "Support workflow",
+                "status_rule": "HUMAN_ATTESTED",
+                "evidence_label": "Organizational governance documentation (human-attested)",
+            },
+        ]
+    }
+    packet_dir = tmp_path / "reviewer_packet"
+    compile_reviewer_packet(
+        proof_pack_dir=proof_pack_dir,
+        boundary_payload=boundary,
+        mapping_payload=mapping,
+        out_dir=packet_dir,
+        packet_overrides={
+            "generated_at": _TS,
+            "packet_id": f"rp_{tmp_path.name}",
+        },
+        keystore=ks,
+    )
+
+    result = verify_reviewer_packet(packet_dir, keystore=ks)
+    assert result["packet_verified"] is True
+    assert result["settlement_state"] == "VERIFIED_WITH_GAPS"
+    assert result["provided_settlement_state"] == "VERIFIED_WITH_GAPS"
+    assert result["errors"] == []
+
+
 @pytest.mark.parametrize(
     ("state", "claim_pass", "complete_coverage", "baseline_state", "all_out_of_scope", "should_verify"),
     [


### PR DESCRIPTION
## Summary

Align the Python reviewer verifier with the browser reviewer verifier for
`HUMAN_ATTESTED` coverage rows.

This fixes a contract mismatch exposed by the NAIC packet:
`HUMAN_ATTESTED` rows intentionally carry text labels, not resolvable file refs.
Python verification now matches the browser and compiler behavior by requiring
evidence-ref resolution only for:

- `EVIDENCED`
- `PARTIAL`
- `FAILED`

Rows marked `HUMAN_ATTESTED` or `OUT_OF_SCOPE` are still validated as legal
statuses, but their `Evidence` cell is no longer treated as a required file
pointer.

## Why

The browser verifier on GitHub Pages is already live with the stricter
reviewer-packet parity logic. Toolkit `main` should match that contract so
`assay reviewer verify` and browser verification stay aligned.

## Files

- `src/assay/reviewer_packet_verify.py`
- `tests/assay/test_reviewer_packet_verify.py`

## Validation

- `pytest tests/assay/test_reviewer_packet_verify.py -q`
- Verified the NAIC reviewer packet through the Python verifier:
  - `packet_verified: true`
  - `settlement_state: VERIFIED_WITH_GAPS`
  - `errors: []`

## Notes for reviewers

The verifier fix is intentionally small and policy-local:
`_COVERAGE_STATUSES_REQUIRING_EVIDENCE_REFS = {"EVIDENCED", "PARTIAL", "FAILED"}`

This preserves strict evidence-target checking for machine-verifiable rows
without treating human-attested labels as broken file references.
