### PR TITLE
feat: authority snapshot seam in ADC emission

### DIFF
--- a/src/assay/adc_emitter.py
+++ b/src/assay/adc_emitter.py
@@ -72,7 +72,9 @@ def refresh_adc_witness_state(
     This is intended for post-hoc witness amendment after a valid witness
     bundle has been generated and verified. The credential body is updated,
     rehashed, and re-signed so downstream readers see the amended witness
-    truth instead of the stale emission-time defaults.
+    truth instead of the stale emission-time defaults. Any opaque
+    authority_snapshot payload already present on the ADC is preserved
+    verbatim.
     """
     body = {k: v for k, v in adc.items() if k not in ("credential_id", "signature")}
     body["time_authority"] = time_authority
@@ -116,6 +118,8 @@ def build_adc(
     # Challenge
     challenge_window_seconds: Optional[int] = None,
     supersedes: Optional[str] = None,
+    # Provenance / authority context
+    authority_snapshot: Optional[Dict[str, Any]] = None,
     # Signing
     sign_fn: Callable[[bytes], str],
 ) -> Dict[str, Any]:
@@ -135,6 +139,9 @@ def build_adc(
     """
     overall_result = _derive_overall_result(integrity_passed, claim_result)
     adc_claim_results = _derive_claim_results(claim_result)
+
+    if authority_snapshot is not None and not isinstance(authority_snapshot, dict):
+        raise TypeError("authority_snapshot must be a JSON object (dict) or None")
 
     # Build credential body — everything except credential_id and signature.
     body: Dict[str, Any] = {
@@ -172,6 +179,10 @@ def build_adc(
         body["claim_results"] = adc_claim_results
     if evidence_observed_at is not None:
         body["evidence_observed_at"] = evidence_observed_at
+    if authority_snapshot is not None:
+        # Opaque provenance payload supplied by the caller. Assay records it
+        # but does not derive, normalize, or enrich its contents.
+        body["authority_snapshot"] = authority_snapshot
 
     # Time semantics
     body["valid_from"] = issued_at

--- a/src/assay/proof_pack.py
+++ b/src/assay/proof_pack.py
@@ -322,6 +322,7 @@ class ProofPack:
         superseded_by: Optional[str] = None,
         emit_adc: bool = False,
         claim_namespace: Optional[str] = None,
+        authority_snapshot: Optional[Dict[str, Any]] = None,
     ):
         # run_id is canonical; trace_id accepted as alias for backward compat
         resolved_run_id = run_id or trace_id
@@ -337,6 +338,7 @@ class ProofPack:
         self.superseded_by = superseded_by
         self.emit_adc = emit_adc
         self.claim_namespace = claim_namespace
+        self.authority_snapshot = authority_snapshot
 
         # Default hashes for fields not yet wired
         self.policy_hash = policy_hash or _sha256_hex(b"default-policy-v0")
@@ -659,6 +661,7 @@ class ProofPack:
                 evidence_observed_at=attestation.get("timestamp_start"),
                 evaluated_at=report["verified_at"],
                 valid_until=self.valid_until,
+                authority_snapshot=self.authority_snapshot,
                 sign_fn=lambda data: ks.sign_b64(data, self.signer_id),
             )
             adc_bytes = json.dumps(adc, indent=2).encode("utf-8")
@@ -691,6 +694,7 @@ def build_proof_pack(
     mode: str = "shadow",
     claims: Optional[List[ClaimSpec]] = None,
     ci_binding: Optional[Dict[str, Any]] = None,
+    authority_snapshot: Optional[Dict[str, Any]] = None,
 ) -> Path:
     """Convenience function: load trace from store and build a Proof Pack.
 
@@ -723,6 +727,7 @@ def build_proof_pack(
         mode=mode,
         claims=claims,
         ci_binding=ci_binding,
+        authority_snapshot=authority_snapshot,
     )
     return pack.build(output_dir, keystore=keystore)
 

--- a/src/assay/schemas/adc_v0.1.schema.json
+++ b/src/assay/schemas/adc_v0.1.schema.json
@@ -129,6 +129,32 @@
       "minLength": 1
     },
 
+    "_comment_authority_snapshot": { "const": "--- Authority Snapshot (opaque provenance) ---" },
+
+    "authority_snapshot": {
+      "type": "object",
+      "description": "Opaque provenance payload supplied by the caller. Assay preserves it but does not derive, normalize, or enrich policy values locally.",
+      "properties": {
+        "source_system": {
+          "type": "string",
+          "description": "Upstream system that supplied the snapshot."
+        },
+        "semantic_authority_version": {
+          "type": "string",
+          "description": "Version string for the upstream authority registry or snapshot format."
+        },
+        "effective_constants": {
+          "type": "object",
+          "description": "Effective policy constants captured by the upstream authority snapshot."
+        },
+        "override_sources": {
+          "type": "object",
+          "description": "Provenance for any overridden constants in the upstream authority snapshot."
+        }
+      },
+      "additionalProperties": true
+    },
+
     "_comment_results": { "const": "--- Results ---" },
 
     "integrity_result": {

--- a/tests/assay/test_adc_emitter.py
+++ b/tests/assay/test_adc_emitter.py
@@ -51,11 +51,26 @@ def _make_receipt(**overrides):
     return base
 
 
-def _minimal_adc_kwargs(ks: AssayKeyStore) -> dict:
+def _authority_snapshot() -> dict:
+    return {
+        "source_system": "ccio",
+        "semantic_authority_version": "0.1.0",
+        "effective_constants": {
+            "D_ABORT": 0.15,
+            "D_QUALITY": 0.70,
+        },
+        "override_sources": {
+            "D_ABORT": "default",
+            "D_QUALITY": "default",
+        },
+    }
+
+
+def _minimal_adc_kwargs(ks: AssayKeyStore, *, authority_snapshot: dict | None = None) -> dict:
     """Minimal valid kwargs for build_adc()."""
     vk = ks.get_verify_key("test-signer")
     pubkey_bytes = vk.encode()
-    return dict(
+    kwargs = dict(
         issuer_id="test-signer",
         signer_pubkey=base64.b64encode(pubkey_bytes).decode("ascii"),
         signer_pubkey_sha256=_sha256_hex(pubkey_bytes),
@@ -69,6 +84,9 @@ def _minimal_adc_kwargs(ks: AssayKeyStore) -> dict:
         evaluated_at="2026-03-09T12:00:00Z",
         sign_fn=_make_sign_fn(ks),
     )
+    if authority_snapshot is not None:
+        kwargs["authority_snapshot"] = authority_snapshot
+    return kwargs
 
 
 # ---------------------------------------------------------------------------
@@ -239,6 +257,30 @@ class TestBuildAdc:
         assert adc["challenge_window_seconds"] == 604800
         assert adc["supersedes"] == "d" * 64
 
+    def test_authority_snapshot_round_trip(self, tmp_path):
+        try:
+            import jsonschema
+        except ImportError:
+            pytest.skip("jsonschema not installed")
+
+        ks = _make_keystore(tmp_path)
+        snapshot = _authority_snapshot()
+        adc = build_adc(**_minimal_adc_kwargs(ks, authority_snapshot=snapshot))
+
+        assert adc["authority_snapshot"] == snapshot
+
+        body = {k: v for k, v in adc.items() if k not in ("signature", "credential_id")}
+        expected_id = _sha256_hex(to_jcs_bytes(body))
+        assert adc["credential_id"] == expected_id
+
+        vk = ks.get_verify_key("test-signer")
+        sig_bytes = base64.b64decode(adc["signature"])
+        vk.verify(to_jcs_bytes({k: v for k, v in adc.items() if k != "signature"}), sig_bytes)
+
+        schema_path = Path(__file__).resolve().parent.parent.parent / "src" / "assay" / "schemas" / "adc_v0.1.schema.json"
+        schema = json.loads(schema_path.read_text())
+        jsonschema.validate(adc, schema)
+
     def test_nullable_fields_default_to_none(self, tmp_path):
         ks = _make_keystore(tmp_path)
         adc = build_adc(**_minimal_adc_kwargs(ks))
@@ -263,7 +305,8 @@ class TestBuildAdc:
             pytest.skip("jsonschema not installed")
 
         ks = _make_keystore(tmp_path)
-        adc = build_adc(**_minimal_adc_kwargs(ks))
+        snapshot = _authority_snapshot()
+        adc = build_adc(**_minimal_adc_kwargs(ks, authority_snapshot=snapshot))
 
         refreshed = refresh_adc_witness_state(
             adc,
@@ -274,6 +317,7 @@ class TestBuildAdc:
 
         assert refreshed["time_authority"] == "tsa_anchored"
         assert refreshed["witness_status"] == "witnessed"
+        assert refreshed["authority_snapshot"] == snapshot
 
         body = {k: v for k, v in refreshed.items() if k not in ("credential_id", "signature")}
         expected_id = _sha256_hex(to_jcs_bytes(body))
@@ -314,6 +358,14 @@ class TestBuildAdc:
         schema = json.loads(schema_path.read_text())
         jsonschema.validate(adc, schema)
 
+    def test_rejects_non_object_authority_snapshot(self, tmp_path):
+        ks = _make_keystore(tmp_path)
+        kwargs = _minimal_adc_kwargs(ks)
+        kwargs["authority_snapshot"] = ["not", "an", "object"]
+
+        with pytest.raises(TypeError, match="authority_snapshot"):
+            build_adc(**kwargs)
+
 
 # ---------------------------------------------------------------------------
 # ProofPack integration
@@ -352,6 +404,22 @@ class TestProofPackIntegration:
         assert adc["evidence_pack_id"].startswith("pack_")
         assert adc["integrity_result"] == "PASS"
         assert adc["overall_result"] == "PASS"
+
+    def test_emit_adc_preserves_authority_snapshot(self, tmp_path):
+        """emit_adc=True threads authority_snapshot into the signed ADC."""
+        ks = _make_keystore(tmp_path)
+        snapshot = _authority_snapshot()
+        pack = ProofPack(
+            run_id="run-002-snapshot",
+            entries=[_make_receipt()],
+            emit_adc=True,
+            signer_id="test-signer",
+            authority_snapshot=snapshot,
+        )
+        out = pack.build(tmp_path / "pack_snapshot", keystore=ks)
+        cred_path = get_decision_credential_path(out, legacy_fallback=False)
+        adc = json.loads(cred_path.read_text())
+        assert adc["authority_snapshot"] == snapshot
 
     def test_emit_adc_with_deterministic_ts(self, tmp_path):
         """Deterministic timestamp flows through to ADC."""

--- a/tests/assay/test_witness.py
+++ b/tests/assay/test_witness.py
@@ -92,6 +92,21 @@ def _make_bundle(
     return bundle
 
 
+def _authority_snapshot() -> dict:
+    return {
+        "source_system": "ccio",
+        "semantic_authority_version": "0.1.0",
+        "effective_constants": {
+            "D_ABORT": 0.15,
+            "D_QUALITY": 0.70,
+        },
+        "override_sources": {
+            "D_ABORT": "default",
+            "D_QUALITY": "default",
+        },
+    }
+
+
 def _mock_rfc3161_round_trip():
     """Return mock subprocess/urlopen handlers for a successful witness run."""
     fake_token = b"\x30\x03\x02\x01\x00"
@@ -535,6 +550,7 @@ class TestWitnessCli:
             entries=[],
             signer_id=signer_id,
             emit_adc=True,
+            authority_snapshot=_authority_snapshot(),
         )
         built = pp.build(pack_dir, keystore=ks)
         return built
@@ -569,6 +585,7 @@ class TestWitnessCli:
         adc = json.loads(cred_path.read_text())
         assert adc["time_authority"] == "local_clock"
         assert adc["witness_status"] == "unwitnessed"
+        assert adc["authority_snapshot"] == _authority_snapshot()
         assert not (cli_pack_with_adc / "witness_bundle.json").exists()
 
     def test_witness_command_refreshes_adc_state(self, cli_pack_with_adc, isolated_home):
@@ -596,6 +613,7 @@ class TestWitnessCli:
         assert after["time_authority"] == "tsa_anchored"
         assert after["witness_status"] == "witnessed"
         assert after["credential_id"] != before["credential_id"]
+        assert after["authority_snapshot"] == before["authority_snapshot"] == _authority_snapshot()
 
         ks = AssayKeyStore(keys_dir=isolated_home / ".assay" / "keys")
         vk = ks.get_verify_key("assay-local")


### PR DESCRIPTION
## Summary

- Add optional `authority_snapshot` to ADC credentials so upstream systems can record which constitutional constants and override sources were active at emission time
- Assay treats the snapshot as an opaque payload — it preserves but does not derive or enrich the contents
- Snapshot survives signing, rehashing, and witness refresh unchanged

## Motivation

Receipts currently don't record what thresholds were active when they were produced. With APM config and env-var override surfaces, two deployments running the same code version can have different effective thresholds. The authority snapshot makes this explicit and inspectable.

This is a contract-first seam: Assay accepts and preserves the payload, upstream systems (CCIO spine controller, deployment config) are responsible for populating it. No Assay code invents policy values.

## Changes

- `src/assay/adc_emitter.py`: `build_adc()` accepts optional `authority_snapshot` (dict), rejects non-objects. `refresh_adc_witness_state()` preserves snapshot through re-sign.
- `src/assay/proof_pack.py`: `ProofPack` and `build_proof_pack()` thread snapshot to ADC emission.
- `src/assay/schemas/adc_v0.1.schema.json`: optional `authority_snapshot` object with generic provenance fields.
- Tests: round-trip, schema validation, non-object rejection, ProofPack emission, witness-refresh preservation.

## Test plan

- [x] `pytest tests/assay/test_adc_emitter.py tests/assay/test_witness.py -q` → 61 passed
- [x] `pytest tests/assay/ -q` → 2263 passed, 11 skipped
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)