### PR TITLE
feat(trust): decision receipt trust evaluation + verification

### DIFF
--- a/src/assay/decision_receipt_trust.py
+++ b/src/assay/decision_receipt_trust.py
@@ -1,0 +1,197 @@
+"""Shared trust evaluator for Decision Receipts.
+
+One source of truth for trust-state classification. The renderer,
+CLI, API, and verification pipeline all consume this — none of them
+define trust semantics independently.
+
+Evidence-to-state mapping:
+
+    State          Evidence required
+    ─────────────  ──────────────────────────────────────────────────
+    VERIFIED       signature present + signer key available + verification passed
+    UNSIGNED       receipt valid, content_hash present, no signature
+    UNVERIFIABLE   signature present but verification key unavailable
+    INVALID        schema/invariant validation failed, signature mismatch,
+                   or content_hash mismatch
+    MISSING        no receipt present
+
+Classification truth table:
+
+    Condition                                     → State
+    ───────────────────────────────────────────────────────────
+    receipt is None                               → MISSING
+    signature absent, structurally sound          → UNSIGNED
+    signature present, key/verifier unavailable   → UNVERIFIABLE
+    signature present, verification fails         → INVALID
+    signature present, verification passes        → VERIFIED
+    schema/invariant validation fails (unsigned)  → INVALID
+    signed + key missing + also malformed         → UNVERIFIABLE (policy)
+
+Classification priority (first match wins):
+    1. MISSING      — receipt is None
+    2. UNVERIFIABLE — signature present, key unavailable (checked before
+                      validation because schema I-7 would flag this as invalid)
+    3. INVALID      — schema/invariant validation fails, or signature mismatch
+    4. VERIFIED     — signature present, key available, verification passed
+    5. UNSIGNED     — no signature, structurally sound
+
+Policy note: UNVERIFIABLE takes priority over INVALID when signature is
+present but key material is missing. This is a deliberate choice: the
+dominant signal is "we cannot discharge the proof obligation," not
+"the receipt is structurally defective." The structural defect may be
+an artifact of incomplete transmission.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional
+
+
+class DecisionReceiptTrustState(str, Enum):
+    """Five-state trust model for Decision Receipts.
+
+    These are formal constitutional states, not UI labels.
+    """
+    VERIFIED = "verified"
+    UNSIGNED = "unsigned"
+    UNVERIFIABLE = "unverifiable"
+    INVALID = "invalid"
+    MISSING = "missing"
+
+
+@dataclass(frozen=True)
+class TrustClassification:
+    """Result of trust classification — state + supporting detail."""
+    state: DecisionReceiptTrustState
+    errors: tuple[str, ...] = ()
+    reason: str = ""
+
+    @property
+    def is_trustworthy(self) -> bool:
+        """Only VERIFIED receipts are fully trustworthy."""
+        return self.state == DecisionReceiptTrustState.VERIFIED
+
+    @property
+    def is_structurally_sound(self) -> bool:
+        """VERIFIED and UNSIGNED receipts are structurally sound."""
+        return self.state in (
+            DecisionReceiptTrustState.VERIFIED,
+            DecisionReceiptTrustState.UNSIGNED,
+        )
+
+
+# Sentinel for "no receipt"
+MISSING = TrustClassification(
+    state=DecisionReceiptTrustState.MISSING,
+    reason="No Decision Receipt present",
+)
+
+
+def classify_trust(
+    receipt: Optional[Dict[str, Any]],
+    *,
+    validator: Optional[Callable[[Dict[str, Any]], Any]] = None,
+    verify_signature: Optional[Callable[[Dict[str, Any]], bool]] = None,
+) -> TrustClassification:
+    """Classify a Decision Receipt into one of 5 trust states.
+
+    Args:
+        receipt: The receipt dict, or None if absent.
+        validator: Optional schema+invariant validator. Must return an
+            object with `.valid: bool` and `.errors: list` attributes.
+            If None, schema validation is skipped (receipt assumed valid).
+        verify_signature: Optional signature verification function.
+            Returns True if signature is valid, False if invalid.
+            If None and signature is present, state is UNVERIFIABLE.
+
+    Returns:
+        TrustClassification with state + supporting detail.
+    """
+    # 1. MISSING — no receipt
+    if receipt is None:
+        return MISSING
+
+    raw_sig = receipt.get("signature")
+    pubkey = receipt.get("signer_pubkey_sha256")
+
+    # Normalize: empty/whitespace-only signature is not a meaningful proof claim.
+    # It's malformed proof material → will be caught as INVALID below.
+    sig = raw_sig if isinstance(raw_sig, str) and raw_sig.strip() else None
+    sig_field_present_but_empty = raw_sig is not None and sig is None
+
+    if sig_field_present_but_empty:
+        return TrustClassification(
+            state=DecisionReceiptTrustState.INVALID,
+            errors=("Signature field is present but empty or whitespace-only",),
+            reason="Malformed proof material",
+        )
+
+    # 2. UNVERIFIABLE — check before validation because schema invariant I-7
+    #    flags "signature present, pubkey null" as invalid. But that is exactly
+    #    the condition UNVERIFIABLE exists for: the receipt may be fine,
+    #    we just can't prove it with available key material.
+    if sig is not None and (verify_signature is None or pubkey is None):
+        return TrustClassification(
+            state=DecisionReceiptTrustState.UNVERIFIABLE,
+            reason="Signature present, verification key unavailable",
+        )
+
+    # 3. INVALID — schema/invariant validation fails
+    if validator is not None:
+        result = validator(receipt)
+        if not result.valid:
+            error_msgs = tuple(
+                f"{e.rule}: {e.message}"
+                for e in getattr(result, "errors", [])
+            )
+            return TrustClassification(
+                state=DecisionReceiptTrustState.INVALID,
+                errors=error_msgs,
+                reason="Schema or invariant validation failed",
+            )
+
+    # 4. Signature present with key and verifier — attempt verification
+    #    (UNVERIFIABLE cases already handled above)
+    if sig is not None:
+        # At this point we know verify_signature is not None and pubkey is not None
+        try:
+            sig_valid = verify_signature(receipt)
+        except Exception as exc:
+            return TrustClassification(
+                state=DecisionReceiptTrustState.INVALID,
+                errors=(f"Signature verification error: {exc}",),
+                reason="Signature verification raised an exception",
+            )
+
+        if sig_valid:
+            return TrustClassification(
+                state=DecisionReceiptTrustState.VERIFIED,
+                reason="Signature verified successfully",
+            )
+        else:
+            return TrustClassification(
+                state=DecisionReceiptTrustState.INVALID,
+                errors=("Signature verification failed: content may have been tampered",),
+                reason="Signature mismatch",
+            )
+
+    # 5. UNSIGNED — no signature, structurally sound
+    content_hash = receipt.get("content_hash")
+    reason = (
+        "Receipt is structurally sound but unsigned"
+        if content_hash
+        else "Receipt is unsigned and has no content hash"
+    )
+    return TrustClassification(
+        state=DecisionReceiptTrustState.UNSIGNED,
+        reason=reason,
+    )
+
+
+__all__ = [
+    "DecisionReceiptTrustState",
+    "TrustClassification",
+    "classify_trust",
+    "MISSING",
+]

--- a/src/assay/decision_receipt_verify.py
+++ b/src/assay/decision_receipt_verify.py
@@ -1,0 +1,117 @@
+"""Decision Receipt signature verification for Assay consumers.
+
+Standalone verification — does NOT import ccio. Uses the same canonical
+byte extraction algorithm as the CCIO signing module to verify Ed25519
+signatures on Decision Receipt v0.1.0 dicts.
+
+Canonical byte contract (from decision_receipt_canonicalization.md):
+- Exclude: content_hash, signature, signer_pubkey_sha256
+- Strip None-valued fields
+- Dedupe + sort verdict_reason_codes
+- Sort evidence_refs by full canonical JSON
+- json.dumps(sort_keys=True, separators=(",",":"))
+"""
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any, Dict, Optional
+
+# Signing-excluded fields (must match CCIO's build.py contract)
+_SIGNING_EXCLUDED = frozenset({"content_hash", "signature", "signer_pubkey_sha256"})
+
+
+def _canonical_bytes(receipt: Dict[str, Any]) -> bytes:
+    """Extract canonical byte sequence for verification."""
+    hashable = {
+        k: v for k, v in receipt.items()
+        if k not in _SIGNING_EXCLUDED and v is not None
+    }
+
+    if "verdict_reason_codes" in hashable and isinstance(hashable["verdict_reason_codes"], list):
+        hashable["verdict_reason_codes"] = sorted(set(hashable["verdict_reason_codes"]))
+
+    if "evidence_refs" in hashable and isinstance(hashable["evidence_refs"], list):
+        hashable["evidence_refs"] = sorted(
+            hashable["evidence_refs"],
+            key=lambda r: json.dumps(r, sort_keys=True, separators=(",", ":")),
+        )
+
+    return json.dumps(
+        hashable, sort_keys=True, separators=(",", ":"), default=str,
+    ).encode("utf-8")
+
+
+class VerificationKeyRequired(TypeError):
+    """Raised when verification is attempted without providing a public key.
+
+    Decision Receipt verification requires an Ed25519 public key.
+    Use make_verifier_with_key(pubkey_bytes) to create a verifier,
+    or pass verify_signature= to classify_trust() directly.
+    """
+
+
+def verify_decision_receipt(receipt: Dict[str, Any]) -> bool:
+    """Verify an Ed25519 signature on a Decision Receipt.
+
+    Raises VerificationKeyRequired because verification cannot proceed
+    without a public key. The SHA-256 fingerprint embedded in the receipt
+    identifies which key was used, but the actual key bytes must be
+    provided out-of-band.
+
+    Use make_verifier_with_key(pubkey_bytes) to create a working verifier.
+
+    Raises:
+        VerificationKeyRequired: Always. This function cannot verify
+            without key material.
+    """
+    raise VerificationKeyRequired(
+        "Decision Receipt verification requires an Ed25519 public key. "
+        "Use make_verifier_with_key(pubkey_bytes) to create a verifier."
+    )
+
+
+def make_verifier_with_key(pubkey_bytes: bytes) -> callable:
+    """Create a verifier with a known Ed25519 public key.
+
+    Args:
+        pubkey_bytes: 32-byte Ed25519 public key.
+
+    Returns:
+        A callable compatible with classify_trust(verify_signature=...).
+    """
+    try:
+        from nacl.signing import VerifyKey
+        from nacl.exceptions import BadSignatureError
+    except ImportError:
+        def _no_nacl(receipt: Dict[str, Any]) -> bool:
+            return False
+        return _no_nacl
+
+    vk = VerifyKey(pubkey_bytes)
+
+    def _verify(receipt: Dict[str, Any]) -> bool:
+        sig_b64 = receipt.get("signature")
+        if not sig_b64 or not isinstance(sig_b64, str):
+            return False
+        try:
+            sig_bytes = base64.b64decode(sig_b64)
+        except Exception:
+            return False
+        canonical = _canonical_bytes(receipt)
+        try:
+            vk.verify(canonical, sig_bytes)
+            return True
+        except BadSignatureError:
+            return False
+        except Exception:
+            return False
+
+    return _verify
+
+
+__all__ = [
+    "VerificationKeyRequired",
+    "verify_decision_receipt",
+    "make_verifier_with_key",
+]

--- a/src/assay/packet_render.py
+++ b/src/assay/packet_render.py
@@ -20,6 +20,7 @@ from typing import Any
 
 _REQUIRED_FILES = ("SETTLEMENT.json", "COVERAGE_MATRIX.md")
 _OPTIONAL_FILES = ("EXECUTIVE_SUMMARY.md", "REVIEWER_GUIDE.md", "CHALLENGE.md", "VERIFY.md")
+_DECISION_RECEIPTS_FILE = "DECISION_RECEIPTS.json"
 
 
 class PacketRenderError(ValueError):
@@ -71,9 +72,17 @@ def render_packet_html(packet_dir: Path) -> str:
 
     coverage_html = _coverage_md_to_html(coverage_md)
 
+    # Decision Receipts (optional — rendered when present)
+    decision_receipts_raw = _load_json_optional(packet_dir / _DECISION_RECEIPTS_FILE)
+    decision_summary_html = _render_decision_summary(
+        decision_receipts_raw if isinstance(decision_receipts_raw, list) else None
+    )
+
     sections: list[str] = []
     if executive_md:
         sections.append(_section("Summary", _md_to_html(executive_md)))
+    if decision_summary_html:
+        sections.append(_section("Decision Summary", decision_summary_html))
     sections.append(_section("Coverage", coverage_html))
     if reviewer_guide_md:
         sections.append(_section("Reviewer guide", _md_to_html(reviewer_guide_md)))
@@ -375,6 +384,174 @@ def _coverage_md_to_html(md: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Decision Summary rendering
+# ---------------------------------------------------------------------------
+
+def _render_decision_summary(receipts: list[dict[str, Any]] | None) -> str:
+    """Render Decision Receipt summary using the shared trust evaluator.
+
+    Trust states (5-state model from decision_receipt_trust.py):
+      verified     — signature present + verification passed
+      unsigned     — structurally sound, no signature
+      unverifiable — signature present, key unavailable
+      invalid      — validation or verification failed
+      missing      — no receipts present
+    """
+    from assay.decision_receipt_trust import (
+        DecisionReceiptTrustState,
+        classify_trust,
+    )
+
+    if receipts is None or not receipts:
+        return _decision_missing_notice()
+
+    # Load validator if available
+    try:
+        from assay.decision_receipt import validate_decision_receipt
+    except ImportError:
+        validate_decision_receipt = None
+
+    parts: list[str] = []
+    for receipt in receipts:
+        trust = classify_trust(receipt, validator=validate_decision_receipt)
+        parts.append(_render_single_decision(receipt, trust))
+
+    return "\n".join(parts)
+
+
+def _decision_missing_notice() -> str:
+    return (
+        '<div class="decision-notice decision-missing">'
+        "<p>No Decision Receipt present in this packet.</p>"
+        "</div>"
+    )
+
+
+def _render_single_decision(
+    receipt: dict[str, Any],
+    trust: Any,
+) -> str:
+    """Render one Decision Receipt based on its trust state."""
+    from assay.decision_receipt_trust import DecisionReceiptTrustState
+
+    state = trust.state
+
+    if state == DecisionReceiptTrustState.INVALID:
+        errors_html = "".join(
+            f"<li>{_esc(e)}</li>" for e in trust.errors
+        )
+        return (
+            '<div class="decision-card decision-invalid">'
+            f'<div class="decision-state warn">Invalid Decision Receipt</div>'
+            f"<ul>{errors_html}</ul>"
+            "</div>"
+        )
+
+    if state == DecisionReceiptTrustState.UNVERIFIABLE:
+        return (
+            '<div class="decision-card decision-unverifiable">'
+            f'<div class="decision-state">{_esc(trust.reason)}</div>'
+            f"{_decision_provenance_row(receipt)}"
+            "</div>"
+        )
+
+    # VERIFIED and UNSIGNED both get full render, with different CSS
+    verdict = receipt.get("verdict", "—")
+    verdict_css = _VERDICT_CSS.get(verdict, "")
+    card_class = (
+        "decision-verified" if state == DecisionReceiptTrustState.VERIFIED
+        else "decision-unsigned"
+    )
+
+    return (
+        f'<div class="decision-card {card_class}">'
+        f'<div class="decision-verdict {verdict_css}">{_esc(verdict)}</div>'
+        f"{_decision_detail_rows(receipt)}"
+        f"{_decision_provenance_row(receipt)}"
+        f"</div>"
+    )
+
+
+def _decision_detail_rows(receipt: dict[str, Any]) -> str:
+    """Render the detail rows for a valid Decision Receipt."""
+    rows: list[str] = []
+
+    authority = receipt.get("authority_id", "—")
+    rows.append(_decision_row("Authority", authority))
+
+    reason = receipt.get("verdict_reason", "")
+    if reason:
+        rows.append(_decision_row("Reason", reason[:200]))
+
+    disposition = receipt.get("disposition", "—")
+    rows.append(_decision_row("Disposition", disposition))
+
+    sufficient = receipt.get("evidence_sufficient")
+    if sufficient is not None:
+        rows.append(_decision_row(
+            "Evidence sufficient",
+            "Yes" if sufficient else "No",
+        ))
+
+    # Extract domain: and clause: codes from verdict_reason_codes
+    codes = receipt.get("verdict_reason_codes", [])
+    domain_codes = [c for c in codes if c.startswith("domain:")]
+    clause_codes = [c for c in codes if c.startswith("clause:")]
+    if domain_codes:
+        rows.append(_decision_row("Failure domain", ", ".join(domain_codes)))
+    if clause_codes:
+        rows.append(_decision_row("Guardian clause", ", ".join(clause_codes)))
+
+    return "\n".join(rows)
+
+
+def _decision_provenance_row(receipt: dict[str, Any]) -> str:
+    """Render provenance: content_hash, signature state, CEID."""
+    parts: list[str] = []
+
+    content_hash = receipt.get("content_hash")
+    if content_hash:
+        parts.append(_decision_row("Content hash", f"{content_hash[:16]}..."))
+    else:
+        parts.append(_decision_row("Content hash", "Not computed"))
+
+    sig = receipt.get("signature")
+    if sig:
+        parts.append(_decision_row("Signature", "Present"))
+    else:
+        parts.append(_decision_row("Signature", "Unsigned"))
+
+    ceid = receipt.get("ceid")
+    if ceid:
+        parts.append(_decision_row("CEID", ceid))
+
+    decision_type = receipt.get("decision_type", "")
+    if decision_type:
+        parts.append(_decision_row("Decision type", decision_type))
+
+    return "\n".join(parts)
+
+
+def _decision_row(label: str, value: str) -> str:
+    return (
+        f'<div class="decision-row">'
+        f'<span class="decision-label">{_esc(label)}</span>'
+        f'<span class="decision-value">{_esc(value)}</span>'
+        f"</div>"
+    )
+
+
+_VERDICT_CSS: dict[str, str] = {
+    "REFUSE": "verdict-refuse",
+    "DEFER": "verdict-defer",
+    "APPROVE": "verdict-approve",
+    "ABSTAIN": "verdict-abstain",
+    "ROLLBACK": "verdict-rollback",
+    "CONFLICT": "verdict-conflict",
+}
+
+
+# ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
 
@@ -525,6 +702,54 @@ _CSS = textwrap.dedent("""\
         color: #999;
         font-size: .82rem;
     }
+    .decision-card {
+        background: #fff;
+        border: 1px solid #ddd8cc;
+        border-radius: 8px;
+        padding: 16px 18px;
+        margin-bottom: 12px;
+    }
+    .decision-valid, .decision-verified { border-left: 4px solid #2d6a3f; }
+    .decision-unsigned { border-left: 4px solid #4a7ab5; }
+    .decision-invalid { border-left: 4px solid #8b1a1a; }
+    .decision-unverifiable { border-left: 4px solid #7d5a00; }
+    .decision-missing {
+        background: #f9f7f3;
+        border: 1px dashed #ccc;
+        border-radius: 8px;
+        padding: 16px 18px;
+        color: #888;
+    }
+    .decision-verdict {
+        font-size: 1.05rem;
+        font-weight: 700;
+        margin-bottom: 10px;
+        padding: 4px 10px;
+        border-radius: 4px;
+        display: inline-block;
+    }
+    .verdict-refuse { background: #fde8e8; color: #8b1a1a; }
+    .verdict-defer { background: #fef3cd; color: #7d5a00; }
+    .verdict-approve { background: #d4edda; color: #2d6a3f; }
+    .verdict-abstain { background: #edeae3; color: #555; }
+    .verdict-rollback { background: #fde8e8; color: #8b1a1a; }
+    .verdict-conflict { background: #fde8e8; color: #8b1a1a; }
+    .decision-state { font-weight: 600; margin-bottom: 8px; }
+    .decision-notice p { font-style: italic; }
+    .decision-row {
+        display: flex;
+        gap: 12px;
+        padding: 3px 0;
+        font-size: .88rem;
+    }
+    .decision-label {
+        min-width: 140px;
+        color: #888;
+        font-size: .82rem;
+        text-transform: uppercase;
+        letter-spacing: .04em;
+    }
+    .decision-value { color: #1a201a; word-break: break-all; }
     @media (max-width: 560px) {
         .meta-grid { grid-template-columns: repeat(2, 1fr); }
         h1 { font-size: 1.5rem; }

--- a/tests/assay/golden_vector.json
+++ b/tests/assay/golden_vector.json
@@ -1,0 +1,52 @@
+{
+  "_comment": "Golden vector for Decision Receipt canonicalization + signing. Asserted in both CCIO and Assay. Change only if canonicalization contract changes.",
+  "_pinned": "2026-03-21",
+  "receipt": {
+    "receipt_id": "golden-vector-001",
+    "receipt_type": "decision_v1",
+    "receipt_version": "0.1.0",
+    "ceid": null,
+    "timestamp": "2026-01-01T00:00:00.000Z",
+    "parent_receipt_id": null,
+    "supersedes": null,
+    "decision_type": "guardian_constitutional_refusal",
+    "decision_subject": "golden:vector",
+    "verdict": "REFUSE",
+    "verdict_reason": "Golden vector test refusal",
+    "verdict_reason_codes": ["clarity_check_failed", "domain:epistemic"],
+    "authority_id": "ccio:settlement:guardian_seat",
+    "authority_class": "BINDING",
+    "authority_scope": "constitutional_baseline",
+    "delegated_from": null,
+    "policy_id": "ccio.settlement.constitutional_baseline.v1",
+    "policy_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "episode_id": "golden-vector-ep",
+    "source_organ": "ccio",
+    "session_state_hash": null,
+    "evidence_refs": [
+      {"ref_type": "receipt", "ref_id": "gate_eval:ece", "ref_role": "supporting"}
+    ],
+    "evidence_sufficient": true,
+    "evidence_gaps": [],
+    "confidence": "high",
+    "conflict_refs": [],
+    "dissent": null,
+    "abstention_reason": null,
+    "unresolved_contradictions": [],
+    "disposition": "block",
+    "disposition_target": null,
+    "obligations_created": [],
+    "proof_tier_at_decision": null,
+    "proof_tier_achieved": null,
+    "proof_tier_minimum_required": null,
+    "provenance_complete": true,
+    "known_provenance_gaps": []
+  },
+  "signing_key_seed_hex": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "expected": {
+    "content_hash": "78c5bc58927a4b08805a806113b9df0a2dd7244761591d1d6dc84087020d2460",
+    "signature": "p20LkhSQnshpN9KxqkiLZrkbNzCY1uLPEaRMXWkobpbcb0kfebWMX17Yih3Eywj/D6Ed8OM5WqcpO3Z1034lCw==",
+    "signer_pubkey_sha256": "448f04ffcba874db93d9fd02520daa583a92b1f20b100ff791202a6d7a93e0de",
+    "pubkey_b64": "5zTqbCtiV95yNV5HKqBaTEh+a0Y8Ap7TBt8vAbVja1g="
+  }
+}

--- a/tests/assay/test_decision_receipt_trust.py
+++ b/tests/assay/test_decision_receipt_trust.py
@@ -1,0 +1,420 @@
+"""Tests for the shared Decision Receipt trust evaluator.
+
+Locks the 5-state trust model before signing lands.
+Classification priority: MISSING → INVALID → UNVERIFIABLE → VERIFIED → UNSIGNED
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+import pytest
+
+from assay.decision_receipt_trust import (
+    DecisionReceiptTrustState,
+    TrustClassification,
+    classify_trust,
+    MISSING,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_VALID_RECEIPT = {
+    "receipt_id": "trust-test-001",
+    "receipt_type": "decision_v1",
+    "receipt_version": "0.1.0",
+    "ceid": None,
+    "timestamp": "2026-03-21T12:00:00.000Z",
+    "parent_receipt_id": None,
+    "supersedes": None,
+    "decision_type": "guardian_constitutional_refusal",
+    "decision_subject": "test:subject",
+    "verdict": "REFUSE",
+    "verdict_reason": "Test refusal reason",
+    "verdict_reason_codes": ["clarity_check_failed", "domain:epistemic"],
+    "authority_id": "ccio:settlement:guardian_seat",
+    "authority_class": "BINDING",
+    "authority_scope": "constitutional_baseline",
+    "delegated_from": None,
+    "policy_id": "ccio.settlement.constitutional_baseline.v1",
+    "policy_hash": "a" * 64,
+    "episode_id": "ep-trust-001",
+    "source_organ": "ccio",
+    "disposition": "block",
+    "disposition_target": None,
+    "obligations_created": [],
+    "evidence_refs": [],
+    "evidence_sufficient": True,
+    "evidence_gaps": [],
+    "confidence": "high",
+    "conflict_refs": [],
+    "dissent": None,
+    "abstention_reason": None,
+    "unresolved_contradictions": [],
+    "proof_tier_at_decision": None,
+    "proof_tier_achieved": None,
+    "proof_tier_minimum_required": None,
+    "provenance_complete": True,
+    "known_provenance_gaps": [],
+    "content_hash": "f" * 64,
+    "signature": None,
+    "signer_pubkey_sha256": None,
+}
+
+
+@dataclass
+class _MockValidationResult:
+    valid: bool
+    errors: List[Any] = None
+
+    def __post_init__(self):
+        if self.errors is None:
+            self.errors = []
+
+
+@dataclass
+class _MockError:
+    rule: str
+    message: str
+
+
+def _passing_validator(receipt: Dict[str, Any]) -> _MockValidationResult:
+    return _MockValidationResult(valid=True)
+
+
+def _failing_validator(receipt: Dict[str, Any]) -> _MockValidationResult:
+    return _MockValidationResult(
+        valid=False,
+        errors=[_MockError(rule="R-TEST", message="Test validation failure")],
+    )
+
+
+def _true_verifier(receipt: Dict[str, Any]) -> bool:
+    return True
+
+
+def _false_verifier(receipt: Dict[str, Any]) -> bool:
+    return False
+
+
+def _exploding_verifier(receipt: Dict[str, Any]) -> bool:
+    raise ValueError("Key material corrupted")
+
+
+# ---------------------------------------------------------------------------
+# MISSING
+# ---------------------------------------------------------------------------
+
+class TestMissing:
+
+    def test_none_receipt_is_missing(self):
+        result = classify_trust(None)
+        assert result.state == DecisionReceiptTrustState.MISSING
+
+    def test_missing_sentinel_matches(self):
+        result = classify_trust(None)
+        assert result == MISSING
+
+    def test_missing_is_not_trustworthy(self):
+        result = classify_trust(None)
+        assert not result.is_trustworthy
+        assert not result.is_structurally_sound
+
+
+# ---------------------------------------------------------------------------
+# UNSIGNED
+# ---------------------------------------------------------------------------
+
+class TestUnsigned:
+
+    def test_no_signature_is_unsigned(self):
+        result = classify_trust(_VALID_RECEIPT)
+        assert result.state == DecisionReceiptTrustState.UNSIGNED
+
+    def test_unsigned_with_content_hash(self):
+        result = classify_trust(_VALID_RECEIPT)
+        assert "structurally sound" in result.reason
+
+    def test_unsigned_without_content_hash(self):
+        receipt = {**_VALID_RECEIPT, "content_hash": None}
+        result = classify_trust(receipt)
+        assert result.state == DecisionReceiptTrustState.UNSIGNED
+        assert "no content hash" in result.reason
+
+    def test_unsigned_is_structurally_sound(self):
+        result = classify_trust(_VALID_RECEIPT)
+        assert result.is_structurally_sound
+        assert not result.is_trustworthy
+
+    def test_unsigned_with_validator_passing(self):
+        result = classify_trust(_VALID_RECEIPT, validator=_passing_validator)
+        assert result.state == DecisionReceiptTrustState.UNSIGNED
+
+
+# ---------------------------------------------------------------------------
+# INVALID
+# ---------------------------------------------------------------------------
+
+class TestInvalid:
+
+    def test_schema_validation_failure_is_invalid(self):
+        result = classify_trust(_VALID_RECEIPT, validator=_failing_validator)
+        assert result.state == DecisionReceiptTrustState.INVALID
+
+    def test_invalid_carries_errors(self):
+        result = classify_trust(_VALID_RECEIPT, validator=_failing_validator)
+        assert len(result.errors) > 0
+        assert "R-TEST" in result.errors[0]
+
+    def test_malformed_receipt_is_invalid(self):
+        bad = {"receipt_id": "bad"}
+        result = classify_trust(bad, validator=_failing_validator)
+        assert result.state == DecisionReceiptTrustState.INVALID
+
+    def test_invalid_is_not_structurally_sound(self):
+        result = classify_trust(_VALID_RECEIPT, validator=_failing_validator)
+        assert not result.is_structurally_sound
+        assert not result.is_trustworthy
+
+    def test_signature_mismatch_is_invalid(self):
+        """Signed receipt where verification fails → INVALID, not unverifiable."""
+        receipt = {
+            **_VALID_RECEIPT,
+            "signature": "bad_sig",
+            "signer_pubkey_sha256": "some_key_hash",
+        }
+        result = classify_trust(receipt, verify_signature=_false_verifier)
+        assert result.state == DecisionReceiptTrustState.INVALID
+        assert "tampered" in result.errors[0].lower() or "mismatch" in result.reason.lower()
+
+    def test_verification_exception_is_invalid(self):
+        """Verifier raising exception → INVALID with error detail."""
+        receipt = {
+            **_VALID_RECEIPT,
+            "signature": "some_sig",
+            "signer_pubkey_sha256": "some_key",
+        }
+        result = classify_trust(receipt, verify_signature=_exploding_verifier)
+        assert result.state == DecisionReceiptTrustState.INVALID
+        assert "corrupted" in result.errors[0].lower()
+
+
+# ---------------------------------------------------------------------------
+# UNVERIFIABLE
+# ---------------------------------------------------------------------------
+
+class TestUnverifiable:
+
+    def test_sig_present_no_key_is_unverifiable(self):
+        receipt = {
+            **_VALID_RECEIPT,
+            "signature": "some_sig_base64",
+            "signer_pubkey_sha256": None,
+        }
+        result = classify_trust(receipt)
+        assert result.state == DecisionReceiptTrustState.UNVERIFIABLE
+
+    def test_sig_present_no_verifier_is_unverifiable(self):
+        """Signature + key present, but no verify function → unverifiable."""
+        receipt = {
+            **_VALID_RECEIPT,
+            "signature": "some_sig",
+            "signer_pubkey_sha256": "some_key_hash",
+        }
+        # No verify_signature callback provided
+        result = classify_trust(receipt)
+        assert result.state == DecisionReceiptTrustState.UNVERIFIABLE
+
+    def test_unverifiable_reason_mentions_key(self):
+        receipt = {
+            **_VALID_RECEIPT,
+            "signature": "sig",
+            "signer_pubkey_sha256": None,
+        }
+        result = classify_trust(receipt)
+        assert "key unavailable" in result.reason.lower()
+
+    def test_unverifiable_is_not_invalid(self):
+        """Critical boundary: unverifiable must NOT be collapsed into invalid."""
+        receipt = {
+            **_VALID_RECEIPT,
+            "signature": "sig",
+            "signer_pubkey_sha256": None,
+        }
+        result = classify_trust(receipt)
+        assert result.state != DecisionReceiptTrustState.INVALID
+
+
+# ---------------------------------------------------------------------------
+# VERIFIED
+# ---------------------------------------------------------------------------
+
+class TestVerified:
+
+    def test_sig_present_verification_passes(self):
+        receipt = {
+            **_VALID_RECEIPT,
+            "signature": "valid_sig_base64",
+            "signer_pubkey_sha256": "key_hash_abc123",
+        }
+        result = classify_trust(receipt, verify_signature=_true_verifier)
+        assert result.state == DecisionReceiptTrustState.VERIFIED
+
+    def test_verified_is_trustworthy(self):
+        receipt = {
+            **_VALID_RECEIPT,
+            "signature": "valid_sig",
+            "signer_pubkey_sha256": "key_hash",
+        }
+        result = classify_trust(receipt, verify_signature=_true_verifier)
+        assert result.is_trustworthy
+        assert result.is_structurally_sound
+
+    def test_verified_with_validator_passing(self):
+        receipt = {
+            **_VALID_RECEIPT,
+            "signature": "valid_sig",
+            "signer_pubkey_sha256": "key_hash",
+        }
+        result = classify_trust(
+            receipt,
+            validator=_passing_validator,
+            verify_signature=_true_verifier,
+        )
+        assert result.state == DecisionReceiptTrustState.VERIFIED
+
+
+# ---------------------------------------------------------------------------
+# Classification priority
+# ---------------------------------------------------------------------------
+
+class TestPriority:
+
+    def test_unverifiable_beats_invalid(self):
+        """Missing key takes priority over schema validation.
+
+        The signature-present-key-absent pattern is UNVERIFIABLE, not INVALID,
+        even if the validator would also flag I-7. This is because the receipt
+        may be structurally fine — we just can't prove it with available keys.
+        """
+        receipt = {
+            **_VALID_RECEIPT,
+            "signature": "some_sig",
+            "signer_pubkey_sha256": None,
+        }
+        result = classify_trust(receipt, validator=_failing_validator)
+        assert result.state == DecisionReceiptTrustState.UNVERIFIABLE
+
+    def test_invalid_beats_unsigned(self):
+        result = classify_trust(_VALID_RECEIPT, validator=_failing_validator)
+        assert result.state == DecisionReceiptTrustState.INVALID
+
+    def test_missing_beats_everything(self):
+        result = classify_trust(None, validator=_failing_validator)
+        assert result.state == DecisionReceiptTrustState.MISSING
+
+
+# ---------------------------------------------------------------------------
+# Boundary: unverifiable vs invalid
+# ---------------------------------------------------------------------------
+
+class TestBoundary:
+    """The distinction between unverifiable and invalid is constitutionally important."""
+
+    def test_missing_key_is_unverifiable_not_invalid(self):
+        """Key unavailable ≠ verification failed."""
+        receipt = {
+            **_VALID_RECEIPT,
+            "signature": "sig",
+            "signer_pubkey_sha256": None,
+        }
+        result = classify_trust(receipt)
+        assert result.state == DecisionReceiptTrustState.UNVERIFIABLE
+        assert result.state != DecisionReceiptTrustState.INVALID
+
+    def test_bad_signature_is_invalid_not_unverifiable(self):
+        """Verification attempted and failed ≠ verification impossible."""
+        receipt = {
+            **_VALID_RECEIPT,
+            "signature": "bad_sig",
+            "signer_pubkey_sha256": "key_hash",
+        }
+        result = classify_trust(receipt, verify_signature=_false_verifier)
+        assert result.state == DecisionReceiptTrustState.INVALID
+        assert result.state != DecisionReceiptTrustState.UNVERIFIABLE
+
+    def test_malformed_signed_receipt_without_key_is_unverifiable(self):
+        """Signed + key missing + structurally broken → UNVERIFIABLE wins.
+
+        Policy choice: if key material is unavailable, we surface
+        unverifiability even if validation would also fail. This is because
+        the structural defect may be an artifact of incomplete transmission,
+        and the dominant signal is "we cannot verify the signature."
+        """
+        broken_signed = {
+            "receipt_id": "broken-signed-001",
+            "signature": "some_sig",
+            "signer_pubkey_sha256": None,
+            # Missing most required fields — would fail validation
+        }
+        result = classify_trust(broken_signed, validator=_failing_validator)
+        assert result.state == DecisionReceiptTrustState.UNVERIFIABLE
+
+
+# ---------------------------------------------------------------------------
+# Enum properties
+# ---------------------------------------------------------------------------
+
+class TestEmptySignature:
+    """P1 fix: empty/whitespace signature is INVALID, not UNVERIFIABLE."""
+
+    def test_empty_string_signature_is_invalid(self):
+        receipt = {**_VALID_RECEIPT, "signature": ""}
+        result = classify_trust(receipt)
+        assert result.state == DecisionReceiptTrustState.INVALID
+        assert "empty" in result.errors[0].lower()
+
+    def test_whitespace_signature_is_invalid(self):
+        receipt = {**_VALID_RECEIPT, "signature": "   "}
+        result = classify_trust(receipt)
+        assert result.state == DecisionReceiptTrustState.INVALID
+
+    def test_none_signature_is_not_invalid(self):
+        """None signature = unsigned, not invalid."""
+        receipt = {**_VALID_RECEIPT, "signature": None}
+        result = classify_trust(receipt)
+        assert result.state == DecisionReceiptTrustState.UNSIGNED
+
+    def test_real_signature_no_key_is_unverifiable(self):
+        """Non-empty signature + no key = UNVERIFIABLE (not invalid)."""
+        receipt = {
+            **_VALID_RECEIPT,
+            "signature": "abc123realbase64",
+            "signer_pubkey_sha256": None,
+        }
+        result = classify_trust(receipt)
+        assert result.state == DecisionReceiptTrustState.UNVERIFIABLE
+
+
+class TestEnumContract:
+
+    def test_all_five_states_exist(self):
+        states = set(DecisionReceiptTrustState)
+        assert len(states) == 5
+        assert DecisionReceiptTrustState.VERIFIED in states
+        assert DecisionReceiptTrustState.UNSIGNED in states
+        assert DecisionReceiptTrustState.UNVERIFIABLE in states
+        assert DecisionReceiptTrustState.INVALID in states
+        assert DecisionReceiptTrustState.MISSING in states
+
+    def test_states_are_lowercase_strings(self):
+        for state in DecisionReceiptTrustState:
+            assert state.value == state.value.lower()
+
+    def test_trust_classification_is_frozen(self):
+        tc = TrustClassification(state=DecisionReceiptTrustState.UNSIGNED)
+        with pytest.raises(AttributeError):
+            tc.state = DecisionReceiptTrustState.VERIFIED

--- a/tests/assay/test_decision_receipt_verify.py
+++ b/tests/assay/test_decision_receipt_verify.py
@@ -1,0 +1,256 @@
+"""Tests for Decision Receipt signature verification in Assay.
+
+Proves: CCIO-signed receipts verify correctly through Assay's standalone
+verifier. This is the cross-repo verification boundary.
+"""
+from __future__ import annotations
+
+import base64
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+import pytest
+
+try:
+    from nacl.signing import SigningKey
+    HAS_NACL = True
+except ImportError:
+    HAS_NACL = False
+
+from assay.decision_receipt_verify import (
+    VerificationKeyRequired,
+    make_verifier_with_key,
+    verify_decision_receipt,
+)
+from assay.decision_receipt_trust import (
+    DecisionReceiptTrustState,
+    classify_trust,
+)
+
+needs_nacl = pytest.mark.skipif(not HAS_NACL, reason="PyNaCl not installed")
+
+
+def _make_receipt() -> Dict[str, Any]:
+    """Minimal valid unsigned Decision Receipt for testing."""
+    return {
+        "receipt_id": "verify-test-001",
+        "receipt_type": "decision_v1",
+        "receipt_version": "0.1.0",
+        "ceid": None,
+        "timestamp": "2026-03-21T12:00:00.000Z",
+        "parent_receipt_id": None,
+        "supersedes": None,
+        "decision_type": "guardian_constitutional_refusal",
+        "decision_subject": "test:verify",
+        "verdict": "REFUSE",
+        "verdict_reason": "Test verification",
+        "verdict_reason_codes": ["clarity_check_failed", "domain:epistemic"],
+        "authority_id": "ccio:settlement:guardian_seat",
+        "authority_class": "BINDING",
+        "authority_scope": "constitutional_baseline",
+        "delegated_from": None,
+        "policy_id": "ccio.settlement.constitutional_baseline.v1",
+        "policy_hash": "a" * 64,
+        "episode_id": "ep-verify-001",
+        "source_organ": "ccio",
+        "disposition": "block",
+        "disposition_target": None,
+        "obligations_created": [],
+        "evidence_refs": [],
+        "evidence_sufficient": True,
+        "evidence_gaps": [],
+        "confidence": "high",
+        "conflict_refs": [],
+        "dissent": None,
+        "abstention_reason": None,
+        "unresolved_contradictions": [],
+        "proof_tier_at_decision": None,
+        "proof_tier_achieved": None,
+        "proof_tier_minimum_required": None,
+        "provenance_complete": True,
+        "known_provenance_gaps": [],
+        "content_hash": None,
+        "signature": None,
+        "signer_pubkey_sha256": None,
+    }
+
+
+def _sign_receipt_standalone(receipt: Dict[str, Any], sk: "SigningKey") -> Dict[str, Any]:
+    """Sign a receipt using the same canonical algorithm as CCIO.
+
+    This reimplements the signing inline so the test doesn't import CCIO.
+    """
+    import hashlib
+
+    # Same canonical byte extraction as CCIO's sign.py and Assay's verify.py
+    excluded = {"content_hash", "signature", "signer_pubkey_sha256"}
+    hashable = {k: v for k, v in receipt.items() if k not in excluded and v is not None}
+    if "verdict_reason_codes" in hashable and isinstance(hashable["verdict_reason_codes"], list):
+        hashable["verdict_reason_codes"] = sorted(set(hashable["verdict_reason_codes"]))
+    if "evidence_refs" in hashable and isinstance(hashable["evidence_refs"], list):
+        hashable["evidence_refs"] = sorted(
+            hashable["evidence_refs"],
+            key=lambda r: json.dumps(r, sort_keys=True, separators=(",", ":")),
+        )
+    canonical = json.dumps(hashable, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+
+    # content_hash
+    receipt["content_hash"] = hashlib.sha256(canonical).hexdigest()
+
+    # signer identity
+    vk = sk.verify_key
+    receipt["signer_pubkey_sha256"] = hashlib.sha256(bytes(vk)).hexdigest()
+
+    # Ed25519 signature
+    signed = sk.sign(canonical)
+    receipt["signature"] = base64.b64encode(signed.signature).decode("ascii")
+
+    return receipt
+
+
+# ---------------------------------------------------------------------------
+# Cross-repo verification
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# P2 fix: verify_decision_receipt raises instead of lying
+# ---------------------------------------------------------------------------
+
+class TestVerifierApiContract:
+
+    def test_verify_decision_receipt_raises_without_key(self):
+        """The top-level verifier must not silently return False."""
+        receipt = _make_receipt()
+        with pytest.raises(VerificationKeyRequired):
+            verify_decision_receipt(receipt)
+
+    def test_error_message_mentions_make_verifier(self):
+        receipt = _make_receipt()
+        with pytest.raises(VerificationKeyRequired, match="make_verifier_with_key"):
+            verify_decision_receipt(receipt)
+
+
+# ---------------------------------------------------------------------------
+# Cross-repo verification
+# ---------------------------------------------------------------------------
+
+@needs_nacl
+class TestCrossRepoVerification:
+    """Prove Assay can verify receipts signed by CCIO's algorithm."""
+
+    def test_signed_receipt_verifies_in_assay(self):
+        sk = SigningKey(b"\xcc" * 32)
+        receipt = _sign_receipt_standalone(_make_receipt(), sk)
+
+        verifier = make_verifier_with_key(bytes(sk.verify_key))
+        assert verifier(receipt) is True
+
+    def test_tampered_receipt_fails_in_assay(self):
+        sk = SigningKey(b"\xcc" * 32)
+        receipt = _sign_receipt_standalone(_make_receipt(), sk)
+
+        receipt["verdict"] = "APPROVE"  # tamper
+
+        verifier = make_verifier_with_key(bytes(sk.verify_key))
+        assert verifier(receipt) is False
+
+    def test_wrong_key_fails_in_assay(self):
+        sk = SigningKey(b"\xcc" * 32)
+        receipt = _sign_receipt_standalone(_make_receipt(), sk)
+
+        other_key = SigningKey(b"\xdd" * 32)
+        verifier = make_verifier_with_key(bytes(other_key.verify_key))
+        assert verifier(receipt) is False
+
+
+# ---------------------------------------------------------------------------
+# Trust evaluator integration
+# ---------------------------------------------------------------------------
+
+@needs_nacl
+class TestTrustEvaluatorIntegration:
+    """End-to-end: signed receipt → classify_trust → VERIFIED."""
+
+    def test_signed_receipt_classified_as_verified(self):
+        sk = SigningKey(b"\xee" * 32)
+        receipt = _sign_receipt_standalone(_make_receipt(), sk)
+
+        verifier = make_verifier_with_key(bytes(sk.verify_key))
+        trust = classify_trust(receipt, verify_signature=verifier)
+        assert trust.state == DecisionReceiptTrustState.VERIFIED
+        assert trust.is_trustworthy
+
+    def test_tampered_receipt_classified_as_invalid(self):
+        sk = SigningKey(b"\xee" * 32)
+        receipt = _sign_receipt_standalone(_make_receipt(), sk)
+        receipt["verdict"] = "APPROVE"  # tamper
+
+        verifier = make_verifier_with_key(bytes(sk.verify_key))
+        trust = classify_trust(receipt, verify_signature=verifier)
+        assert trust.state == DecisionReceiptTrustState.INVALID
+
+    def test_unsigned_receipt_classified_as_unsigned(self):
+        receipt = _make_receipt()
+        receipt["content_hash"] = "f" * 64
+
+        trust = classify_trust(receipt)
+        assert trust.state == DecisionReceiptTrustState.UNSIGNED
+
+    def test_signed_no_key_classified_as_unverifiable(self):
+        sk = SigningKey(b"\xee" * 32)
+        receipt = _sign_receipt_standalone(_make_receipt(), sk)
+
+        # No verifier provided
+        trust = classify_trust(receipt)
+        assert trust.state == DecisionReceiptTrustState.UNVERIFIABLE
+
+
+# ---------------------------------------------------------------------------
+# Cross-repo golden vector
+# ---------------------------------------------------------------------------
+
+@needs_nacl
+class TestGoldenVector:
+    """Shared golden vector — same fixture as CCIO. Proves contract fidelity."""
+
+    def test_golden_vector_verifies_in_assay(self):
+        """CCIO-produced golden signature verifies through Assay's standalone verifier."""
+        import copy
+        from pathlib import Path
+
+        vector_path = Path(__file__).parent / "golden_vector.json"
+        vector = json.loads(vector_path.read_text())
+
+        # Reconstruct the signed receipt from the vector
+        receipt = copy.deepcopy(vector["receipt"])
+        receipt["content_hash"] = vector["expected"]["content_hash"]
+        receipt["signature"] = vector["expected"]["signature"]
+        receipt["signer_pubkey_sha256"] = vector["expected"]["signer_pubkey_sha256"]
+
+        # Verify using Assay's standalone verifier with the known public key
+        import base64 as b64
+        pubkey_bytes = b64.b64decode(vector["expected"]["pubkey_b64"])
+        verifier = make_verifier_with_key(pubkey_bytes)
+        assert verifier(receipt) is True
+
+    def test_golden_vector_trust_state_is_verified(self):
+        """Golden vector receipt classifies as VERIFIED through trust evaluator."""
+        import copy
+        from pathlib import Path
+
+        vector_path = Path(__file__).parent / "golden_vector.json"
+        vector = json.loads(vector_path.read_text())
+
+        receipt = copy.deepcopy(vector["receipt"])
+        receipt["content_hash"] = vector["expected"]["content_hash"]
+        receipt["signature"] = vector["expected"]["signature"]
+        receipt["signer_pubkey_sha256"] = vector["expected"]["signer_pubkey_sha256"]
+
+        import base64 as b64
+        pubkey_bytes = b64.b64decode(vector["expected"]["pubkey_b64"])
+        verifier = make_verifier_with_key(pubkey_bytes)
+
+        trust = classify_trust(receipt, verify_signature=verifier)
+        assert trust.state == DecisionReceiptTrustState.VERIFIED
+        assert trust.is_trustworthy

--- a/tests/assay/test_packet_render.py
+++ b/tests/assay/test_packet_render.py
@@ -263,3 +263,218 @@ def test_gallery_packet_no_external_assets():
     assert "cdn." not in html
     assert "googleapis.com" not in html
     assert 'src="http' not in html
+
+
+# ---------------------------------------------------------------------------
+# 8. Decision Summary — 4 trust states (Run 4)
+# ---------------------------------------------------------------------------
+
+_VALID_DECISION_RECEIPT = {
+    "receipt_id": "dr-test-001",
+    "receipt_type": "decision_v1",
+    "receipt_version": "0.1.0",
+    "ceid": None,
+    "timestamp": "2026-03-20T12:00:00.000Z",
+    "parent_receipt_id": None,
+    "supersedes": None,
+    "decision_type": "guardian_constitutional_refusal",
+    "decision_subject": "council:task_eval:test",
+    "verdict": "REFUSE",
+    "verdict_reason": "Guardian: clarity check failed",
+    "verdict_reason_codes": [
+        "clarity_check_failed",
+        "domain:epistemic",
+    ],
+    "authority_id": "ccio:settlement:guardian_seat",
+    "authority_class": "BINDING",
+    "authority_scope": "constitutional_baseline",
+    "delegated_from": None,
+    "policy_id": "ccio.settlement.constitutional_baseline.v1",
+    "policy_hash": "a" * 64,
+    "episode_id": "ep-test-001",
+    "source_organ": "ccio",
+    "disposition": "block",
+    "disposition_target": None,
+    "obligations_created": [],
+    "evidence_refs": [],
+    "evidence_sufficient": True,
+    "evidence_gaps": [],
+    "confidence": "high",
+    "conflict_refs": [],
+    "dissent": None,
+    "abstention_reason": None,
+    "unresolved_contradictions": [],
+    "proof_tier_at_decision": None,
+    "proof_tier_achieved": None,
+    "proof_tier_minimum_required": None,
+    "provenance_complete": True,
+    "known_provenance_gaps": [],
+    "content_hash": "abcdef0123456789" * 4,
+    "signature": None,
+    "signer_pubkey_sha256": None,
+}
+
+
+def _make_packet_with_decisions(
+    tmp_path: Path,
+    receipts: list | None = None,
+) -> Path:
+    """Write a packet dir with optional DECISION_RECEIPTS.json."""
+    packet_dir = _make_packet(tmp_path)
+    if receipts is not None:
+        (packet_dir / "DECISION_RECEIPTS.json").write_text(
+            json.dumps(receipts), encoding="utf-8"
+        )
+    return packet_dir
+
+
+class TestDecisionSummaryMissing:
+    """Trust state: missing — no Decision Receipt file present."""
+
+    def test_missing_receipts_renders_notice(self, tmp_path):
+        packet_dir = _make_packet(tmp_path)
+        html = render_packet_html(packet_dir)
+        assert "No Decision Receipt present" in html
+
+    def test_missing_notice_has_css_class(self, tmp_path):
+        packet_dir = _make_packet(tmp_path)
+        html = render_packet_html(packet_dir)
+        assert "decision-missing" in html
+
+    def test_empty_receipts_list_renders_notice(self, tmp_path):
+        packet_dir = _make_packet_with_decisions(tmp_path, receipts=[])
+        html = render_packet_html(packet_dir)
+        assert "No Decision Receipt present" in html
+
+
+class TestDecisionSummaryValid:
+    """Trust state: valid — receipt passes validation, full render."""
+
+    def test_valid_receipt_renders_verdict(self, tmp_path):
+        packet_dir = _make_packet_with_decisions(tmp_path, [_VALID_DECISION_RECEIPT])
+        html = render_packet_html(packet_dir)
+        assert "REFUSE" in html
+        assert "verdict-refuse" in html
+
+    def test_valid_receipt_renders_authority(self, tmp_path):
+        packet_dir = _make_packet_with_decisions(tmp_path, [_VALID_DECISION_RECEIPT])
+        html = render_packet_html(packet_dir)
+        assert "ccio:settlement:guardian_seat" in html
+
+    def test_valid_receipt_renders_reason(self, tmp_path):
+        packet_dir = _make_packet_with_decisions(tmp_path, [_VALID_DECISION_RECEIPT])
+        html = render_packet_html(packet_dir)
+        assert "clarity check failed" in html
+
+    def test_valid_receipt_renders_domain_codes(self, tmp_path):
+        packet_dir = _make_packet_with_decisions(tmp_path, [_VALID_DECISION_RECEIPT])
+        html = render_packet_html(packet_dir)
+        assert "domain:epistemic" in html
+
+    def test_valid_receipt_renders_content_hash(self, tmp_path):
+        packet_dir = _make_packet_with_decisions(tmp_path, [_VALID_DECISION_RECEIPT])
+        html = render_packet_html(packet_dir)
+        assert "abcdef0123456789" in html  # first 16 chars
+
+    def test_valid_receipt_renders_unsigned_state(self, tmp_path):
+        packet_dir = _make_packet_with_decisions(tmp_path, [_VALID_DECISION_RECEIPT])
+        html = render_packet_html(packet_dir)
+        assert "Unsigned" in html
+
+    def test_valid_receipt_has_decision_valid_class(self, tmp_path):
+        packet_dir = _make_packet_with_decisions(tmp_path, [_VALID_DECISION_RECEIPT])
+        html = render_packet_html(packet_dir)
+        assert "decision-unsigned" in html
+
+    def test_decision_summary_section_heading(self, tmp_path):
+        packet_dir = _make_packet_with_decisions(tmp_path, [_VALID_DECISION_RECEIPT])
+        html = render_packet_html(packet_dir)
+        assert "Decision Summary" in html
+
+    def test_approve_verdict_gets_green_class(self, tmp_path):
+        receipt = {**_VALID_DECISION_RECEIPT, "verdict": "APPROVE", "disposition": "execute"}
+        packet_dir = _make_packet_with_decisions(tmp_path, [receipt])
+        html = render_packet_html(packet_dir)
+        assert "verdict-approve" in html
+
+    def test_defer_verdict_gets_amber_class(self, tmp_path):
+        receipt = {**_VALID_DECISION_RECEIPT, "verdict": "DEFER", "disposition": "escalate"}
+        packet_dir = _make_packet_with_decisions(tmp_path, [receipt])
+        html = render_packet_html(packet_dir)
+        assert "verdict-defer" in html
+
+
+class TestDecisionSummaryInvalid:
+    """Trust state: invalid — receipt fails validation, warning block."""
+
+    def test_invalid_receipt_renders_warning(self, tmp_path):
+        bad_receipt = {"receipt_id": "bad", "verdict": "REFUSE"}
+        packet_dir = _make_packet_with_decisions(tmp_path, [bad_receipt])
+        html = render_packet_html(packet_dir)
+        assert "decision-invalid" in html
+        assert "Invalid Decision Receipt" in html
+
+    def test_invalid_receipt_shows_errors(self, tmp_path):
+        # Missing most required fields → validation errors
+        bad_receipt = {"receipt_id": "bad-002"}
+        packet_dir = _make_packet_with_decisions(tmp_path, [bad_receipt])
+        html = render_packet_html(packet_dir)
+        assert "decision-invalid" in html
+
+
+class TestDecisionSummaryUnverifiable:
+    """Trust state: unverifiable — signature present, key unavailable."""
+
+    def test_unverifiable_has_distinct_class(self, tmp_path):
+        receipt = {
+            **_VALID_DECISION_RECEIPT,
+            "signature": "some_sig_bytes_base64",
+            "signer_pubkey_sha256": None,
+        }
+        packet_dir = _make_packet_with_decisions(tmp_path, [receipt])
+        html = render_packet_html(packet_dir)
+        assert "decision-unverifiable" in html
+        assert "verification key unavailable" in html
+
+    def test_unverifiable_not_collapsed_into_invalid(self, tmp_path):
+        receipt = {
+            **_VALID_DECISION_RECEIPT,
+            "signature": "some_sig",
+            "signer_pubkey_sha256": None,
+        }
+        packet_dir = _make_packet_with_decisions(tmp_path, [receipt])
+        html = render_packet_html(packet_dir)
+        # Check the body (after </style>), not the CSS definitions
+        body = html.split("</style>", 1)[-1]
+        assert "decision-invalid" not in body
+        assert "decision-unverifiable" in body
+
+
+class TestDecisionSummaryEndToEnd:
+    """C8: Milestone acceptance proof — emitted receipt → packet → correct rendering."""
+
+    def test_e2e_guardian_refusal_to_reviewer_packet(self, tmp_path):
+        """Build a receipt via the canonical builder, render in packet, verify output."""
+        # Build receipt using the CCIO shared builder
+        # (We inline the dict here rather than importing CCIO to keep assay tests standalone)
+        receipt = {**_VALID_DECISION_RECEIPT}
+        receipt["verdict_reason_codes"] = [
+            "clarity_check_failed",
+            "coherence_check_failed",
+            "domain:epistemic",
+        ]
+        receipt["content_hash"] = "e" * 64
+
+        packet_dir = _make_packet_with_decisions(tmp_path, [receipt])
+        html = render_packet_html(packet_dir)
+
+        # Verify all expected elements appear
+        assert "Decision Summary" in html
+        assert "REFUSE" in html
+        assert "verdict-refuse" in html
+        assert "ccio:settlement:guardian_seat" in html
+        assert "domain:epistemic" in html
+        assert "eeeeeeeeeeeeeeee" in html  # content_hash[:16]
+        assert "Unsigned" in html
+        assert "decision-unsigned" in html
+        assert "guardian_constitutional_refusal" in html


### PR DESCRIPTION
## Summary
- 5-state trust evaluator: VERIFIED / UNSIGNED / UNVERIFIABLE / INVALID / MISSING — single `classify_trust()` function
- Standalone Ed25519 verification via `make_verifier_with_key()` — no CCIO import needed
- `verify_decision_receipt()` now raises `VerificationKeyRequired` instead of silently returning False
- Reviewer packet Decision Summary section with trust-state rendering and verdict coloring
- Cross-repo golden vector shared with CCIO (PR Haserjian/ccio#108)

## Test plan
- [ ] 83 Assay tests pass (`pytest tests/assay/test_decision_receipt_trust.py tests/assay/test_decision_receipt_verify.py tests/assay/test_packet_render.py`)
- [ ] Golden vector verifies through standalone Assay verifier
- [ ] Trust evaluator classifies all 5 states correctly
- [ ] Empty signature → INVALID (not UNVERIFIABLE)
- [ ] Reviewer packet renders Decision Summary for valid/invalid/missing/unverifiable receipts

**Breaking change:** `verify_decision_receipt()` now raises `VerificationKeyRequired` when called without key material. Use `make_verifier_with_key(pubkey_bytes)` for working verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)