### PR TITLE
feat(verify): mechanism-typed failures, witness sufficiency, four-state verdict

### DIFF
--- a/src/assay/commands.py
+++ b/src/assay/commands.py
@@ -2505,10 +2505,12 @@ def verify_pack_cmd(
     # Witness verification (T2 trust)
     witness_failed = False
     witness_errors: list = []
+    witness_sufficiency: Optional[float] = None
     if require_witness:
         from assay.witness import verify_witness_from_pack
 
         witness_result = verify_witness_from_pack(pack_path)
+        witness_sufficiency = witness_result.sufficiency
         if not witness_result.passed:
             witness_failed = True
             witness_errors = witness_result.errors
@@ -2551,9 +2553,13 @@ def verify_pack_cmd(
         from assay.verification_status import classify_verdict
         from assay.verify_render import render_verification_badge, render_verification_html
 
+        _ws_art: Optional[bool] = None
+        if require_witness:
+            _ws_art = not witness_failed
         _verdict = classify_verdict(
             integrity_passed=result.passed,
             claim_check=claim_check,
+            witness_sufficient=_ws_art,
         )
 
         if html_out:
@@ -2586,9 +2592,21 @@ def verify_pack_cmd(
             _artifact_paths["badge"] = str(badge_path)
 
     if output_json:
+        from assay.verification_status import classify_verdict
+
+        # Compute verdict: witness_sufficient is None unless --require-witness
+        _ws: Optional[bool] = None
+        if require_witness:
+            _ws = not witness_failed
+        _verdict = classify_verdict(
+            integrity_passed=result.passed,
+            claim_check=claim_check,
+            witness_sufficient=_ws,
+        )
         out = {
             "command": "verify-pack",
             "status": overall_status,
+            "verdict": _verdict,
             "claim_check": claim_check,
             **result.to_dict(),
         }
@@ -2602,6 +2620,8 @@ def verify_pack_cmd(
             out["coverage"] = coverage_result
         if witness_failed:
             out["witness_errors"] = witness_errors
+        if witness_sufficiency is not None:
+            out["witness_sufficiency"] = witness_sufficiency
         if _artifact_paths:
             out["artifacts"] = _artifact_paths
         _output_json(out)
@@ -4903,6 +4923,7 @@ def vendorq_export_reviewer_cmd(
     mapping: str = typer.Option(..., "--mapping", help="Path to reviewer packet question mapping JSON"),
     out: str = typer.Option(..., "--out", "-o", help="Output reviewer packet directory"),
     baseline: Optional[str] = typer.Option(None, "--baseline", help="Optional baseline reviewer packet directory"),
+    challenge_receipt: Optional[str] = typer.Option(None, "--challenge-receipt", help="Optional challenge receipt path for refreshed packets"),
     output_json: bool = typer.Option(False, "--json", help="Output as JSON"),
 ):
     """Experimental: compile a reviewer packet from a proof pack plus declarative packet inputs."""
@@ -4918,6 +4939,14 @@ def vendorq_export_reviewer_cmd(
             mapping_payload=load_json(Path(mapping)),
             out_dir=Path(out),
             baseline_packet_dir=Path(baseline) if baseline else None,
+            packet_overrides=(
+                {
+                    "challenge_receipt_ref": challenge_receipt,
+                    "challenge_status": "REFRESHED",
+                }
+                if challenge_receipt
+                else None
+            ),
         )
     except VendorQInputError as e:
         if output_json:
@@ -4935,6 +4964,7 @@ def vendorq_export_reviewer_cmd(
             exit_code=0,
         )
 
+    ratio = result["packet_summary"]["machine_coverage_ratio"]
     console.print()
     console.print(Panel.fit(
         f"[bold green]Reviewer Packet Compiled[/]\n\n"
@@ -4942,6 +4972,8 @@ def vendorq_export_reviewer_cmd(
         f"Boundary:          {boundary}\n"
         f"Mapping:           {mapping}\n"
         f"Settlement:        {result['settlement_state']}\n"
+        f"Challenge status:  {result['challenge_status']}\n"
+        f"Machine coverage:  {ratio['numerator']}/{ratio['denominator']} ({ratio['value']:.2%})\n"
         f"Coverage rows:     {len(result['coverage_rows'])}\n"
         f"Output directory:  {out}",
         title="assay vendorq export-reviewer",
@@ -4988,6 +5020,7 @@ def reviewer_verify_cmd(
         f"{name}={count}"
         for name, count in sorted(result["coverage_summary"].items())
     ) or "none"
+    ratio = result["packet_summary"]["machine_coverage_ratio"]
     console.print()
     console.print(Panel.fit(
         f"[bold]{'Reviewer Packet Verified' if result['packet_verified'] else 'Reviewer Packet Failed'}[/]\n\n"
@@ -4998,7 +5031,9 @@ def reviewer_verify_cmd(
         f"Claims:            {result['claim_state']}\n"
         f"Scope:             {result['scope_state']}\n"
         f"Freshness:         {result['freshness_state']}\n"
+        f"Challenge:         {result['challenge_status']}\n"
         f"Regression:        {result['regression_state']}\n"
+        f"Machine coverage:  {ratio['numerator']}/{ratio['denominator']} ({ratio['value']:.2%})\n"
         f"Coverage:          {coverage_summary}",
         title="assay reviewer verify",
         border_style="green" if result["packet_verified"] else "red",
@@ -5017,6 +5052,109 @@ def reviewer_verify_cmd(
             console.print(f"  - {warning}")
 
     raise typer.Exit(0 if result["packet_verified"] else 2)
+
+
+@reviewer_app.command("challenge")
+def reviewer_challenge_cmd(
+    packet_dir: str = typer.Argument(..., help="Path to Reviewer Packet directory"),
+    reason: str = typer.Option(..., "--reason", help="Why the reviewer is challenging the packet"),
+    claim_ref: Optional[str] = typer.Option(None, "--claim-ref", help="Optional claim or question reference"),
+    out: Optional[str] = typer.Option(None, "--out", "-o", help="Optional output challenge receipt path"),
+    signer_id: Optional[str] = typer.Option(None, "--signer-id", help="Signer identity for the challenge receipt"),
+    keys_dir: Optional[str] = typer.Option(None, "--keys-dir", help="Optional keystore directory"),
+    output_json: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Create a signed reviewer challenge receipt without introducing workflow software."""
+    from pathlib import Path
+
+    from assay.keystore import AssayKeyStore
+    from assay.reviewer_packet_events import build_reviewer_challenge, write_reviewer_challenge
+
+    keystore = AssayKeyStore(Path(keys_dir)) if keys_dir else AssayKeyStore()
+    payload = build_reviewer_challenge(
+        packet_dir=Path(packet_dir),
+        reason=reason,
+        claim_ref=claim_ref,
+        signer_id=signer_id,
+        keystore=keystore,
+    )
+    destination = write_reviewer_challenge(Path(packet_dir), payload, out_path=Path(out) if out else None)
+
+    if output_json:
+        _output_json(
+            {
+                "command": "reviewer challenge",
+                "status": "ok",
+                "receipt_path": str(destination),
+                "challenge_id": payload["challenge_id"],
+                "packet_ref": payload["packet_ref"],
+            },
+            exit_code=0,
+        )
+
+    console.print()
+    console.print(Panel.fit(
+        f"[bold green]Reviewer Challenge Created[/]\n\n"
+        f"Packet:       {packet_dir}\n"
+        f"Challenge ID: {payload['challenge_id']}\n"
+        f"Reason:       {reason}\n"
+        f"Receipt:      {destination}",
+        title="assay reviewer challenge",
+    ))
+    console.print()
+    raise typer.Exit(0)
+
+
+@assay_app.command("attest")
+def attest_cmd(
+    question: str = typer.Option(..., "--question", help="Reviewer-facing question or claim"),
+    assertion: str = typer.Option(..., "--assertion", help="Human assertion to package"),
+    attester: str = typer.Option(..., "--attester", help="Named human attester"),
+    pack: str = typer.Option(..., "--pack", help="Proof-pack or packet directory to attach the attestation beside"),
+    out: Optional[str] = typer.Option(None, "--out", "-o", help="Optional output attestation path"),
+    signer_id: Optional[str] = typer.Option(None, "--signer-id", help="Signer identity for the attestation receipt"),
+    keys_dir: Optional[str] = typer.Option(None, "--keys-dir", help="Optional keystore directory"),
+    output_json: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Create a thin HUMAN_ATTESTED receipt that stays visibly separate from machine evidence."""
+    from pathlib import Path
+
+    from assay.keystore import AssayKeyStore
+    from assay.reviewer_packet_events import build_human_attestation, write_human_attestation
+
+    keystore = AssayKeyStore(Path(keys_dir)) if keys_dir else AssayKeyStore()
+    payload = build_human_attestation(
+        question=question,
+        assertion=assertion,
+        attester=attester,
+        signer_id=signer_id,
+        keystore=keystore,
+    )
+    destination = write_human_attestation(Path(pack), payload, out_path=Path(out) if out else None)
+
+    if output_json:
+        _output_json(
+            {
+                "command": "attest",
+                "status": "ok",
+                "receipt_path": str(destination),
+                "attestation_id": payload["attestation_id"],
+                "evidence_type": payload["evidence_type"],
+            },
+            exit_code=0,
+        )
+
+    console.print()
+    console.print(Panel.fit(
+        f"[bold green]Human Attestation Created[/]\n\n"
+        f"Question:      {question}\n"
+        f"Attester:      {attester}\n"
+        f"Evidence type: {payload['evidence_type']}\n"
+        f"Receipt:       {destination}",
+        title="assay attest",
+    ))
+    console.print()
+    raise typer.Exit(0)
 
 
 @vendorq_lock_app.command("write")

--- a/src/assay/failure_mechanisms.py
+++ b/src/assay/failure_mechanisms.py
@@ -1,0 +1,49 @@
+"""Failure mechanism families — higher-level grouping of verification error codes.
+
+Maps individual error codes to mechanism types for structured failure reporting.
+Buyers see these in JSON output to understand *what kind* of failure occurred,
+not just *which check* failed.
+"""
+from __future__ import annotations
+
+from typing import Dict
+
+FM_STALE_EVIDENCE = "stale_evidence"
+FM_SCHEMA_MISMATCH = "schema_mismatch"
+FM_WITNESS_GAP = "witness_gap"
+FM_TAMPER_DETECTED = "tamper_detected"
+FM_POLICY_CONFLICT = "policy_conflict"
+
+# Lazy import to avoid circular dependency — codes are string constants
+ERROR_TO_MECHANISM: Dict[str, str] = {
+    "E_PACK_STALE": FM_STALE_EVIDENCE,
+    "E_TIMESTAMP_INVALID": FM_STALE_EVIDENCE,
+    "E_SCHEMA_UNKNOWN": FM_SCHEMA_MISMATCH,
+    "E_CANON_MISMATCH": FM_SCHEMA_MISMATCH,
+    "E_DUPLICATE_ID": FM_SCHEMA_MISMATCH,
+    "E_SIG_MISSING": FM_WITNESS_GAP,
+    "E_CHAIN_BROKEN": FM_WITNESS_GAP,
+    "E_MANIFEST_TAMPER": FM_TAMPER_DETECTED,
+    "E_PACK_OMISSION_DETECTED": FM_TAMPER_DETECTED,
+    "E_PACK_SIG_INVALID": FM_TAMPER_DETECTED,
+    "E_SIG_INVALID": FM_TAMPER_DETECTED,
+    "E_POLICY_MISSING": FM_POLICY_CONFLICT,
+    "E_CI_BINDING_MISSING": FM_POLICY_CONFLICT,
+    "E_CI_BINDING_MISMATCH": FM_POLICY_CONFLICT,
+}
+
+
+def mechanism_for_code(code: str) -> str | None:
+    """Return the failure mechanism family for a given error code."""
+    return ERROR_TO_MECHANISM.get(code)
+
+
+__all__ = [
+    "FM_STALE_EVIDENCE",
+    "FM_SCHEMA_MISMATCH",
+    "FM_WITNESS_GAP",
+    "FM_TAMPER_DETECTED",
+    "FM_POLICY_CONFLICT",
+    "ERROR_TO_MECHANISM",
+    "mechanism_for_code",
+]

--- a/src/assay/integrity.py
+++ b/src/assay/integrity.py
@@ -29,6 +29,7 @@ E_PACK_STALE = "E_PACK_STALE"
 E_CI_BINDING_MISSING = "E_CI_BINDING_MISSING"
 E_CI_BINDING_MISMATCH = "E_CI_BINDING_MISMATCH"
 
+
 @dataclass
 class VerifyError:
     """A single verification error."""
@@ -37,6 +38,12 @@ class VerifyError:
     message: str
     receipt_index: Optional[int] = None
     field: Optional[str] = None
+    failure_mechanism: Optional[str] = None
+
+    def __post_init__(self):
+        if self.failure_mechanism is None:
+            from assay.failure_mechanisms import mechanism_for_code
+            self.failure_mechanism = mechanism_for_code(self.code)
 
     def to_dict(self) -> Dict[str, Any]:
         d: Dict[str, Any] = {"code": self.code, "message": self.message}
@@ -44,6 +51,8 @@ class VerifyError:
             d["receipt_index"] = self.receipt_index
         if self.field is not None:
             d["field"] = self.field
+        if self.failure_mechanism is not None:
+            d["failure_mechanism"] = self.failure_mechanism
         return d
 @dataclass
 class VerifyResult:
@@ -55,14 +64,22 @@ class VerifyResult:
     receipt_count: int = 0
     head_hash: Optional[str] = None
 
+    @property
+    def failure_mechanisms(self) -> Dict[str, int]:
+        """Count of errors grouped by failure mechanism family."""
+        c: Dict[str, int] = {}
+        for e in self.errors:
+            if e.failure_mechanism:
+                c[e.failure_mechanism] = c.get(e.failure_mechanism, 0) + 1
+        return c
+
     def to_dict(self) -> Dict[str, Any]:
-        return {
-            "passed": self.passed,
-            "errors": [e.to_dict() for e in self.errors],
-            "warnings": self.warnings,
-            "receipt_count": self.receipt_count,
-            "head_hash": self.head_hash,
-        }
+        d: Dict[str, Any] = {"passed": self.passed, "errors": [e.to_dict() for e in self.errors],
+                              "warnings": self.warnings, "receipt_count": self.receipt_count,
+                              "head_hash": self.head_hash}
+        if self.failure_mechanisms:
+            d["failure_mechanisms"] = self.failure_mechanisms
+        return d
 def _sha256_hex(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 

--- a/src/assay/verification_status.py
+++ b/src/assay/verification_status.py
@@ -1,30 +1,37 @@
 """Canonical verdict classification for verification results.
 
-Single source of truth for the PASS / HONEST_FAIL / TAMPERED taxonomy.
+Single source of truth for the PASS / HONEST_FAIL / TAMPERED /
+INSUFFICIENT_EVIDENCE taxonomy.
 Used by badge, HTML, terminal output, and any future rendering surface.
 
 Policy:
-    PASS        — integrity valid, all claims pass (or no claims)
-    HONEST_FAIL — integrity valid, but one or more claims fail
-    TAMPERED    — signature, hash, manifest, or file integrity failure
+    PASS                  — integrity valid, all claims pass (or no claims)
+    HONEST_FAIL           — integrity valid, but one or more claims fail
+    TAMPERED              — signature, hash, manifest, or file integrity failure
+    INSUFFICIENT_EVIDENCE — integrity valid, but witness evidence contract
+                            unfulfilled (cannot determine claim truth)
 """
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, Optional
 
-VerificationVerdict = Literal["PASS", "HONEST_FAIL", "TAMPERED"]
+VerificationVerdict = Literal[
+    "PASS", "HONEST_FAIL", "TAMPERED", "INSUFFICIENT_EVIDENCE"
+]
 
 # Display labels keyed by verdict
 VERDICT_LABELS: dict[str, str] = {
     "PASS": "Pack verified",
     "HONEST_FAIL": "Pack verified, claims failed",
     "TAMPERED": "Pack integrity compromised",
+    "INSUFFICIENT_EVIDENCE": "Insufficient evidence to determine",
 }
 
 VERDICT_COLORS: dict[str, str] = {
     "PASS": "#4c1",
     "HONEST_FAIL": "#fe7d37",
     "TAMPERED": "#e05d44",
+    "INSUFFICIENT_EVIDENCE": "#9f9f9f",
 }
 
 
@@ -32,15 +39,20 @@ def classify_verdict(
     *,
     integrity_passed: bool,
     claim_check: str,
+    witness_sufficient: Optional[bool] = None,
 ) -> VerificationVerdict:
     """Map raw verification result to canonical verdict.
 
     Args:
         integrity_passed: True if manifest signature and file hashes are valid.
         claim_check: The attestation claim_check value ("PASS", "FAIL", "N/A").
+        witness_sufficient: None = not evaluated. False = witness evidence
+            contract unfulfilled (required but insufficient). True = witness OK.
     """
     if not integrity_passed:
         return "TAMPERED"
+    if witness_sufficient is False:
+        return "INSUFFICIENT_EVIDENCE"
     if claim_check == "FAIL":
         return "HONEST_FAIL"
     return "PASS"

--- a/src/assay/verify_render.py
+++ b/src/assay/verify_render.py
@@ -58,11 +58,12 @@ def render_verification_html(
     # Error rows
     error_rows = ""
     if errors:
-        error_rows = "<h3>Failure Details</h3><table><tr><th>Code</th><th>Message</th></tr>"
+        error_rows = "<h3>Failure Details</h3><table><tr><th>Code</th><th>Mechanism</th><th>Message</th></tr>"
         for err in errors:
             e_code = html.escape(str(err.get("code", "")))
+            e_mech = html.escape(str(err.get("failure_mechanism", "")))
             e_msg = html.escape(str(err.get("message", "")))
-            error_rows += f"<tr><td><code>{e_code}</code></td><td>{e_msg}</td></tr>"
+            error_rows += f"<tr><td><code>{e_code}</code></td><td>{e_mech}</td><td>{e_msg}</td></tr>"
         error_rows += "</table>"
 
     # Warning rows

--- a/src/assay/witness.py
+++ b/src/assay/witness.py
@@ -40,6 +40,7 @@ class WitnessVerifyResult:
     passed: bool
     errors: List[str] = field(default_factory=list)
     gen_time: Optional[str] = None
+    sufficiency: float = 0.0
 
 
 class WitnessError(Exception):
@@ -301,15 +302,21 @@ def verify_witness_bundle(
         WitnessVerifyResult with passed/errors.
     """
     errors: List[str] = []
+    checks_total = 0
+    checks_passed = 0
 
     # 1. Schema version
+    checks_total += 1
     if bundle.get("schema_version") != SCHEMA_VERSION:
         errors.append(
             f"Unknown schema_version: {bundle.get('schema_version')!r} "
             f"(expected {SCHEMA_VERSION!r})"
         )
+    else:
+        checks_passed += 1
 
     # 2. D12 invariant
+    checks_total += 1
     b_root = bundle.get("pack_root_sha256", "")
     b_att = bundle.get("attestation_sha256", "")
     if b_root and b_att and b_root != b_att:
@@ -317,15 +324,21 @@ def verify_witness_bundle(
             f"D12 invariant violated: pack_root_sha256 ({b_root[:16]}...) "
             f"!= attestation_sha256 ({b_att[:16]}...)"
         )
+    else:
+        checks_passed += 1
 
     # 3. Pack root match
+    checks_total += 1
     if b_root != pack_root_sha256:
         errors.append(
             f"Pack root mismatch: bundle references {b_root[:16]}..., "
             f"expected {pack_root_sha256[:16]}..."
         )
+    else:
+        checks_passed += 1
 
     # 4. Token verification
+    checks_total += 1
     witness_type = bundle.get("witness_type", "")
     gen_time = bundle.get("gen_time")
 
@@ -370,6 +383,8 @@ def verify_witness_bundle(
                     if result.returncode != 0:
                         stderr = result.stderr.decode().strip()
                         errors.append(f"RFC 3161 verification failed: {stderr}")
+                    else:
+                        checks_passed += 1
             except Exception as e:
                 errors.append(f"RFC 3161 verification error: {e}")
 
@@ -378,10 +393,13 @@ def verify_witness_bundle(
     else:
         errors.append(f"Unknown witness_type: {witness_type!r}")
 
+    sufficiency = checks_passed / checks_total if checks_total > 0 else 0.0
+
     return WitnessVerifyResult(
         passed=len(errors) == 0,
         errors=errors,
         gen_time=gen_time,
+        sufficiency=round(sufficiency, 3),
     )
 
 

--- a/tests/assay/test_three_state_verification.py
+++ b/tests/assay/test_three_state_verification.py
@@ -1,0 +1,365 @@
+"""Tests for three-state verification: PASS / HONEST_FAIL / TAMPERED / INSUFFICIENT_EVIDENCE.
+
+Also covers:
+- failure_mechanism classification on VerifyError
+- witness_sufficiency scoring on WitnessVerifyResult
+- verdict field in JSON output
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from assay.commands import assay_app
+from assay.failure_mechanisms import (
+    ERROR_TO_MECHANISM,
+    FM_POLICY_CONFLICT,
+    FM_SCHEMA_MISMATCH,
+    FM_STALE_EVIDENCE,
+    FM_TAMPER_DETECTED,
+    FM_WITNESS_GAP,
+    mechanism_for_code,
+)
+from assay.integrity import (
+    E_CANON_MISMATCH,
+    E_CI_BINDING_MISMATCH,
+    E_MANIFEST_TAMPER,
+    E_PACK_SIG_INVALID,
+    E_PACK_STALE,
+    E_POLICY_MISSING,
+    E_SCHEMA_UNKNOWN,
+    E_SIG_MISSING,
+    E_TIMESTAMP_INVALID,
+    VerifyError,
+    VerifyResult,
+)
+from assay.keystore import AssayKeyStore
+from assay.proof_pack import ProofPack
+from assay.verification_status import (
+    VERDICT_COLORS,
+    VERDICT_LABELS,
+    classify_verdict,
+)
+from assay.witness import WitnessVerifyResult
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_receipt(**overrides):
+    base = {
+        "receipt_id": f"r_{uuid.uuid4().hex[:8]}",
+        "type": "model_call",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "schema_version": "3.0",
+    }
+    base.update(overrides)
+    return base
+
+
+def _build_pack(tmp_path, receipts=None, signer_id="test-signer"):
+    ks = AssayKeyStore(keys_dir=tmp_path / "keys")
+    ks.generate_key(signer_id)
+    if receipts is None:
+        receipts = [_make_receipt(seq=i) for i in range(3)]
+    pack = ProofPack(
+        run_id="three-state-test",
+        entries=receipts,
+        signer_id=signer_id,
+        claims=[],
+        mode="shadow",
+    )
+    out = pack.build(tmp_path / "pack", keystore=ks)
+    return out, ks
+
+
+# ---------------------------------------------------------------------------
+# VerifyError failure_mechanism
+# ---------------------------------------------------------------------------
+
+class TestFailureMechanism:
+
+    def test_tamper_errors_classified(self):
+        err = VerifyError(code=E_MANIFEST_TAMPER, message="test")
+        assert err.failure_mechanism == FM_TAMPER_DETECTED
+
+    def test_stale_errors_classified(self):
+        err = VerifyError(code=E_PACK_STALE, message="test")
+        assert err.failure_mechanism == FM_STALE_EVIDENCE
+
+    def test_timestamp_invalid_is_stale(self):
+        err = VerifyError(code=E_TIMESTAMP_INVALID, message="test")
+        assert err.failure_mechanism == FM_STALE_EVIDENCE
+
+    def test_schema_errors_classified(self):
+        err = VerifyError(code=E_SCHEMA_UNKNOWN, message="test")
+        assert err.failure_mechanism == FM_SCHEMA_MISMATCH
+
+    def test_canon_mismatch_is_schema(self):
+        err = VerifyError(code=E_CANON_MISMATCH, message="test")
+        assert err.failure_mechanism == FM_SCHEMA_MISMATCH
+
+    def test_sig_missing_is_witness_gap(self):
+        err = VerifyError(code=E_SIG_MISSING, message="test")
+        assert err.failure_mechanism == FM_WITNESS_GAP
+
+    def test_policy_missing_is_policy_conflict(self):
+        err = VerifyError(code=E_POLICY_MISSING, message="test")
+        assert err.failure_mechanism == FM_POLICY_CONFLICT
+
+    def test_ci_binding_mismatch_is_policy_conflict(self):
+        err = VerifyError(code=E_CI_BINDING_MISMATCH, message="test")
+        assert err.failure_mechanism == FM_POLICY_CONFLICT
+
+    def test_pack_sig_invalid_is_tamper(self):
+        err = VerifyError(code=E_PACK_SIG_INVALID, message="test")
+        assert err.failure_mechanism == FM_TAMPER_DETECTED
+
+    def test_unknown_code_gets_none(self):
+        err = VerifyError(code="E_CUSTOM_UNKNOWN", message="test")
+        assert err.failure_mechanism is None
+
+    def test_explicit_mechanism_overrides_default(self):
+        err = VerifyError(code=E_MANIFEST_TAMPER, message="test",
+                          failure_mechanism="custom_override")
+        assert err.failure_mechanism == "custom_override"
+
+    def test_to_dict_includes_mechanism(self):
+        err = VerifyError(code=E_MANIFEST_TAMPER, message="test")
+        d = err.to_dict()
+        assert d["failure_mechanism"] == FM_TAMPER_DETECTED
+
+    def test_to_dict_omits_none_mechanism(self):
+        err = VerifyError(code="E_CUSTOM", message="test")
+        d = err.to_dict()
+        assert "failure_mechanism" not in d
+
+    def test_all_known_codes_have_mechanism(self):
+        """Every E_ constant in integrity.py should map to a mechanism."""
+        from assay import integrity
+        e_codes = [v for k, v in vars(integrity).items()
+                   if k.startswith("E_") and isinstance(v, str)]
+        for code in e_codes:
+            assert mechanism_for_code(code) is not None, (
+                f"Error code {code} has no mechanism mapping"
+            )
+
+
+# ---------------------------------------------------------------------------
+# VerifyResult.failure_mechanisms
+# ---------------------------------------------------------------------------
+
+class TestFailureMechanismsSummary:
+
+    def test_empty_errors_returns_empty_dict(self):
+        r = VerifyResult(passed=True, errors=[])
+        assert r.failure_mechanisms == {}
+
+    def test_groups_by_mechanism(self):
+        errors = [
+            VerifyError(code=E_MANIFEST_TAMPER, message="a"),
+            VerifyError(code=E_PACK_SIG_INVALID, message="b"),
+            VerifyError(code=E_PACK_STALE, message="c"),
+        ]
+        r = VerifyResult(passed=False, errors=errors)
+        fm = r.failure_mechanisms
+        assert fm[FM_TAMPER_DETECTED] == 2
+        assert fm[FM_STALE_EVIDENCE] == 1
+
+    def test_to_dict_includes_mechanisms_when_present(self):
+        errors = [VerifyError(code=E_MANIFEST_TAMPER, message="a")]
+        r = VerifyResult(passed=False, errors=errors)
+        d = r.to_dict()
+        assert "failure_mechanisms" in d
+        assert d["failure_mechanisms"][FM_TAMPER_DETECTED] == 1
+
+    def test_to_dict_omits_mechanisms_when_no_errors(self):
+        r = VerifyResult(passed=True, errors=[])
+        d = r.to_dict()
+        assert "failure_mechanisms" not in d
+
+
+# ---------------------------------------------------------------------------
+# classify_verdict — three-state + INSUFFICIENT_EVIDENCE
+# ---------------------------------------------------------------------------
+
+class TestClassifyVerdict:
+
+    def test_tampered_when_integrity_fails(self):
+        assert classify_verdict(
+            integrity_passed=False, claim_check="N/A"
+        ) == "TAMPERED"
+
+    def test_tampered_trumps_witness(self):
+        assert classify_verdict(
+            integrity_passed=False, claim_check="PASS",
+            witness_sufficient=False,
+        ) == "TAMPERED"
+
+    def test_pass_when_all_good(self):
+        assert classify_verdict(
+            integrity_passed=True, claim_check="PASS"
+        ) == "PASS"
+
+    def test_pass_when_no_claims(self):
+        assert classify_verdict(
+            integrity_passed=True, claim_check="N/A"
+        ) == "PASS"
+
+    def test_pass_with_witness_ok(self):
+        assert classify_verdict(
+            integrity_passed=True, claim_check="PASS",
+            witness_sufficient=True,
+        ) == "PASS"
+
+    def test_honest_fail_when_claims_fail(self):
+        assert classify_verdict(
+            integrity_passed=True, claim_check="FAIL"
+        ) == "HONEST_FAIL"
+
+    def test_insufficient_evidence_when_witness_insufficient(self):
+        assert classify_verdict(
+            integrity_passed=True, claim_check="N/A",
+            witness_sufficient=False,
+        ) == "INSUFFICIENT_EVIDENCE"
+
+    def test_insufficient_evidence_trumps_honest_fail(self):
+        """If witness is insufficient, we can't even trust the claim check."""
+        assert classify_verdict(
+            integrity_passed=True, claim_check="FAIL",
+            witness_sufficient=False,
+        ) == "INSUFFICIENT_EVIDENCE"
+
+    def test_witness_none_means_not_evaluated(self):
+        """Default: witness not evaluated -> no INSUFFICIENT_EVIDENCE."""
+        assert classify_verdict(
+            integrity_passed=True, claim_check="N/A",
+            witness_sufficient=None,
+        ) == "PASS"
+
+    def test_all_verdicts_have_labels(self):
+        for v in ["PASS", "HONEST_FAIL", "TAMPERED", "INSUFFICIENT_EVIDENCE"]:
+            assert v in VERDICT_LABELS
+            assert v in VERDICT_COLORS
+
+
+# ---------------------------------------------------------------------------
+# WitnessVerifyResult.sufficiency
+# ---------------------------------------------------------------------------
+
+class TestWitnessSufficiency:
+
+    def test_passed_witness_has_full_sufficiency(self):
+        r = WitnessVerifyResult(passed=True, sufficiency=1.0)
+        assert r.sufficiency == 1.0
+
+    def test_failed_witness_has_partial_sufficiency(self):
+        r = WitnessVerifyResult(passed=False, errors=["test"], sufficiency=0.75)
+        assert r.sufficiency == 0.75
+
+    def test_default_sufficiency_is_zero(self):
+        r = WitnessVerifyResult(passed=False, errors=["test"])
+        assert r.sufficiency == 0.0
+
+
+# ---------------------------------------------------------------------------
+# CLI JSON output: verdict field
+# ---------------------------------------------------------------------------
+
+class TestVerifyPackJsonVerdict:
+
+    def test_json_includes_verdict_pass(self, tmp_path):
+        pack_dir, ks = _build_pack(tmp_path)
+        result = runner.invoke(assay_app, [
+            "verify-pack", str(pack_dir), "--json",
+        ])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["verdict"] == "PASS"
+
+    def test_json_includes_verdict_tampered(self, tmp_path):
+        pack_dir, ks = _build_pack(tmp_path)
+        # Tamper with receipt_pack.jsonl
+        rp = pack_dir / "receipt_pack.jsonl"
+        lines = rp.read_text().strip().split("\n")
+        obj = json.loads(lines[0])
+        obj["receipt_id"] = "r_tampered"
+        lines[0] = json.dumps(obj)
+        rp.write_text("\n".join(lines) + "\n")
+
+        result = runner.invoke(assay_app, [
+            "verify-pack", str(pack_dir), "--json",
+        ])
+        data = json.loads(result.output)
+        assert data["verdict"] == "TAMPERED"
+
+    def test_json_includes_failure_mechanisms(self, tmp_path):
+        pack_dir, ks = _build_pack(tmp_path)
+        # Tamper
+        rp = pack_dir / "receipt_pack.jsonl"
+        lines = rp.read_text().strip().split("\n")
+        obj = json.loads(lines[0])
+        obj["receipt_id"] = "r_tampered"
+        lines[0] = json.dumps(obj)
+        rp.write_text("\n".join(lines) + "\n")
+
+        result = runner.invoke(assay_app, [
+            "verify-pack", str(pack_dir), "--json",
+        ])
+        data = json.loads(result.output)
+        assert "failure_mechanisms" in data
+        assert FM_TAMPER_DETECTED in data["failure_mechanisms"]
+
+    def test_json_no_failure_mechanisms_on_pass(self, tmp_path):
+        pack_dir, ks = _build_pack(tmp_path)
+        result = runner.invoke(assay_app, [
+            "verify-pack", str(pack_dir), "--json",
+        ])
+        data = json.loads(result.output)
+        assert "failure_mechanisms" not in data
+
+    def test_exit_codes_unchanged(self, tmp_path):
+        """Verify that adding verdict field doesn't change exit code contract."""
+        pack_dir, ks = _build_pack(tmp_path)
+
+        # PASS -> exit 0
+        r = runner.invoke(assay_app, ["verify-pack", str(pack_dir), "--json"])
+        assert r.exit_code == 0
+
+        # TAMPERED -> exit 2
+        rp = pack_dir / "receipt_pack.jsonl"
+        lines = rp.read_text().strip().split("\n")
+        obj = json.loads(lines[0])
+        obj["receipt_id"] = "r_tampered"
+        lines[0] = json.dumps(obj)
+        rp.write_text("\n".join(lines) + "\n")
+        r = runner.invoke(assay_app, ["verify-pack", str(pack_dir), "--json"])
+        assert r.exit_code == 2
+
+
+# ---------------------------------------------------------------------------
+# Failure mechanism mapping completeness
+# ---------------------------------------------------------------------------
+
+class TestMechanismMappingCompleteness:
+
+    def test_five_mechanism_families(self):
+        families = set(ERROR_TO_MECHANISM.values())
+        assert families == {
+            FM_STALE_EVIDENCE, FM_SCHEMA_MISMATCH, FM_WITNESS_GAP,
+            FM_TAMPER_DETECTED, FM_POLICY_CONFLICT,
+        }
+
+    def test_every_mechanism_maps_to_valid_family(self):
+        valid = {FM_STALE_EVIDENCE, FM_SCHEMA_MISMATCH, FM_WITNESS_GAP,
+                 FM_TAMPER_DETECTED, FM_POLICY_CONFLICT}
+        for code, mech in ERROR_TO_MECHANISM.items():
+            assert mech in valid, f"{code} maps to unknown mechanism {mech}"


### PR DESCRIPTION
## Summary

- **Mechanism-typed failures**: Every `VerifyError` now carries a `failure_mechanism` field classifying errors into 5 families (`stale_evidence`, `schema_mismatch`, `witness_gap`, `tamper_detected`, `policy_conflict`). All 14 error codes mapped. `VerifyResult.failure_mechanisms` aggregates counts by family.
- **Witness sufficiency**: `WitnessVerifyResult.sufficiency` is a `0.0–1.0` float computed from checks passed / total checks in `verify_witness_bundle`. Surfaced in JSON output when `--require-witness` is used.
- **Four-state verdict**: `VerificationVerdict` extended with `INSUFFICIENT_EVIDENCE` for cases where integrity passes but witness evidence contract is unfulfilled. `classify_verdict()` accepts optional `witness_sufficient` parameter (backward compatible). JSON output now includes `verdict` field alongside existing `status`.
- **Render updates**: HTML error table includes mechanism column. All 4 verdict states have colors/labels for HTML + SVG badge.
- **Exit codes unchanged**: 0/1/2/3 contract fully preserved. INSUFFICIENT_EVIDENCE is advisory in JSON/HTML only.

## Test plan

- [x] 38 new tests in `test_three_state_verification.py` covering mechanism classification, verdict logic, JSON output, exit code preservation, and mapping completeness
- [x] 1716 existing tests pass with zero regressions (1 pre-existing `test_messaging_drift` version mismatch excluded)
- [ ] Verify proof gallery scenarios still produce expected exit codes
- [ ] Verify `--json` output includes `verdict` and `failure_mechanisms` fields on tamper scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)