### PR TITLE
feat(decision): CLI validator and buyer-facing example

### DIFF
--- a/docs/examples/what-an-ai-decision-receipt-looks-like.md
+++ b/docs/examples/what-an-ai-decision-receipt-looks-like.md
@@ -1,0 +1,104 @@
+# What an Auditable AI Decision Looks Like
+
+When your AI system refuses a request, blocks an action, or approves a workflow — what evidence do you have that the decision was governed?
+
+Most systems log a status code. Some add a reason string. Almost none produce a **reviewable, policy-bound, evidence-linked decision artifact**.
+
+A Decision Receipt does.
+
+---
+
+## Example: Automated Claim Denial
+
+An AI claims adjudication system receives a request to auto-approve a claim. The system refuses.
+
+Here is the receipt it produces:
+
+### Decision
+
+| Field | Value |
+|-------|-------|
+| **What was decided** | REFUSE — claim auto-approval blocked |
+| **Why** | Claim touches protected data without required consent verification. Policy floor would be breached. |
+| **Reason codes** | `consent_gate_missing`, `policy_floor_breach` |
+| **Confidence** | High — evidence was sufficient to determine refusal |
+
+### Authority
+
+| Field | Value |
+|-------|-------|
+| **Who decided** | Governance gate (automated, not human override) |
+| **Authority level** | BINDING — this decision blocks execution |
+| **Jurisdiction** | Consent and data protection policy |
+| **Policy applied** | `claims.consent_governance.v4` |
+| **Policy hash** | `2345...ef01` (verifiable — the exact policy version is pinned) |
+
+### Evidence Considered
+
+| Evidence | Role | Integrity |
+|----------|------|-----------|
+| Consent verification check (negative result) | Supporting the refusal | Hash-verified |
+
+No evidence gaps were identified. The refusal is based on complete information, not missing data.
+
+### What Happens Next
+
+| Field | Value |
+|-------|-------|
+| **Disposition** | Blocked — no downstream execution |
+| **Review path** | Operator can resubmit after consent gate approval |
+| **Obligations** | None created — clean refusal, no follow-up required |
+
+### Audit Properties
+
+| Property | Value |
+|----------|-------|
+| **Immutable** | This receipt cannot be edited after creation. Revisions create a new receipt pointing to this one. |
+| **Signed** | Can be Ed25519-signed by the deciding authority |
+| **Replayable** | Policy hash + evidence references allow reconstruction of why this decision was made |
+| **Proof tier** | CONSTITUTIONAL — highest verification level |
+
+---
+
+## What This Proves
+
+A Decision Receipt answers five questions that matter for compliance, audit, and trust:
+
+1. **What was decided?** — REFUSE, with typed reason codes
+2. **Who decided it?** — Identified authority with declared jurisdiction
+3. **Under what rules?** — Pinned policy version, hash-verifiable
+4. **On what evidence?** — Referenced, hash-bound, role-tagged
+5. **What happened next?** — Blocked, with a clear review path
+
+This is not a log line. It is a **governed artifact** that survives later review.
+
+---
+
+## Why Refusal Matters Most
+
+Approval is easy to explain after the fact. Refusal is where governance earns trust.
+
+When your AI system says "no," the people who need to understand why include:
+- the operator who submitted the request
+- the compliance team reviewing decisions
+- the auditor asking "was this policy actually enforced?"
+- the regulator asking "can you prove your AI follows your rules?"
+
+A Decision Receipt gives all of them the same artifact — not a narrative, not a log, but a structured, verifiable, policy-bound decision record.
+
+---
+
+## Try It
+
+```bash
+pip install assay-ai
+assay decision path/to/decision_receipt.json
+```
+
+The validator checks structural integrity, constitutional invariants (like "you cannot approve with insufficient evidence"), and forbidden states (like "high confidence with insufficient evidence").
+
+Every consequential AI decision can leave a receipt. Including when it says no.
+
+---
+
+*Built with [Assay](https://github.com/Haserjian/assay) — proof infrastructure for AI systems.*

--- a/src/assay/commands.py
+++ b/src/assay/commands.py
@@ -9663,6 +9663,95 @@ def pilot_closeout_cmd(
     raise typer.Exit(0)
 
 
+@assay_app.command("decision", hidden=True)
+def decision_validate_cmd(
+    receipt_path: str = typer.Argument(..., help="Path to a Decision Receipt JSON file"),
+    output_json: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Validate a Decision Receipt against constitutional invariants.
+
+    Checks structural integrity, verdict-disposition coherence,
+    authority constraints, evidence sufficiency, proof-tier monotonicity,
+    provenance self-consistency, and forbidden states.
+
+    Exit 0 = valid. Exit 1 = invalid.
+    """
+    from pathlib import Path as _Path
+
+    from assay.decision_receipt import validate_decision_receipt
+
+    path = _Path(receipt_path)
+    if not path.exists():
+        if output_json:
+            _output_json({"command": "decision", "status": "error",
+                          "error": f"File not found: {receipt_path}"}, exit_code=1)
+        console.print(f"[red]Error:[/] {receipt_path} not found")
+        raise typer.Exit(1)
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as e:
+        if output_json:
+            _output_json({"command": "decision", "status": "error",
+                          "error": f"Cannot parse: {e}"}, exit_code=1)
+        console.print(f"[red]Error:[/] Cannot parse {receipt_path}: {e}")
+        raise typer.Exit(1)
+
+    result = validate_decision_receipt(data)
+    verdict = data.get("verdict", "?")
+    decision_type = data.get("decision_type", "?")
+    subject = data.get("decision_subject", "?")
+    authority = data.get("authority_id", "?")
+
+    if output_json:
+        out = {
+            "command": "decision",
+            "status": "ok" if result.valid else "invalid",
+            "verdict": verdict,
+            "decision_type": decision_type,
+            "decision_subject": subject,
+            **result.to_dict(),
+        }
+        _output_json(out, exit_code=0 if result.valid else 1)
+
+    if result.valid:
+        reason = data.get("verdict_reason", "")
+        disposition = data.get("disposition", "?")
+        confidence = data.get("confidence", "?")
+        ev_suff = data.get("evidence_sufficient", "?")
+        policy = data.get("policy_id", "?")
+
+        console.print()
+        console.print(Panel.fit(
+            f"[bold green]Decision Receipt: VALID[/]\n\n"
+            f"Verdict:     [bold]{verdict}[/]\n"
+            f"Subject:     {subject}\n"
+            f"Type:        {decision_type}\n"
+            f"Authority:   {authority}\n"
+            f"Disposition: {disposition}\n"
+            f"Confidence:  {confidence}\n"
+            f"Evidence:    {'sufficient' if ev_suff else 'insufficient'}\n"
+            f"Policy:      {policy}\n"
+            + (f"\nReason: {reason}" if reason else ""),
+            title="assay decision",
+        ))
+    else:
+        console.print()
+        console.print(Panel.fit(
+            f"[bold red]Decision Receipt: INVALID[/]\n\n"
+            f"Verdict:  {verdict}\n"
+            f"Subject:  {subject}\n"
+            f"Errors:   {len(result.errors)}",
+            title="assay decision",
+        ))
+        for err in result.errors:
+            field_str = f" ({err.field})" if err.field else ""
+            console.print(f"  [{err.layer}] [red]{err.rule}[/]{field_str}: {err.message}")
+
+    console.print()
+    raise typer.Exit(0 if result.valid else 1)
+
+
 def main():
     """Entrypoint for assay CLI."""
     assay_app()


### PR DESCRIPTION
## Summary

- `assay decision <file>` — hidden CLI command for validating Decision Receipts against constitutional invariants. Human-readable panel output or `--json` structured diagnostics. Exit 0 = valid, exit 1 = invalid.
- Buyer-facing example doc showing what an auditable AI refusal looks like (claims adjudication denial with authority, evidence, disposition, and audit tables)

Follows PR #35 (Decision Receipt v0.1.0 schema + validator + 49 tests).

## Test plan

- [x] QA verified: CLI command name matches doc references
- [x] Validator logic confirmed working via direct import (commands.py has pre-existing 3.9 `float|int` incompatibility at line 106 — unrelated, CI runs 3.11+)
- [x] Schema-validator enum parity confirmed across all 9 constrained fields
- [ ] Verify CLI smoke passes on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)