### PR TITLE
[codex] fix witness lifecycle adc refresh

### DIFF
--- a/src/assay/adc_emitter.py
+++ b/src/assay/adc_emitter.py
@@ -60,6 +60,32 @@ def _derive_claim_results(
     return results
 
 
+def refresh_adc_witness_state(
+    adc: Dict[str, Any],
+    *,
+    time_authority: str,
+    witness_status: str,
+    sign_fn: Callable[[bytes], str],
+) -> Dict[str, Any]:
+    """Return a re-signed ADC with updated witness state.
+
+    This is intended for post-hoc witness amendment after a valid witness
+    bundle has been generated and verified. The credential body is updated,
+    rehashed, and re-signed so downstream readers see the amended witness
+    truth instead of the stale emission-time defaults.
+    """
+    body = {k: v for k, v in adc.items() if k not in ("credential_id", "signature")}
+    body["time_authority"] = time_authority
+    body["witness_status"] = witness_status
+
+    credential_id = _sha256_hex(to_jcs_bytes(body))
+    body["credential_id"] = credential_id
+
+    canonical_for_signing = to_jcs_bytes(body)
+    body["signature"] = sign_fn(canonical_for_signing)
+    return body
+
+
 def build_adc(
     *,
     # Issuer
@@ -158,7 +184,8 @@ def build_adc(
     body["supersedes"] = supersedes
     body["superseded_by"] = None
 
-    # Witness (always unwitnessed at emission time)
+    # Witness defaults at emission time. The witness command may later
+    # reissue this credential once valid external witness material exists.
     body["witness_status"] = "unwitnessed"
     body["ledger_entry_hash"] = None
     body["transparency_log_id"] = None
@@ -175,4 +202,4 @@ def build_adc(
     return body
 
 
-__all__ = ["build_adc"]
+__all__ = ["build_adc", "refresh_adc_witness_state"]

--- a/src/assay/commands.py
+++ b/src/assay/commands.py
@@ -3370,9 +3370,13 @@ def witness_cmd(
     """
     from pathlib import Path
 
+    from assay.adc_emitter import refresh_adc_witness_state
+    from assay.keystore import get_default_keystore
+    from assay.proof_pack import get_decision_credential_path, get_pack_summary_path
     from assay.witness import (
         WitnessError,
         generate_witness_bundle,
+        verify_witness_from_pack,
     )
 
     pack_path = Path(pack_dir)
@@ -3387,23 +3391,59 @@ def witness_cmd(
     out_path = Path(output) if output else None
 
     try:
+        decision_credential_path = get_decision_credential_path(pack_path)
+        decision_credential: Optional[dict] = None
+        signer_id: Optional[str] = None
+        keystore = None
+
+        if decision_credential_path.exists():
+            try:
+                decision_credential = json.loads(decision_credential_path.read_text())
+            except Exception as e:
+                raise WitnessError(f"Invalid decision credential JSON: {e}") from e
+
+            signer_id = str(decision_credential.get("issuer_id") or "")
+            if not signer_id:
+                raise WitnessError(
+                    "decision_credential.json missing issuer_id; cannot refresh witness state"
+                )
+
+            keystore = get_default_keystore()
+            if not keystore.has_key(signer_id):
+                raise WitnessError(
+                    f"Signer key not found for witness refresh: {signer_id}"
+                )
+
         bundle = generate_witness_bundle(
             pack_path,
             witness_type=witness_type,
             tsa_url=tsa_url,
             output_path=out_path,
         )
+
+        bundle_path = out_path or (pack_path / "witness_bundle.json")
+        witness_result = verify_witness_from_pack(pack_path, bundle_path=bundle_path)
+        if not witness_result.passed:
+            raise WitnessError(
+                "Generated witness bundle failed verification: "
+                + "; ".join(witness_result.errors)
+            )
+
+        if decision_credential is not None and keystore is not None and signer_id is not None:
+            refreshed_adc = refresh_adc_witness_state(
+                decision_credential,
+                time_authority="tsa_anchored",
+                witness_status="witnessed",
+                sign_fn=lambda data: keystore.sign_b64(data, signer_id),
+            )
+            decision_credential_path.write_text(json.dumps(refreshed_adc, indent=2) + "\n")
     except WitnessError as e:
         if output_json:
             _output_json({"command": "witness", "status": "error", "error": str(e)}, exit_code=2)
         console.print(f"[red]Error:[/] {e}")
         raise typer.Exit(2)
 
-    bundle_path = out_path or (pack_path / "witness_bundle.json")
-
     # Update PACK_SUMMARY.md if it exists in the unsigned sidecar dir
-    from assay.proof_pack import get_pack_summary_path
-
     summary_path = get_pack_summary_path(pack_path)
     if summary_path.exists():
         summary = summary_path.read_text()

--- a/src/assay/schemas/adc_v0.1.schema.json
+++ b/src/assay/schemas/adc_v0.1.schema.json
@@ -193,7 +193,7 @@
     "time_authority": {
       "type": "string",
       "description": "Source of time assertions in this credential.",
-      "enum": ["local_clock", "rfc3161_tsa", "transparency_log"]
+      "enum": ["local_clock", "ntp_verified", "tsa_anchored"]
     },
 
     "_comment_challenge_semantics": { "const": "--- Challenge Semantics ---" },
@@ -223,8 +223,8 @@
 
     "witness_status": {
       "type": "string",
-      "description": "Whether this credential has been independently witnessed. Progresses from unwitnessed to stronger levels.",
-      "enum": ["unwitnessed", "hash_verified", "signature_verified"]
+      "description": "Whether this credential has been independently witnessed. Progresses from unwitnessed to witnessed or rekor_included.",
+      "enum": ["unwitnessed", "witnessed", "rekor_included"]
     },
     "ledger_entry_hash": {
       "type": ["string", "null"],

--- a/tests/assay/test_adc_emitter.py
+++ b/tests/assay/test_adc_emitter.py
@@ -15,6 +15,7 @@ from assay.adc_emitter import (
     _derive_claim_results,
     _derive_overall_result,
     build_adc,
+    refresh_adc_witness_state,
 )
 from assay.claim_verifier import ClaimResult, ClaimSetResult
 from assay.keystore import AssayKeyStore
@@ -252,7 +253,39 @@ class TestBuildAdc:
     def test_witness_defaults_unwitnessed(self, tmp_path):
         ks = _make_keystore(tmp_path)
         adc = build_adc(**_minimal_adc_kwargs(ks))
+        assert adc["time_authority"] == "local_clock"
         assert adc["witness_status"] == "unwitnessed"
+
+    def test_refresh_witness_state_updates_fields_and_signature(self, tmp_path):
+        try:
+            import jsonschema
+        except ImportError:
+            pytest.skip("jsonschema not installed")
+
+        ks = _make_keystore(tmp_path)
+        adc = build_adc(**_minimal_adc_kwargs(ks))
+
+        refreshed = refresh_adc_witness_state(
+            adc,
+            time_authority="tsa_anchored",
+            witness_status="witnessed",
+            sign_fn=_make_sign_fn(ks),
+        )
+
+        assert refreshed["time_authority"] == "tsa_anchored"
+        assert refreshed["witness_status"] == "witnessed"
+
+        body = {k: v for k, v in refreshed.items() if k not in ("credential_id", "signature")}
+        expected_id = _sha256_hex(to_jcs_bytes(body))
+        assert refreshed["credential_id"] == expected_id
+
+        vk = ks.get_verify_key("test-signer")
+        sig_bytes = base64.b64decode(refreshed["signature"])
+        vk.verify(to_jcs_bytes({k: v for k, v in refreshed.items() if k != "signature"}), sig_bytes)
+
+        schema_path = Path(__file__).resolve().parent.parent.parent / "src" / "assay" / "schemas" / "adc_v0.1.schema.json"
+        schema = json.loads(schema_path.read_text())
+        jsonschema.validate(refreshed, schema)
 
     def test_deterministic_same_input_same_id(self, tmp_path):
         """Same inputs produce same credential_id (content-addressable)."""

--- a/tests/assay/test_witness.py
+++ b/tests/assay/test_witness.py
@@ -13,6 +13,7 @@ Covers:
   - Round-trip: generate -> verify (offline, mocked)
 """
 
+import base64
 import json
 from pathlib import Path
 from unittest.mock import patch, MagicMock
@@ -20,9 +21,11 @@ from unittest.mock import patch, MagicMock
 import pytest
 from typer.testing import CliRunner
 
+from assay._receipts.canonicalize import to_jcs_bytes
 from assay.commands import assay_app
 from assay.keystore import AssayKeyStore
 from assay.proof_pack import ProofPack
+from assay.proof_pack import get_decision_credential_path
 from assay.witness import (
     SCHEMA_VERSION,
     WitnessError,
@@ -87,6 +90,59 @@ def _make_bundle(
     }
     bundle.update(overrides)
     return bundle
+
+
+def _mock_rfc3161_round_trip():
+    """Return mock subprocess/urlopen handlers for a successful witness run."""
+    fake_token = b"\x30\x03\x02\x01\x00"
+    fake_ca = b"-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----"
+    fake_tsa = b"-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----"
+
+    mock_query = MagicMock()
+    mock_query.returncode = 0
+    mock_query.stderr = b""
+
+    mock_reply = MagicMock()
+    mock_reply.returncode = 0
+    mock_reply.stdout = b"Time stamp: Mar  4 12:34:56 2026 GMT\n"
+    mock_reply.stderr = b""
+
+    mock_query_text = MagicMock()
+    mock_query_text.returncode = 0
+    mock_query_text.stdout = b"Nonce: 0x44C02FF2BD956A61\n"
+    mock_query_text.stderr = b""
+
+    mock_verify = MagicMock()
+    mock_verify.returncode = 0
+    mock_verify.stderr = b""
+
+    def mock_run(cmd, **kwargs):
+        if "ts" in cmd and "-query" in cmd and "-text" in cmd:
+            return mock_query_text
+        if "ts" in cmd and "-query" in cmd:
+            out_idx = cmd.index("-out")
+            Path(cmd[out_idx + 1]).write_bytes(b"fake-query")
+            return mock_query
+        if "ts" in cmd and "-reply" in cmd:
+            return mock_reply
+        if "ts" in cmd and "-verify" in cmd:
+            return mock_verify
+        return mock_query
+
+    def mock_urlopen(req, **kwargs):
+        resp = MagicMock()
+        url = req.full_url if hasattr(req, "full_url") else str(req)
+        if "tsr" in url:
+            resp.read.return_value = fake_token
+        elif "cacert" in url:
+            resp.read.return_value = fake_ca
+        elif "tsa.crt" in url:
+            resp.read.return_value = fake_tsa
+        else:
+            resp.read.return_value = fake_token
+        return resp
+
+    return mock_run, mock_urlopen
 
 
 class TestVerifyWitnessBundle:
@@ -466,6 +522,23 @@ class TestWitnessCli:
         built = pp.build(pack_dir, keystore=ks)
         return built
 
+    @pytest.fixture
+    def cli_pack_with_adc(self, tmp_path, isolated_home):
+        signer_id = "assay-local"
+        keys_dir = isolated_home / ".assay" / "keys"
+        ks = AssayKeyStore(keys_dir=keys_dir)
+        ks.generate_key(signer_id)
+
+        pack_dir = tmp_path / "proof_pack_cli_adc"
+        pp = ProofPack(
+            run_id="witness-cli-adc-test",
+            entries=[],
+            signer_id=signer_id,
+            emit_adc=True,
+        )
+        built = pp.build(pack_dir, keystore=ks)
+        return built
+
     def test_witness_command_missing_pack(self, isolated_home, tmp_path):
         """witness command with missing pack should exit 2."""
         result = runner.invoke(
@@ -489,6 +562,48 @@ class TestWitnessCli:
             ["verify-witness", str(tmp_path / "missing-pack")],
         )
         assert result.exit_code == 2
+
+    def test_adc_defaults_to_unwitnessed_without_bundle(self, cli_pack_with_adc):
+        """Before witnessing, the ADC should still say local_clock / unwitnessed."""
+        cred_path = get_decision_credential_path(cli_pack_with_adc, legacy_fallback=False)
+        adc = json.loads(cred_path.read_text())
+        assert adc["time_authority"] == "local_clock"
+        assert adc["witness_status"] == "unwitnessed"
+        assert not (cli_pack_with_adc / "witness_bundle.json").exists()
+
+    def test_witness_command_refreshes_adc_state(self, cli_pack_with_adc, isolated_home):
+        """After witnessing, the ADC should be reissued with witness truth."""
+        manifest = json.loads((cli_pack_with_adc / "pack_manifest.json").read_text())
+        pack_root = manifest["pack_root_sha256"]
+        cred_path = get_decision_credential_path(cli_pack_with_adc, legacy_fallback=False)
+        before = json.loads(cred_path.read_text())
+        assert before["time_authority"] == "local_clock"
+        assert before["witness_status"] == "unwitnessed"
+
+        mock_run, mock_urlopen = _mock_rfc3161_round_trip()
+
+        with patch("assay.witness.subprocess.run", side_effect=mock_run), \
+             patch("assay.witness.urlopen", side_effect=mock_urlopen):
+            result = runner.invoke(
+                assay_app,
+                ["witness", str(cli_pack_with_adc)],
+            )
+
+        assert result.exit_code == 0, result.stdout
+        assert (cli_pack_with_adc / "witness_bundle.json").exists()
+
+        after = json.loads(cred_path.read_text())
+        assert after["time_authority"] == "tsa_anchored"
+        assert after["witness_status"] == "witnessed"
+        assert after["credential_id"] != before["credential_id"]
+
+        ks = AssayKeyStore(keys_dir=isolated_home / ".assay" / "keys")
+        vk = ks.get_verify_key("assay-local")
+        body = {k: v for k, v in after.items() if k != "signature"}
+        vk.verify(to_jcs_bytes(body), base64.b64decode(after["signature"]))
+
+        bundle = json.loads((cli_pack_with_adc / "witness_bundle.json").read_text())
+        assert bundle["pack_root_sha256"] == pack_root
 
     def test_verify_witness_command_with_valid_bundle(self, cli_pack):
         """verify-witness with valid bundle should exit 0."""


### PR DESCRIPTION
This PR closes the witness lifecycle gap in Assay.

Problem: RFC 3161 witnessing could generate a valid `witness_bundle.json` next to a proof pack while the emitted ADC sidecar still said `time_authority: local_clock` and `witness_status: unwitnessed`. That left downstream readers with stale truth even after stronger witness evidence existed on disk.

Fix: the witness CLI now verifies the generated bundle and, when an ADC sidecar is present and the signer key is available locally, refreshes `decision_credential.json` in place by updating the witness fields, recomputing `credential_id`, and re-signing the credential.

This keeps the manifest and pack architecture intact. The signed pack manifest remains immutable; the lifecycle refresh applies to the ADC sidecar, which is the artifact that carries witness state in this repo.

I also aligned the ADC schema vocabulary with the registry semantics from CCIO so the runtime and the taxonomy agree: `time_authority` now uses `local_clock`, `ntp_verified`, and `tsa_anchored`; `witness_status` now uses `unwitnessed`, `witnessed`, and `rekor_included`.

Tests:
- `pytest tests/assay/test_adc_emitter.py tests/assay/test_witness.py -q`
- `pytest tests/assay/ -q` -> 2260 passed, 11 skipped
