### PR TITLE
feat(posture): proof posture triad — core capability

### DIFF
--- a/docs/PROOF_POSTURE.md
+++ b/docs/PROOF_POSTURE.md
@@ -1,0 +1,112 @@
+# Proof Posture
+
+**Status:** Normative
+**Modules:** `claim_verifier.py`, `residual_risk.py`, `proof_debt.py`, `proof_posture.py`
+**Canonical specimen:** `tests/assay/fixtures/proof_posture/canonical_specimen.json`
+
+---
+
+## Four epistemic states
+
+Every verified claim set produces a proof posture with exactly four categories:
+
+| State | Meaning | Example |
+|---|---|---|
+| **proven** | Claim passed verification AND falsifier was executed and survived | "Model calls exist" with deletion test run |
+| **supported but capped** | Claim passed verification BUT cannot reach strong proof status | "Auth preserved" with no kill test named |
+| **tolerated** | Risk is acknowledged, has owner + expiry + next cheapest evidence | "Coverage gap tolerated until next sprint" |
+| **owed** | Constitutional obligation not yet fulfilled | "Name a falsifier" / "Assign owner" |
+
+These four states are the complete grammar. Do not add synonyms.
+
+---
+
+## Falsifier statuses
+
+| Status | Meaning |
+|---|---|
+| `not_required` | Warning-severity claim, or enforcement not active |
+| `absent` | Critical claim with no falsifier named |
+| `named` | Falsifier described but not yet executed |
+| `executed_passed` | Falsifier was run; claim survived disproof |
+| `executed_failed` | Falsifier was run; claim was disproved |
+
+---
+
+## Tier cap decision table
+
+Caps are applied via `TIER_CAP_TABLE` in `claim_verifier.py`. The table is the single source of truth.
+
+| Severity | Falsifier Status | Cap? | Reason |
+|---|---|---|---|
+| warning | any | No | Warnings are never capped |
+| critical | not_required | No | Enforcement not active |
+| critical | absent | **Yes** | No named falsifier |
+| critical | named | **Yes** | Falsifier not executed |
+| critical | executed_passed | No | Full proof eligible |
+| critical | executed_failed | **Yes** | Claim disproved |
+
+Cap is an admissibility downgrade, not a failure. The claim still passes or fails on its own evidence. The cap constrains how strongly the result can be relied upon.
+
+---
+
+## Proof debt sources
+
+Proof debt accrues from **exactly three sources**. This list is closed.
+
+| Source | Trigger | Severity | Repayment |
+|---|---|---|---|
+| `missing_evidence` | Critical claim failed verification | severe | Attach evidence satisfying the claim |
+| `missing_falsifier` | Critical claim has no named kill test | moderate | Name the cheapest disproof test |
+| `unowned_risk` | Residual risk missing owner or expiry | severe (no owner) / moderate (no expiry) | Assign owner and/or expiry condition |
+
+Do not add sources for generic unease, low confidence, weak wording, or reviewer vibes. Those belong elsewhere.
+
+---
+
+## Disposition
+
+Computed from posture components:
+
+| Disposition | Condition |
+|---|---|
+| `verified` | All claims pass, no caps, no blocking risk, no severe debt |
+| `supported_but_capped` | All claims pass, some tier-capped, no blocking risk |
+| `incomplete` | Critical claims failed, or severe debt exists |
+| `blocked` | Blocking residual risk prevents promotion |
+
+Priority: blocked > incomplete > supported_but_capped > verified.
+
+---
+
+## Residual risk structure
+
+Each item requires all seven fields:
+
+- `claim_id` — which claim this risk relates to
+- `risk_statement` — what is unresolved
+- `why_tolerated` — why this is acceptable for now
+- `owner` — who is responsible (empty = unowned = debt)
+- `expiry_condition` — when this tolerance expires (empty = no expiry = debt)
+- `next_cheapest_evidence` — what would most cheaply reduce this risk
+- `blocking_on_merge` — whether this risk prevents promotion
+
+Critical failures are NOT residual risk. They are failures. Do not smuggle failure through the residual risk side door.
+
+---
+
+## Vocabulary discipline
+
+These terms are normative. Do not substitute.
+
+| Use | Do not use |
+|---|---|
+| proven | verified, confirmed, validated |
+| supported but capped | provisional, weak-pass, soft verified |
+| tolerated | managed, accepted, known |
+| owed | pending, deferred, backlogged |
+| absent | missing, none, empty |
+| executed_passed | survived, confirmed, cleared |
+| executed_failed | disproved, contradicted, killed |
+| incomplete | needs work, partially done, almost |
+| blocked | held, paused, on hold |

--- a/src/assay/proof_debt.py
+++ b/src/assay/proof_debt.py
@@ -1,0 +1,166 @@
+"""
+Proof Debt Ledger for Assay Proof Packs.
+
+Proof debt transforms weak evidence from a passive label into an
+active liability.  Debt accrues from exactly three sources:
+
+  1. missing_evidence   — required evidence not present
+  2. missing_falsifier  — critical claim without a named kill test
+  3. unowned_risk       — residual risk carried without owner or expiry
+
+Debt is NOT:
+  - generic unease
+  - low confidence vibes
+  - broad quality concerns
+
+Those belong elsewhere.  If proof debt gets too broad, it stops being
+a constitutional primitive and becomes emotional bookkeeping.
+
+Each debt item suggests a repayment action so the system feels like
+guidance, not judgment theater.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+DEBT_SOURCES = {"missing_evidence", "missing_falsifier", "unowned_risk"}
+
+
+@dataclass
+class ProofDebtItem:
+    """A single unit of epistemic debt."""
+
+    claim_id: str
+    source: str  # one of DEBT_SOURCES
+    description: str
+    repayment_action: str
+    severity: str = "moderate"  # low | moderate | severe
+
+    def __post_init__(self) -> None:
+        if self.source not in DEBT_SOURCES:
+            raise ValueError(
+                f"Invalid debt source '{self.source}'; "
+                f"must be one of {sorted(DEBT_SOURCES)}"
+            )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "claim_id": self.claim_id,
+            "source": self.source,
+            "description": self.description,
+            "repayment_action": self.repayment_action,
+            "severity": self.severity,
+        }
+
+
+@dataclass
+class ProofDebtLedger:
+    """Collection of proof debt items for an episode or packet."""
+
+    items: List[ProofDebtItem] = field(default_factory=list)
+
+    @property
+    def n_items(self) -> int:
+        return len(self.items)
+
+    @property
+    def by_source(self) -> Dict[str, int]:
+        counts: Dict[str, int] = {}
+        for item in self.items:
+            counts[item.source] = counts.get(item.source, 0) + 1
+        return counts
+
+    @property
+    def by_severity(self) -> Dict[str, int]:
+        counts: Dict[str, int] = {}
+        for item in self.items:
+            counts[item.severity] = counts.get(item.severity, 0) + 1
+        return counts
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "n_items": self.n_items,
+            "by_source": self.by_source,
+            "by_severity": self.by_severity,
+            "items": [item.to_dict() for item in self.items],
+        }
+
+    def add(self, item: ProofDebtItem) -> None:
+        self.items.append(item)
+
+
+def compute_proof_debt(
+    claim_results: List[Dict[str, Any]],
+    *,
+    residual_risk_items: Optional[List[Dict[str, Any]]] = None,
+) -> ProofDebtLedger:
+    """Compute proof debt from claim results and residual risk.
+
+    Debt accrues from exactly three sources:
+      1. Critical claim failed (missing_evidence)
+      2. Critical claim has no falsifier (missing_falsifier)
+      3. Residual risk item has no owner or no expiry (unowned_risk)
+    """
+    ledger = ProofDebtLedger()
+
+    for cr in claim_results:
+        claim_id = cr.get("claim_id", "")
+        severity = cr.get("severity", "critical")
+        passed = cr.get("passed", False)
+        falsifier_status = cr.get("falsifier_status", "not_required")
+        tier_cap = cr.get("tier_cap")
+
+        # Source 1: missing evidence (critical claim failed)
+        if not passed and severity == "critical":
+            expected = cr.get("expected", "?")
+            ledger.add(ProofDebtItem(
+                claim_id=claim_id,
+                source="missing_evidence",
+                description=f"Critical claim failed: expected {expected}",
+                repayment_action=f"Attach evidence satisfying: {expected}",
+                severity="severe",
+            ))
+
+        # Source 2: missing falsifier (critical claim without kill test)
+        if falsifier_status == "absent" or (
+            severity == "critical" and tier_cap and "falsifier" in (tier_cap or "")
+        ):
+            ledger.add(ProofDebtItem(
+                claim_id=claim_id,
+                source="missing_falsifier",
+                description="Critical claim has no named kill test",
+                repayment_action="Name the cheapest test that would disprove this claim",
+                severity="moderate",
+            ))
+
+    # Source 3: unowned residual risk
+    for rr in (residual_risk_items or []):
+        claim_id = rr.get("claim_id", "")
+        owner = rr.get("owner", "")
+        expiry = rr.get("expiry_condition", "")
+
+        if not owner or not expiry:
+            missing = []
+            if not owner:
+                missing.append("owner")
+            if not expiry:
+                missing.append("expiry_condition")
+            ledger.add(ProofDebtItem(
+                claim_id=claim_id,
+                source="unowned_risk",
+                description=f"Residual risk missing: {', '.join(missing)}",
+                repayment_action=f"Assign {' and '.join(missing)} to this residual risk",
+                severity="moderate" if owner else "severe",
+            ))
+
+    return ledger
+
+
+__all__ = [
+    "ProofDebtItem",
+    "ProofDebtLedger",
+    "compute_proof_debt",
+    "DEBT_SOURCES",
+]

--- a/src/assay/proof_posture.py
+++ b/src/assay/proof_posture.py
@@ -1,0 +1,208 @@
+"""
+Proof Posture: unified summary of claim verification + residual risk + proof debt.
+
+A proof posture answers four questions:
+  - what is proven?
+  - what is supported but capped?
+  - what remains unresolved but tolerated?
+  - what is still owed?
+
+Most verification systems know only pass/fail/warning.
+Proof posture adds a richer epistemic grammar.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class ProofPosture:
+    """Structured summary of the epistemic state of a claim set."""
+
+    # From claim verification
+    n_claims: int = 0
+    n_passed: int = 0
+    n_failed: int = 0
+    n_capped: int = 0
+
+    # From residual risk
+    n_residual_risks: int = 0
+    n_risks_blocking: int = 0
+    n_risks_unowned: int = 0
+
+    # From proof debt
+    n_debt_items: int = 0
+    debt_by_source: Dict[str, int] = field(default_factory=dict)
+    debt_by_severity: Dict[str, int] = field(default_factory=dict)
+
+    # Disposition
+    disposition: str = "unknown"  # verified | supported_but_capped | incomplete | blocked
+
+    # Detail lists for rendering
+    capped_claims: List[Dict[str, str]] = field(default_factory=list)
+    residual_risks: List[Dict[str, str]] = field(default_factory=list)
+    debt_items: List[Dict[str, str]] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "disposition": self.disposition,
+            "claims": {
+                "total": self.n_claims,
+                "passed": self.n_passed,
+                "failed": self.n_failed,
+                "capped": self.n_capped,
+            },
+            "residual_risk": {
+                "total": self.n_residual_risks,
+                "blocking": self.n_risks_blocking,
+                "unowned": self.n_risks_unowned,
+            },
+            "proof_debt": {
+                "total": self.n_debt_items,
+                "by_source": self.debt_by_source,
+                "by_severity": self.debt_by_severity,
+            },
+            "capped_claims": self.capped_claims,
+            "residual_risks": self.residual_risks,
+            "debt_items": self.debt_items,
+        }
+
+
+def compute_disposition(
+    *,
+    n_failed: int,
+    n_capped: int,
+    n_risks_blocking: int,
+    n_debt_severe: int,
+) -> str:
+    """Derive disposition from posture components.
+
+    Disposition values:
+      - verified:              all claims pass, no caps, no blocking risk
+      - supported_but_capped:  all claims pass but some are tier-capped
+      - incomplete:            critical claims failed or severe debt exists
+      - blocked:               blocking residual risk prevents promotion
+    """
+    if n_risks_blocking > 0:
+        return "blocked"
+    if n_failed > 0:
+        return "incomplete"
+    if n_debt_severe > 0:
+        return "incomplete"
+    if n_capped > 0:
+        return "supported_but_capped"
+    return "verified"
+
+
+def build_proof_posture(
+    *,
+    claim_set_result: Optional[Dict[str, Any]] = None,
+    residual_risk_ledger: Optional[Dict[str, Any]] = None,
+    proof_debt_ledger: Optional[Dict[str, Any]] = None,
+) -> ProofPosture:
+    """Build a ProofPosture from the outputs of the three primitives."""
+    posture = ProofPosture()
+
+    # Claims
+    if claim_set_result:
+        posture.n_claims = claim_set_result.get("n_claims", 0)
+        posture.n_passed = claim_set_result.get("n_passed", 0)
+        posture.n_failed = claim_set_result.get("n_failed", 0)
+        posture.n_capped = claim_set_result.get("n_capped", 0)
+        for r in claim_set_result.get("results", []):
+            if r.get("tier_cap"):
+                posture.capped_claims.append({
+                    "claim_id": r.get("claim_id", ""),
+                    "tier_cap": r["tier_cap"],
+                    "falsifier_status": r.get("falsifier_status", ""),
+                })
+
+    # Residual risk
+    if residual_risk_ledger:
+        posture.n_residual_risks = residual_risk_ledger.get("n_items", 0)
+        posture.n_risks_blocking = residual_risk_ledger.get("n_blocking", 0)
+        posture.n_risks_unowned = residual_risk_ledger.get("n_unowned", 0)
+        for item in residual_risk_ledger.get("items", []):
+            posture.residual_risks.append({
+                "claim_id": item.get("claim_id", ""),
+                "risk_statement": item.get("risk_statement", ""),
+                "owner": item.get("owner", ""),
+                "next_cheapest_evidence": item.get("next_cheapest_evidence", ""),
+            })
+
+    # Proof debt
+    if proof_debt_ledger:
+        posture.n_debt_items = proof_debt_ledger.get("n_items", 0)
+        posture.debt_by_source = proof_debt_ledger.get("by_source", {})
+        posture.debt_by_severity = proof_debt_ledger.get("by_severity", {})
+        for item in proof_debt_ledger.get("items", []):
+            posture.debt_items.append({
+                "claim_id": item.get("claim_id", ""),
+                "source": item.get("source", ""),
+                "repayment_action": item.get("repayment_action", ""),
+            })
+
+    # Disposition
+    posture.disposition = compute_disposition(
+        n_failed=posture.n_failed,
+        n_capped=posture.n_capped,
+        n_risks_blocking=posture.n_risks_blocking,
+        n_debt_severe=posture.debt_by_severity.get("severe", 0),
+    )
+
+    return posture
+
+
+def render_proof_posture_text(posture: ProofPosture) -> str:
+    """Render a compact human-readable proof posture summary.
+
+    Designed for PR comments and terminal output.
+    Tiny top section, details below.
+    """
+    lines: List[str] = []
+
+    # Header
+    disp_label = {
+        "verified": "VERIFIED",
+        "supported_but_capped": "SUPPORTED (capped)",
+        "incomplete": "INCOMPLETE",
+        "blocked": "BLOCKED",
+        "unknown": "UNKNOWN",
+    }
+    lines.append(f"Proof Posture: {disp_label.get(posture.disposition, posture.disposition)}")
+    lines.append("")
+
+    # Claims summary
+    lines.append(f"Claims: {posture.n_passed} verified, {posture.n_failed} failed, {posture.n_capped} capped")
+
+    # Capped claims
+    if posture.capped_claims:
+        for cc in posture.capped_claims:
+            lines.append(f"  - {cc['claim_id']}: {cc['tier_cap']}")
+
+    # Residual risks
+    if posture.n_residual_risks > 0:
+        lines.append(f"Residual risks: {posture.n_residual_risks} ({posture.n_risks_unowned} unowned)")
+        for rr in posture.residual_risks:
+            owner = rr.get("owner") or "unowned"
+            lines.append(f"  - {rr['claim_id']}: {rr['risk_statement']} [{owner}]")
+            nce = rr.get("next_cheapest_evidence")
+            if nce:
+                lines.append(f"    next evidence: {nce}")
+
+    # Proof debt
+    if posture.n_debt_items > 0:
+        lines.append(f"Proof debt: {posture.n_debt_items} items owed")
+        for di in posture.debt_items:
+            lines.append(f"  - {di['claim_id']} ({di['source']}): {di['repayment_action']}")
+
+    return "\n".join(lines)
+
+
+__all__ = [
+    "ProofPosture",
+    "build_proof_posture",
+    "compute_disposition",
+    "render_proof_posture_text",
+]

--- a/src/assay/residual_risk.py
+++ b/src/assay/residual_risk.py
@@ -1,0 +1,141 @@
+"""
+Residual Risk Ledger for Assay Proof Packs.
+
+Residual risk tracks what remains unresolved but tolerated after
+verification.  Each item is aggressively structured — not prose.
+
+Distinct from failure:
+  - failed     = claim did not pass verification
+  - unproven   = insufficient evidence to evaluate
+  - tolerated  = risk acknowledged, owner assigned, expiry set
+
+The key field is next_cheapest_evidence: it turns uncertainty into
+a navigable frontier instead of a fog bank.
+"""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from assay._receipts.canonicalize import to_jcs_bytes
+
+
+@dataclass
+class ResidualRiskItem:
+    """A single unresolved risk carried forward with explicit tolerance."""
+
+    claim_id: str
+    risk_statement: str
+    why_tolerated: str
+    owner: str
+    expiry_condition: str
+    next_cheapest_evidence: str
+    blocking_on_merge: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "claim_id": self.claim_id,
+            "risk_statement": self.risk_statement,
+            "why_tolerated": self.why_tolerated,
+            "owner": self.owner,
+            "expiry_condition": self.expiry_condition,
+            "next_cheapest_evidence": self.next_cheapest_evidence,
+            "blocking_on_merge": self.blocking_on_merge,
+        }
+
+
+@dataclass
+class ResidualRiskLedger:
+    """Collection of residual risks for an episode or packet."""
+
+    items: List[ResidualRiskItem] = field(default_factory=list)
+
+    @property
+    def n_items(self) -> int:
+        return len(self.items)
+
+    @property
+    def n_blocking(self) -> int:
+        return sum(1 for item in self.items if item.blocking_on_merge)
+
+    @property
+    def n_unowned(self) -> int:
+        return sum(1 for item in self.items if not item.owner)
+
+    def fingerprint(self) -> str:
+        """Deterministic hash of the ledger contents."""
+        canonical = [item.to_dict() for item in sorted(self.items, key=lambda i: i.claim_id)]
+        return hashlib.sha256(to_jcs_bytes(canonical)).hexdigest()
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "n_items": self.n_items,
+            "n_blocking": self.n_blocking,
+            "n_unowned": self.n_unowned,
+            "fingerprint": self.fingerprint(),
+            "items": [item.to_dict() for item in self.items],
+        }
+
+    def add(self, item: ResidualRiskItem) -> None:
+        self.items.append(item)
+
+
+def build_residual_risk_from_claims(
+    claim_results: List[Dict[str, Any]],
+    *,
+    risk_annotations: Optional[Dict[str, Dict[str, str]]] = None,
+) -> ResidualRiskLedger:
+    """Build a residual risk ledger from claim verification results.
+
+    Any claim that passed but has a tier_cap, or failed with warning
+    severity, becomes a candidate residual risk.  The risk_annotations
+    dict maps claim_id to override fields (why_tolerated, owner,
+    expiry_condition, next_cheapest_evidence).
+    """
+    annotations = risk_annotations or {}
+    ledger = ResidualRiskLedger()
+
+    for cr in claim_results:
+        claim_id = cr.get("claim_id", "")
+        tier_cap = cr.get("tier_cap")
+        severity = cr.get("severity", "critical")
+        passed = cr.get("passed", False)
+
+        # Capped claims: passed but with limited proof strength
+        if passed and tier_cap:
+            ann = annotations.get(claim_id, {})
+            ledger.add(ResidualRiskItem(
+                claim_id=claim_id,
+                risk_statement=f"Claim passed but capped: {tier_cap}",
+                why_tolerated=ann.get("why_tolerated", "no rationale provided"),
+                owner=ann.get("owner", ""),
+                expiry_condition=ann.get("expiry_condition", ""),
+                next_cheapest_evidence=ann.get(
+                    "next_cheapest_evidence",
+                    "name a falsifier for this claim",
+                ),
+                blocking_on_merge=False,
+            ))
+
+        # Warning-severity failures: tolerated but noted
+        if not passed and severity == "warning":
+            ann = annotations.get(claim_id, {})
+            ledger.add(ResidualRiskItem(
+                claim_id=claim_id,
+                risk_statement=f"Warning claim failed: expected {cr.get('expected', '?')}, actual {cr.get('actual', '?')}",
+                why_tolerated=ann.get("why_tolerated", "warning severity — not blocking"),
+                owner=ann.get("owner", ""),
+                expiry_condition=ann.get("expiry_condition", ""),
+                next_cheapest_evidence=ann.get("next_cheapest_evidence", ""),
+                blocking_on_merge=False,
+            ))
+
+    return ledger
+
+
+__all__ = [
+    "ResidualRiskItem",
+    "ResidualRiskLedger",
+    "build_residual_risk_from_claims",
+]

--- a/tests/assay/fixtures/proof_posture/canonical_specimen.json
+++ b/tests/assay/fixtures/proof_posture/canonical_specimen.json
@@ -1,0 +1,79 @@
+{
+  "disposition": "incomplete",
+  "claims": {
+    "total": 4,
+    "passed": 3,
+    "failed": 1,
+    "capped": 2
+  },
+  "residual_risk": {
+    "total": 3,
+    "blocking": 0,
+    "unowned": 2
+  },
+  "proof_debt": {
+    "total": 4,
+    "by_source": {
+      "missing_falsifier": 2,
+      "unowned_risk": 2
+    },
+    "by_severity": {
+      "moderate": 2,
+      "severe": 2
+    }
+  },
+  "capped_claims": [
+    {
+      "claim_id": "auth_behavior_preserved",
+      "tier_cap": "capped: no named falsifier",
+      "falsifier_status": "absent"
+    },
+    {
+      "claim_id": "timestamps_valid",
+      "tier_cap": "capped: falsifier named but not executed",
+      "falsifier_status": "named"
+    }
+  ],
+  "residual_risks": [
+    {
+      "claim_id": "auth_behavior_preserved",
+      "risk_statement": "Claim passed but capped: capped: no named falsifier",
+      "owner": "security-team",
+      "next_cheapest_evidence": "Run session expiry matrix"
+    },
+    {
+      "claim_id": "high_receipt_count",
+      "risk_statement": "Warning claim failed: expected >= 10 receipts, actual 3 receipts",
+      "owner": "",
+      "next_cheapest_evidence": ""
+    },
+    {
+      "claim_id": "timestamps_valid",
+      "risk_statement": "Claim passed but capped: capped: falsifier named but not executed",
+      "owner": "",
+      "next_cheapest_evidence": "name a falsifier for this claim"
+    }
+  ],
+  "debt_items": [
+    {
+      "claim_id": "auth_behavior_preserved",
+      "source": "missing_falsifier",
+      "repayment_action": "Name the cheapest test that would disprove this claim"
+    },
+    {
+      "claim_id": "timestamps_valid",
+      "source": "missing_falsifier",
+      "repayment_action": "Name the cheapest test that would disprove this claim"
+    },
+    {
+      "claim_id": "high_receipt_count",
+      "source": "unowned_risk",
+      "repayment_action": "Assign owner and expiry_condition to this residual risk"
+    },
+    {
+      "claim_id": "timestamps_valid",
+      "source": "unowned_risk",
+      "repayment_action": "Assign owner and expiry_condition to this residual risk"
+    }
+  ]
+}

--- a/tests/assay/fixtures/proof_posture/canonical_specimen.txt
+++ b/tests/assay/fixtures/proof_posture/canonical_specimen.txt
@@ -1,0 +1,16 @@
+Proof Posture: INCOMPLETE
+
+Claims: 3 verified, 1 failed, 2 capped
+  - auth_behavior_preserved: capped: no named falsifier
+  - timestamps_valid: capped: falsifier named but not executed
+Residual risks: 3 (2 unowned)
+  - auth_behavior_preserved: Claim passed but capped: capped: no named falsifier [security-team]
+    next evidence: Run session expiry matrix
+  - high_receipt_count: Warning claim failed: expected >= 10 receipts, actual 3 receipts [unowned]
+  - timestamps_valid: Claim passed but capped: capped: falsifier named but not executed [unowned]
+    next evidence: name a falsifier for this claim
+Proof debt: 4 items owed
+  - auth_behavior_preserved (missing_falsifier): Name the cheapest test that would disprove this claim
+  - timestamps_valid (missing_falsifier): Name the cheapest test that would disprove this claim
+  - high_receipt_count (unowned_risk): Assign owner and expiry_condition to this residual risk
+  - timestamps_valid (unowned_risk): Assign owner and expiry_condition to this residual risk

--- a/tests/assay/test_falsifiers.py
+++ b/tests/assay/test_falsifiers.py
@@ -1,0 +1,770 @@
+"""Tests for falsifier, residual risk, and proof debt primitives.
+
+These three primitives form a constitutional triad:
+  - Falsifiers: what would cheaply disprove this claim?
+  - Residual risk: what remains unresolved but tolerated?
+  - Proof debt: what is still owed?
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from assay.claim_verifier import (
+    ALLOWED_SEVERITIES,
+    ClaimResult,
+    ClaimSetResult,
+    ClaimSpec,
+    FalsifierSpec,
+    TIER_CAP_TABLE,
+    verify_claims,
+)
+from assay.residual_risk import (
+    ResidualRiskItem,
+    ResidualRiskLedger,
+    build_residual_risk_from_claims,
+)
+from assay.proof_debt import (
+    ProofDebtItem,
+    ProofDebtLedger,
+    compute_proof_debt,
+    DEBT_SOURCES,
+)
+from assay.proof_posture import (
+    ProofPosture,
+    build_proof_posture,
+    compute_disposition,
+    render_proof_posture_text,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_RECEIPTS = [
+    {"receipt_id": "r1", "type": "model_call", "timestamp": "2026-03-14T00:00:00Z"},
+    {"receipt_id": "r2", "type": "model_call", "timestamp": "2026-03-14T00:00:01Z"},
+    {"receipt_id": "r3", "type": "tool_use", "timestamp": "2026-03-14T00:00:02Z"},
+]
+
+FALSIFIER_AUTH = FalsifierSpec(
+    description="Run login/logout/session-expiry matrix against changed endpoints",
+    test_command="pytest tests/auth/ -k session_matrix",
+    evaluation_surface="auth endpoints",
+)
+
+FALSIFIER_AUTH_EXECUTED = FalsifierSpec(
+    description="Run login/logout/session-expiry matrix against changed endpoints",
+    test_command="pytest tests/auth/ -k session_matrix",
+    evaluation_surface="auth endpoints",
+    executed=True,
+)
+
+CLAIM_WITH_FALSIFIER = ClaimSpec(
+    claim_id="has_model_calls",
+    description="At least one model call receipt exists",
+    check="receipt_type_present",
+    params={"receipt_type": "model_call"},
+    severity="critical",
+    falsifier=FALSIFIER_AUTH_EXECUTED,
+)
+
+CLAIM_WITHOUT_FALSIFIER = ClaimSpec(
+    claim_id="has_tool_use",
+    description="At least one tool_use receipt exists",
+    check="receipt_type_present",
+    params={"receipt_type": "tool_use"},
+    severity="critical",
+)
+
+CLAIM_WARNING = ClaimSpec(
+    claim_id="many_receipts",
+    description="At least 10 receipts",
+    check="receipt_count_ge",
+    params={"min_count": 10},
+    severity="warning",
+)
+
+
+# ===========================================================================
+# FALSIFIER TESTS
+# ===========================================================================
+
+class TestFalsifierSpec:
+    def test_to_dict_minimal(self):
+        f = FalsifierSpec(description="Check ECE on held-out data")
+        d = f.to_dict()
+        assert d == {"description": "Check ECE on held-out data"}
+        assert "test_command" not in d
+        assert "evaluation_surface" not in d
+
+    def test_to_dict_full(self):
+        d = FALSIFIER_AUTH.to_dict()
+        assert d["description"] == "Run login/logout/session-expiry matrix against changed endpoints"
+        assert d["test_command"] == "pytest tests/auth/ -k session_matrix"
+        assert d["evaluation_surface"] == "auth endpoints"
+
+
+class TestClaimSpecWithFalsifier:
+    def test_to_dict_includes_falsifier(self):
+        d = CLAIM_WITH_FALSIFIER.to_dict()
+        assert "falsifier" in d
+        assert d["falsifier"]["description"] == FALSIFIER_AUTH_EXECUTED.description
+
+    def test_to_dict_omits_falsifier_when_none(self):
+        d = CLAIM_WITHOUT_FALSIFIER.to_dict()
+        assert "falsifier" not in d
+
+
+class TestVerifyClaimsWithFalsifiers:
+    def test_no_enforcement_by_default(self):
+        result = verify_claims(SAMPLE_RECEIPTS, [CLAIM_WITHOUT_FALSIFIER])
+        assert result.passed is True
+        assert result.n_capped == 0
+        cr = result.results[0]
+        assert cr.falsifier_status == "not_required"
+        assert cr.tier_cap is None
+
+    def test_enforcement_caps_missing_falsifier(self):
+        result = verify_claims(
+            SAMPLE_RECEIPTS, [CLAIM_WITHOUT_FALSIFIER], require_falsifiers=True,
+        )
+        assert result.passed is True
+        assert result.n_capped == 1
+        cr = result.results[0]
+        assert cr.falsifier_status == "absent"
+        assert cr.tier_cap is not None
+        assert "falsifier" in cr.tier_cap.lower()
+
+    def test_enforcement_no_cap_when_falsifier_executed(self):
+        result = verify_claims(
+            SAMPLE_RECEIPTS, [CLAIM_WITH_FALSIFIER], require_falsifiers=True,
+        )
+        assert result.passed is True
+        assert result.n_capped == 0
+        cr = result.results[0]
+        assert cr.falsifier_status == "executed_passed"
+        assert cr.tier_cap is None
+
+    def test_warning_severity_never_capped(self):
+        result = verify_claims(
+            SAMPLE_RECEIPTS, [CLAIM_WARNING], require_falsifiers=True,
+        )
+        assert result.passed is True
+        cr = result.results[0]
+        assert cr.falsifier_status == "not_required"
+        assert cr.tier_cap is None
+
+    def test_falsifier_summary_counts(self):
+        result = verify_claims(
+            SAMPLE_RECEIPTS,
+            [CLAIM_WITH_FALSIFIER, CLAIM_WITHOUT_FALSIFIER, CLAIM_WARNING],
+            require_falsifiers=True,
+        )
+        s = result.falsifier_summary
+        assert s.get("executed_passed", 0) == 1
+        assert s.get("absent", 0) == 1
+        assert s.get("not_required", 0) == 1
+
+    def test_cap_does_not_cause_failure(self):
+        result = verify_claims(
+            SAMPLE_RECEIPTS, [CLAIM_WITHOUT_FALSIFIER], require_falsifiers=True,
+        )
+        assert result.passed is True
+        assert result.results[0].passed is True
+        assert result.results[0].tier_cap is not None
+
+    def test_to_dict_includes_cap(self):
+        result = verify_claims(
+            SAMPLE_RECEIPTS, [CLAIM_WITHOUT_FALSIFIER], require_falsifiers=True,
+        )
+        d = result.results[0].to_dict()
+        assert "tier_cap" in d
+        assert "falsifier_status" in d
+        assert d["falsifier_status"] == "absent"
+
+    def test_to_dict_omits_cap_when_none(self):
+        result = verify_claims(SAMPLE_RECEIPTS, [CLAIM_WITH_FALSIFIER], require_falsifiers=True)
+        d = result.results[0].to_dict()
+        assert "tier_cap" not in d
+
+    def test_claim_set_to_dict_includes_cap_summary(self):
+        result = verify_claims(
+            SAMPLE_RECEIPTS, [CLAIM_WITHOUT_FALSIFIER], require_falsifiers=True,
+        )
+        d = result.to_dict()
+        assert d["n_capped"] == 1
+        assert "falsifier_summary" in d
+
+    def test_claim_set_to_dict_omits_cap_when_zero(self):
+        result = verify_claims(SAMPLE_RECEIPTS, [CLAIM_WITH_FALSIFIER])
+        d = result.to_dict()
+        assert "n_capped" not in d
+        assert "falsifier_summary" not in d
+
+    def test_backward_compat_no_falsifiers(self):
+        claim = ClaimSpec(
+            claim_id="basic", description="Basic check",
+            check="receipt_count_ge", params={"min_count": 1},
+        )
+        result = verify_claims(SAMPLE_RECEIPTS, [claim])
+        assert result.passed is True
+        assert result.n_capped == 0
+        d = result.to_dict()
+        assert "passed" in d
+        assert "n_claims" in d
+
+
+# ===========================================================================
+# RESIDUAL RISK TESTS
+# ===========================================================================
+
+class TestResidualRiskItem:
+    def test_to_dict(self):
+        item = ResidualRiskItem(
+            claim_id="auth_preserves_behavior",
+            risk_statement="Auth behavior unverified under session expiry",
+            why_tolerated="No auth changes in this PR",
+            owner="security-team",
+            expiry_condition="Next auth-touching PR",
+            next_cheapest_evidence="Run session matrix test",
+        )
+        d = item.to_dict()
+        assert d["claim_id"] == "auth_preserves_behavior"
+        assert d["blocking_on_merge"] is False
+        assert d["next_cheapest_evidence"] == "Run session matrix test"
+
+
+class TestResidualRiskLedger:
+    def test_empty_ledger(self):
+        ledger = ResidualRiskLedger()
+        assert ledger.n_items == 0
+        assert ledger.n_blocking == 0
+        assert ledger.n_unowned == 0
+
+    def test_add_items(self):
+        ledger = ResidualRiskLedger()
+        ledger.add(ResidualRiskItem(
+            claim_id="c1", risk_statement="risk", why_tolerated="ok",
+            owner="team", expiry_condition="never", next_cheapest_evidence="test",
+        ))
+        ledger.add(ResidualRiskItem(
+            claim_id="c2", risk_statement="risk", why_tolerated="ok",
+            owner="", expiry_condition="", next_cheapest_evidence="test",
+            blocking_on_merge=True,
+        ))
+        assert ledger.n_items == 2
+        assert ledger.n_blocking == 1
+        assert ledger.n_unowned == 1
+
+    def test_fingerprint_deterministic(self):
+        ledger1 = ResidualRiskLedger()
+        ledger2 = ResidualRiskLedger()
+        item = ResidualRiskItem(
+            claim_id="c1", risk_statement="r", why_tolerated="ok",
+            owner="o", expiry_condition="e", next_cheapest_evidence="n",
+        )
+        ledger1.add(item)
+        ledger2.add(item)
+        assert ledger1.fingerprint() == ledger2.fingerprint()
+
+    def test_to_dict(self):
+        ledger = ResidualRiskLedger()
+        ledger.add(ResidualRiskItem(
+            claim_id="c1", risk_statement="r", why_tolerated="ok",
+            owner="o", expiry_condition="e", next_cheapest_evidence="n",
+        ))
+        d = ledger.to_dict()
+        assert d["n_items"] == 1
+        assert d["n_blocking"] == 0
+        assert d["n_unowned"] == 0
+        assert len(d["items"]) == 1
+
+
+class TestBuildResidualRiskFromClaims:
+    def test_capped_claim_creates_risk(self):
+        claims = [
+            {"claim_id": "c1", "passed": True, "tier_cap": "capped: no named falsifier",
+             "severity": "critical"},
+        ]
+        ledger = build_residual_risk_from_claims(claims)
+        assert ledger.n_items == 1
+        assert "capped" in ledger.items[0].risk_statement.lower()
+
+    def test_warning_failure_creates_risk(self):
+        claims = [
+            {"claim_id": "c1", "passed": False, "severity": "warning",
+             "expected": ">= 10", "actual": "3"},
+        ]
+        ledger = build_residual_risk_from_claims(claims)
+        assert ledger.n_items == 1
+        assert "warning" in ledger.items[0].risk_statement.lower()
+
+    def test_critical_failure_not_residual(self):
+        claims = [{"claim_id": "c1", "passed": False, "severity": "critical"}]
+        ledger = build_residual_risk_from_claims(claims)
+        assert ledger.n_items == 0
+
+    def test_clean_pass_no_risk(self):
+        claims = [{"claim_id": "c1", "passed": True, "severity": "critical"}]
+        ledger = build_residual_risk_from_claims(claims)
+        assert ledger.n_items == 0
+
+    def test_annotations_override_defaults(self):
+        claims = [
+            {"claim_id": "c1", "passed": True, "tier_cap": "capped", "severity": "critical"},
+        ]
+        annotations = {
+            "c1": {
+                "why_tolerated": "PR has no auth changes",
+                "owner": "security-team",
+                "expiry_condition": "Next auth PR",
+                "next_cheapest_evidence": "Run session matrix",
+            }
+        }
+        ledger = build_residual_risk_from_claims(claims, risk_annotations=annotations)
+        item = ledger.items[0]
+        assert item.owner == "security-team"
+        assert item.next_cheapest_evidence == "Run session matrix"
+
+
+# ===========================================================================
+# PROOF DEBT TESTS
+# ===========================================================================
+
+class TestProofDebtItem:
+    def test_valid_sources(self):
+        for source in DEBT_SOURCES:
+            item = ProofDebtItem(claim_id="c1", source=source, description="d", repayment_action="a")
+            assert item.source == source
+
+    def test_invalid_source_raises(self):
+        with pytest.raises(ValueError, match="Invalid debt source"):
+            ProofDebtItem(claim_id="c1", source="vibes", description="d", repayment_action="a")
+
+    def test_to_dict(self):
+        item = ProofDebtItem(
+            claim_id="c1", source="missing_falsifier",
+            description="No kill test", repayment_action="Name one", severity="moderate",
+        )
+        d = item.to_dict()
+        assert d["source"] == "missing_falsifier"
+        assert d["severity"] == "moderate"
+
+
+class TestProofDebtLedger:
+    def test_empty(self):
+        ledger = ProofDebtLedger()
+        assert ledger.n_items == 0
+        assert ledger.by_source == {}
+        assert ledger.by_severity == {}
+
+    def test_by_source(self):
+        ledger = ProofDebtLedger()
+        ledger.add(ProofDebtItem("c1", "missing_evidence", "d", "a"))
+        ledger.add(ProofDebtItem("c2", "missing_falsifier", "d", "a"))
+        ledger.add(ProofDebtItem("c3", "missing_falsifier", "d", "a"))
+        assert ledger.by_source == {"missing_evidence": 1, "missing_falsifier": 2}
+
+    def test_to_dict(self):
+        ledger = ProofDebtLedger()
+        ledger.add(ProofDebtItem("c1", "missing_evidence", "d", "a", "severe"))
+        d = ledger.to_dict()
+        assert d["n_items"] == 1
+        assert d["by_source"] == {"missing_evidence": 1}
+        assert d["by_severity"] == {"severe": 1}
+
+
+class TestComputeProofDebt:
+    def test_critical_failure_creates_missing_evidence_debt(self):
+        claims = [{"claim_id": "c1", "passed": False, "severity": "critical", "expected": ">= 5 receipts"}]
+        ledger = compute_proof_debt(claims)
+        assert ledger.n_items == 1
+        assert ledger.items[0].source == "missing_evidence"
+        assert ledger.items[0].severity == "severe"
+
+    def test_warning_failure_no_debt(self):
+        claims = [{"claim_id": "c1", "passed": False, "severity": "warning"}]
+        ledger = compute_proof_debt(claims)
+        assert ledger.n_items == 0
+
+    def test_absent_falsifier_creates_debt(self):
+        claims = [
+            {"claim_id": "c1", "passed": True, "severity": "critical",
+             "falsifier_status": "absent", "tier_cap": "capped: no named falsifier"},
+        ]
+        ledger = compute_proof_debt(claims)
+        assert ledger.n_items == 1
+        assert ledger.items[0].source == "missing_falsifier"
+        assert "disprove" in ledger.items[0].repayment_action.lower()
+
+    def test_named_falsifier_no_debt(self):
+        claims = [{"claim_id": "c1", "passed": True, "severity": "critical", "falsifier_status": "named"}]
+        ledger = compute_proof_debt(claims)
+        assert ledger.n_items == 0
+
+    def test_unowned_residual_risk_creates_debt(self):
+        risks = [{"claim_id": "c1", "owner": "", "expiry_condition": ""}]
+        ledger = compute_proof_debt([], residual_risk_items=risks)
+        assert ledger.n_items == 1
+        assert ledger.items[0].source == "unowned_risk"
+        assert ledger.items[0].severity == "severe"
+
+    def test_owned_risk_without_expiry_creates_moderate_debt(self):
+        risks = [{"claim_id": "c1", "owner": "team", "expiry_condition": ""}]
+        ledger = compute_proof_debt([], residual_risk_items=risks)
+        assert ledger.n_items == 1
+        assert ledger.items[0].severity == "moderate"
+
+    def test_fully_owned_risk_no_debt(self):
+        risks = [{"claim_id": "c1", "owner": "team", "expiry_condition": "next sprint"}]
+        ledger = compute_proof_debt([], residual_risk_items=risks)
+        assert ledger.n_items == 0
+
+    def test_full_triad_integration(self):
+        result = verify_claims(
+            SAMPLE_RECEIPTS,
+            [CLAIM_WITH_FALSIFIER, CLAIM_WITHOUT_FALSIFIER, CLAIM_WARNING],
+            require_falsifiers=True,
+        )
+        claim_dicts = [r.to_dict() for r in result.results]
+        risk_ledger = build_residual_risk_from_claims(claim_dicts)
+        debt_ledger = compute_proof_debt(
+            claim_dicts, residual_risk_items=[r.to_dict() for r in risk_ledger.items],
+        )
+        assert result.passed is True
+        assert result.n_capped == 1
+        assert risk_ledger.n_items == 2
+        assert debt_ledger.n_items >= 1
+        sources = {item.source for item in debt_ledger.items}
+        assert "missing_falsifier" in sources
+
+
+# ===========================================================================
+# TIER CAP DECISION TABLE TESTS
+# ===========================================================================
+
+class TestTierCapDecisionTable:
+    def test_warning_never_capped(self):
+        for (sev, fs), (cap, _) in TIER_CAP_TABLE.items():
+            if sev == "warning":
+                assert cap is False, f"warning/{fs} should not be capped"
+
+    def test_critical_absent_capped(self):
+        cap, reason = TIER_CAP_TABLE[("critical", "absent")]
+        assert cap is True
+        assert "falsifier" in reason.lower()
+
+    def test_critical_named_capped(self):
+        cap, reason = TIER_CAP_TABLE[("critical", "named")]
+        assert cap is True
+        assert "not executed" in reason.lower()
+
+    def test_critical_executed_passed_uncapped(self):
+        cap, reason = TIER_CAP_TABLE[("critical", "executed_passed")]
+        assert cap is False
+        assert reason is None
+
+    def test_critical_executed_failed_capped(self):
+        cap, reason = TIER_CAP_TABLE[("critical", "executed_failed")]
+        assert cap is True
+        assert "disproved" in reason.lower()
+
+    def test_critical_not_required_uncapped(self):
+        cap, reason = TIER_CAP_TABLE[("critical", "not_required")]
+        assert cap is False
+
+    def test_table_covers_all_status_severity_pairs(self):
+        from assay.claim_verifier import FALSIFIER_STATUSES
+        for sev in ALLOWED_SEVERITIES:
+            for fs in FALSIFIER_STATUSES:
+                assert (sev, fs) in TIER_CAP_TABLE, f"Missing: ({sev}, {fs})"
+
+
+class TestFalsifierExecution:
+    def test_executed_passed_uncapped(self):
+        claim = ClaimSpec(
+            claim_id="auth_safe", description="Auth behavior preserved",
+            check="receipt_type_present", params={"receipt_type": "model_call"},
+            severity="critical",
+            falsifier=FalsifierSpec(description="Run session matrix", executed=True),
+        )
+        result = verify_claims(SAMPLE_RECEIPTS, [claim], require_falsifiers=True)
+        cr = result.results[0]
+        assert cr.falsifier_status == "executed_passed"
+        assert cr.tier_cap is None
+        assert result.n_capped == 0
+
+    def test_executed_failed_capped(self):
+        claim = ClaimSpec(
+            claim_id="auth_safe", description="Auth behavior preserved",
+            check="receipt_type_present", params={"receipt_type": "model_call"},
+            severity="critical",
+            falsifier=FalsifierSpec(description="Run session matrix", executed=False),
+        )
+        result = verify_claims(SAMPLE_RECEIPTS, [claim], require_falsifiers=True)
+        cr = result.results[0]
+        assert cr.falsifier_status == "executed_failed"
+        assert cr.tier_cap is not None
+        assert "disproved" in cr.tier_cap.lower()
+
+    def test_named_not_executed_capped(self):
+        claim = ClaimSpec(
+            claim_id="auth_safe", description="Auth behavior preserved",
+            check="receipt_type_present", params={"receipt_type": "model_call"},
+            severity="critical",
+            falsifier=FalsifierSpec(description="Run session matrix"),
+        )
+        result = verify_claims(SAMPLE_RECEIPTS, [claim], require_falsifiers=True)
+        cr = result.results[0]
+        assert cr.falsifier_status == "named"
+        assert cr.tier_cap is not None
+        assert "not executed" in cr.tier_cap.lower()
+
+    def test_falsifier_recorded_even_without_enforcement(self):
+        claim = ClaimSpec(
+            claim_id="c1", description="test",
+            check="receipt_type_present", params={"receipt_type": "model_call"},
+            severity="critical",
+            falsifier=FalsifierSpec(description="test", executed=True),
+        )
+        result = verify_claims(SAMPLE_RECEIPTS, [claim], require_falsifiers=False)
+        cr = result.results[0]
+        assert cr.falsifier_status == "executed_passed"
+        assert cr.tier_cap is None
+
+
+# ===========================================================================
+# RESIDUAL RISK HARDENING TESTS
+# ===========================================================================
+
+class TestResidualRiskConstitutional:
+    def test_owner_missing_is_unowned(self):
+        ledger = ResidualRiskLedger()
+        ledger.add(ResidualRiskItem(
+            claim_id="c1", risk_statement="r", why_tolerated="ok",
+            owner="", expiry_condition="e", next_cheapest_evidence="n",
+        ))
+        assert ledger.n_unowned == 1
+
+    def test_expiry_missing(self):
+        item = ResidualRiskItem(
+            claim_id="c1", risk_statement="r", why_tolerated="ok",
+            owner="team", expiry_condition="", next_cheapest_evidence="n",
+        )
+        d = item.to_dict()
+        assert d["expiry_condition"] == ""
+
+    def test_next_cheapest_evidence_missing(self):
+        item = ResidualRiskItem(
+            claim_id="c1", risk_statement="r", why_tolerated="ok",
+            owner="team", expiry_condition="e", next_cheapest_evidence="",
+        )
+        d = item.to_dict()
+        assert d["next_cheapest_evidence"] == ""
+
+    def test_blocking_risk_counted(self):
+        ledger = ResidualRiskLedger()
+        ledger.add(ResidualRiskItem(
+            claim_id="c1", risk_statement="r", why_tolerated="ok",
+            owner="team", expiry_condition="e", next_cheapest_evidence="n",
+            blocking_on_merge=True,
+        ))
+        ledger.add(ResidualRiskItem(
+            claim_id="c2", risk_statement="r", why_tolerated="ok",
+            owner="team", expiry_condition="e", next_cheapest_evidence="n",
+            blocking_on_merge=False,
+        ))
+        assert ledger.n_blocking == 1
+
+    def test_critical_failure_never_becomes_residual_risk(self):
+        claims = [{"claim_id": "c1", "passed": False, "severity": "critical", "expected": "thing", "actual": "nope"}]
+        ledger = build_residual_risk_from_claims(claims)
+        assert ledger.n_items == 0
+
+
+# ===========================================================================
+# PROOF POSTURE TESTS
+# ===========================================================================
+
+class TestComputeDisposition:
+    def test_verified(self):
+        assert compute_disposition(n_failed=0, n_capped=0, n_risks_blocking=0, n_debt_severe=0) == "verified"
+
+    def test_capped(self):
+        assert compute_disposition(n_failed=0, n_capped=1, n_risks_blocking=0, n_debt_severe=0) == "supported_but_capped"
+
+    def test_incomplete_from_failure(self):
+        assert compute_disposition(n_failed=1, n_capped=0, n_risks_blocking=0, n_debt_severe=0) == "incomplete"
+
+    def test_incomplete_from_severe_debt(self):
+        assert compute_disposition(n_failed=0, n_capped=0, n_risks_blocking=0, n_debt_severe=2) == "incomplete"
+
+    def test_blocked(self):
+        assert compute_disposition(n_failed=0, n_capped=0, n_risks_blocking=1, n_debt_severe=0) == "blocked"
+
+    def test_blocked_overrides_incomplete(self):
+        assert compute_disposition(n_failed=1, n_capped=1, n_risks_blocking=1, n_debt_severe=1) == "blocked"
+
+
+class TestBuildProofPosture:
+    def test_empty_posture(self):
+        posture = build_proof_posture()
+        assert posture.disposition == "verified"
+        assert posture.n_claims == 0
+
+    def test_from_dicts(self):
+        posture = build_proof_posture(
+            claim_set_result={"n_claims": 3, "n_passed": 2, "n_failed": 1, "results": []},
+            residual_risk_ledger={"n_items": 1, "n_blocking": 0, "n_unowned": 1, "items": []},
+            proof_debt_ledger={"n_items": 2, "by_source": {"missing_falsifier": 2}, "by_severity": {"moderate": 2}, "items": []},
+        )
+        assert posture.disposition == "incomplete"
+        assert posture.n_claims == 3
+
+    def test_to_dict_structure(self):
+        posture = build_proof_posture()
+        d = posture.to_dict()
+        assert "disposition" in d
+        assert "claims" in d
+        assert "residual_risk" in d
+        assert "proof_debt" in d
+
+
+class TestRenderProofPostureText:
+    def test_verified_output(self):
+        posture = ProofPosture(n_claims=3, n_passed=3, disposition="verified")
+        text = render_proof_posture_text(posture)
+        assert "VERIFIED" in text
+        assert "3 verified" in text
+
+    def test_capped_output(self):
+        posture = ProofPosture(
+            n_claims=2, n_passed=2, n_capped=1,
+            disposition="supported_but_capped",
+            capped_claims=[{"claim_id": "auth", "tier_cap": "capped: no named falsifier", "falsifier_status": "absent"}],
+        )
+        text = render_proof_posture_text(posture)
+        assert "SUPPORTED (capped)" in text
+        assert "auth" in text
+        assert "falsifier" in text
+
+    def test_debt_output(self):
+        posture = ProofPosture(
+            n_claims=1, n_passed=1, n_debt_items=1,
+            disposition="verified",
+            debt_items=[{"claim_id": "c1", "source": "missing_falsifier", "repayment_action": "Name a kill test"}],
+        )
+        text = render_proof_posture_text(posture)
+        assert "1 items owed" in text
+        assert "kill test" in text
+
+
+# ===========================================================================
+# CANONICAL SPECIMEN
+# ===========================================================================
+
+class TestCanonicalSpecimen:
+    def test_canonical_triad_specimen(self):
+        claims = [
+            ClaimSpec('model_calls_present', 'Model call receipts exist', 'receipt_type_present',
+                      {'receipt_type': 'model_call'}, 'critical',
+                      FalsifierSpec('Remove all model_call receipts and verify failure', executed=True)),
+            ClaimSpec('auth_behavior_preserved', 'Auth behavior is unchanged', 'receipt_type_present',
+                      {'receipt_type': 'tool_use'}, 'critical'),
+            ClaimSpec('high_receipt_count', 'At least 10 receipts for statistical confidence',
+                      'receipt_count_ge', {'min_count': 10}, 'warning'),
+            ClaimSpec('timestamps_valid', 'Timestamps are monotonically increasing',
+                      'timestamps_monotonic', severity='critical',
+                      falsifier=FalsifierSpec('Insert out-of-order timestamp')),
+        ]
+        result = verify_claims(SAMPLE_RECEIPTS, claims, require_falsifiers=True)
+        assert result.passed is True
+        assert result.n_capped == 2
+
+        by_id = {r.claim_id: r for r in result.results}
+        assert by_id["model_calls_present"].falsifier_status == "executed_passed"
+        assert by_id["model_calls_present"].tier_cap is None
+        assert by_id["auth_behavior_preserved"].falsifier_status == "absent"
+        assert by_id["auth_behavior_preserved"].tier_cap is not None
+        assert by_id["high_receipt_count"].falsifier_status == "not_required"
+        assert by_id["timestamps_valid"].falsifier_status == "named"
+        assert by_id["timestamps_valid"].tier_cap is not None
+
+        claim_dicts = [r.to_dict() for r in result.results]
+        risk_annotations = {
+            'auth_behavior_preserved': {
+                'why_tolerated': 'No auth code changed in this PR',
+                'owner': 'security-team',
+                'expiry_condition': 'Next PR touching auth/',
+                'next_cheapest_evidence': 'Run session expiry matrix',
+            },
+        }
+        risk_ledger = build_residual_risk_from_claims(claim_dicts, risk_annotations=risk_annotations)
+        assert risk_ledger.n_items == 3
+
+        debt_ledger = compute_proof_debt(claim_dicts, residual_risk_items=[r.to_dict() for r in risk_ledger.items])
+        assert debt_ledger.n_items >= 1
+        sources = {item.source for item in debt_ledger.items}
+        assert "missing_falsifier" in sources
+
+        posture = build_proof_posture(
+            claim_set_result=result.to_dict(),
+            residual_risk_ledger=risk_ledger.to_dict(),
+            proof_debt_ledger=debt_ledger.to_dict(),
+        )
+        assert posture.disposition == "incomplete"
+        assert posture.n_capped == 2
+        assert posture.n_residual_risks == 3
+        assert posture.n_debt_items >= 1
+
+        text = render_proof_posture_text(posture)
+        assert "INCOMPLETE" in text
+        assert "auth_behavior_preserved" in text
+        assert len(text.splitlines()) > 3
+
+    def test_golden_fixture_regression(self):
+        fixture_path = Path(__file__).parent / "fixtures" / "proof_posture" / "canonical_specimen.json"
+        if not fixture_path.exists():
+            pytest.skip("Golden fixture not found")
+        expected = json.loads(fixture_path.read_text())
+
+        claims = [
+            ClaimSpec('model_calls_present', 'Model call receipts exist', 'receipt_type_present',
+                      {'receipt_type': 'model_call'}, 'critical',
+                      FalsifierSpec('Remove all model_call receipts and verify failure', executed=True)),
+            ClaimSpec('auth_behavior_preserved', 'Auth behavior is unchanged', 'receipt_type_present',
+                      {'receipt_type': 'tool_use'}, 'critical'),
+            ClaimSpec('high_receipt_count', 'At least 10 receipts for statistical confidence',
+                      'receipt_count_ge', {'min_count': 10}, 'warning'),
+            ClaimSpec('timestamps_valid', 'Timestamps are monotonically increasing',
+                      'timestamps_monotonic', severity='critical',
+                      falsifier=FalsifierSpec('Insert out-of-order timestamp')),
+        ]
+        result = verify_claims(SAMPLE_RECEIPTS, claims, require_falsifiers=True)
+        claim_dicts = [r.to_dict() for r in result.results]
+        risk_annotations = {
+            'auth_behavior_preserved': {
+                'why_tolerated': 'No auth code changed in this PR',
+                'owner': 'security-team',
+                'expiry_condition': 'Next PR touching auth/',
+                'next_cheapest_evidence': 'Run session expiry matrix',
+            },
+        }
+        risk_ledger = build_residual_risk_from_claims(claim_dicts, risk_annotations=risk_annotations)
+        debt_ledger = compute_proof_debt(claim_dicts, residual_risk_items=[r.to_dict() for r in risk_ledger.items])
+        posture = build_proof_posture(
+            claim_set_result=result.to_dict(),
+            residual_risk_ledger=risk_ledger.to_dict(),
+            proof_debt_ledger=debt_ledger.to_dict(),
+        )
+        actual = posture.to_dict()
+        assert actual == expected, (
+            f"Golden fixture mismatch.\n"
+            f"Expected disposition: {expected['disposition']}\n"
+            f"Actual disposition: {actual['disposition']}\n"
+            f"Diff in claims: {expected['claims']} vs {actual['claims']}"
+        )


### PR DESCRIPTION
## Summary

- Adds proof-posture grammar: four epistemic states (proven, supported-but-capped, tolerated, owed)
- New modules: `claim_verifier.py` (FalsifierSpec, TIER_CAP_TABLE), `residual_risk.py`, `proof_debt.py`, `proof_posture.py`
- CLI: `assay posture <pack_dir> [--require-falsifiers] [--json]`
- Doctrine: `docs/PROOF_POSTURE.md`
- 69 new tests, 556 total passing, 0 regressions

## Decomposition note

Cherry-picked from `feat/proof-posture-restore` (commit b288a97) and rebased onto current main. The original branch also contained golden-path UX changes (README rewrite, CLI authority demotion, docs/GOLDEN_PATH.md) which had 16 conflict regions after 41 commits of main drift. Those are intentionally separated into a follow-up PR to avoid making product-copy and command-discoverability decisions inside conflict resolution.

**This PR**: proof-bearing capability (posture primitives + tests + doctrine)
**Follow-up PR**: intention-heavy UX (README, golden path, command visibility policy)

## Conflict resolution

Single conflict in `src/assay/commands.py`: posture command added alongside existing `replay-judge`; `replay-judge` retains `hidden=True` from main. No other commands modified.

## Test plan

- [x] 69 posture tests pass locally
- [x] 556 total tests pass (1 pre-existing failure: hardcoded path in `test_epistemic_kernel.py`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)