### PR TITLE
feat(episode): closed episode immutability + orphan detection

### DIFF
--- a/src/assay/episode.py
+++ b/src/assay/episode.py
@@ -692,9 +692,21 @@ class Episode:
     # ------------------------------------------------------------------
 
     def transition(self, next_state: EpisodeState) -> None:
-        """Advance the constitutional state machine."""
+        """Advance the constitutional state machine.
+
+        Closed episodes reject all transitions. ABANDONED causes closure,
+        but closure cannot be followed by ABANDONED.
+        """
         if not isinstance(next_state, EpisodeState):
             next_state = EpisodeState(str(next_state))
+
+        # Closed check FIRST — before same-state early return.
+        # A closed episode rejects ALL transitions, even no-ops.
+        if self._closed:
+            raise EpisodeStateError(
+                f"Episode {self._episode_id} is closed; "
+                f"cannot transition to {next_state.value}"
+            )
 
         if next_state == self.state:
             return
@@ -720,8 +732,22 @@ class Episode:
             self.settled_at = now
         elif next_state == EpisodeState.PERSISTED:
             self.persisted_at = now
+        elif next_state == EpisodeState.ABANDONED:
+            # ABANDONED is a terminal state. It MUST emit a receipt.
+            # Without this, episodes can silently disappear — violating
+            # "no silent epistemic death."
+            self._emit_lifecycle("episode.abandoned", {
+                "abandoned_from": self.state.value,
+                "receipt_count": len(self._receipt_ids),
+                "abandoned_at": now.isoformat(),
+            }, enforce_state=False)
 
         self.state = next_state
+
+        # If we just entered ABANDONED, also close the episode to prevent
+        # further emission and ensure episode.closed receipt is emitted.
+        if next_state == EpisodeState.ABANDONED and not self._closed:
+            self.close(status="abandoned")
 
     def start_execution(self) -> None:
         """Enter EXECUTING state."""

--- a/src/assay/orphan_detector.py
+++ b/src/assay/orphan_detector.py
@@ -1,0 +1,224 @@
+"""
+Episode orphan detector -- constitutional integrity check.
+
+Kernel Gap Ledger Row #1, Bypass #4: Assay optional context manager.
+Episodes created with bare `open_episode()` (no `with` block) can be
+garbage collected without ever emitting a terminal receipt.
+
+This module provides a store-backed detector that:
+1. Scans all traces in an AssayStore
+2. Identifies episodes with `episode.opened` but no terminal receipt
+   (`episode.closed` or `episode.abandoned`)
+3. Reports them loudly without mutating store state
+
+Constitutional law:
+    Every episode must terminate constitutionally: either by a typed
+    terminal receipt, or by an explicit detector-reported violation.
+
+Design constraints:
+    - Pure read. Never mutates the store.
+    - Explicit surfacing over magical cleanup.
+    - Auditable: returns structured results, not boolean.
+    - Backward compatible: treats traces without episode.opened as
+      legacy (not orphaned).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+from assay.store import AssayStore
+
+
+# Terminal receipt types that prove an episode was constitutionally closed.
+TERMINAL_RECEIPT_TYPES = frozenset({
+    "episode.closed",
+    "episode.abandoned",
+})
+
+# The receipt type that proves an episode was opened.
+OPENED_RECEIPT_TYPE = "episode.opened"
+
+
+@dataclass(frozen=True)
+class OrphanedEpisode:
+    """A detected orphaned episode -- opened but never terminalized."""
+
+    episode_id: str
+    trace_id: str
+    opened_at: str
+    receipt_count: int
+    last_receipt_type: str
+    last_receipt_at: str
+    trace_path: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "episode_id": self.episode_id,
+            "trace_id": self.trace_id,
+            "opened_at": self.opened_at,
+            "receipt_count": self.receipt_count,
+            "last_receipt_type": self.last_receipt_type,
+            "last_receipt_at": self.last_receipt_at,
+            "trace_path": self.trace_path,
+        }
+
+
+@dataclass(frozen=True)
+class OrphanDetectionResult:
+    """Result of scanning a store for orphaned episodes."""
+
+    orphans: List[OrphanedEpisode] = field(default_factory=list)
+    total_traces_scanned: int = 0
+    total_episodes_found: int = 0
+    total_orphans_found: int = 0
+    scanned_at: str = ""
+
+    @property
+    def clean(self) -> bool:
+        """True if no orphaned episodes were found."""
+        return self.total_orphans_found == 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "clean": self.clean,
+            "total_traces_scanned": self.total_traces_scanned,
+            "total_episodes_found": self.total_episodes_found,
+            "total_orphans_found": self.total_orphans_found,
+            "scanned_at": self.scanned_at,
+            "orphans": [orphan.to_dict() for orphan in self.orphans],
+        }
+
+
+def _extract_episode_id(entry: Dict[str, Any]) -> Optional[str]:
+    """Extract episode_id from a trace entry."""
+    return entry.get("episode_id") or None
+
+
+def _extract_receipt_type(entry: Dict[str, Any]) -> str:
+    """Extract receipt type from a trace entry."""
+    return str(entry.get("type") or entry.get("receipt_type") or "")
+
+
+def _extract_timestamp(entry: Dict[str, Any]) -> str:
+    """Extract timestamp from a trace entry."""
+    return str(entry.get("timestamp") or entry.get("_stored_at") or "")
+
+
+def detect_orphaned_episodes(
+    store: AssayStore,
+    *,
+    max_traces: int = 1000,
+) -> OrphanDetectionResult:
+    """Scan a store for orphaned episodes.
+
+    An orphaned episode is one that has an `episode.opened` receipt
+    but no `episode.closed` or `episode.abandoned` receipt in the
+    same trace.
+
+    This is a pure-read operation. It never mutates the store.
+
+    Args:
+        store: The AssayStore to scan.
+        max_traces: Maximum number of traces to scan (most recent first).
+
+    Returns:
+        OrphanDetectionResult with all findings.
+    """
+    scanned_at = datetime.now(timezone.utc).isoformat()
+    traces = store.list_traces(limit=max_traces)
+
+    orphans: List[OrphanedEpisode] = []
+    total_episodes = 0
+
+    for trace_meta in traces:
+        trace_id = trace_meta["trace_id"]
+        trace_path = trace_meta.get("path")
+        entries = store.read_trace(trace_id)
+        if not entries:
+            continue
+
+        # Track episodes within this trace
+        episodes_in_trace: Dict[str, Dict[str, Any]] = {}
+
+        for entry in entries:
+            receipt_type = _extract_receipt_type(entry)
+            episode_id = _extract_episode_id(entry)
+
+            if receipt_type == OPENED_RECEIPT_TYPE and episode_id:
+                if episode_id not in episodes_in_trace:
+                    episodes_in_trace[episode_id] = {
+                        "opened_at": _extract_timestamp(entry),
+                        "receipt_count": 0,
+                        "last_receipt_type": receipt_type,
+                        "last_receipt_at": _extract_timestamp(entry),
+                        "terminalized": False,
+                    }
+
+            if episode_id and episode_id in episodes_in_trace:
+                info = episodes_in_trace[episode_id]
+                info["receipt_count"] += 1
+                info["last_receipt_type"] = receipt_type
+                info["last_receipt_at"] = _extract_timestamp(entry)
+
+                if receipt_type in TERMINAL_RECEIPT_TYPES:
+                    info["terminalized"] = True
+
+        total_episodes += len(episodes_in_trace)
+
+        for episode_id, info in episodes_in_trace.items():
+            if not info["terminalized"]:
+                orphans.append(OrphanedEpisode(
+                    episode_id=episode_id,
+                    trace_id=trace_id,
+                    opened_at=info["opened_at"],
+                    receipt_count=info["receipt_count"],
+                    last_receipt_type=info["last_receipt_type"],
+                    last_receipt_at=info["last_receipt_at"],
+                    trace_path=trace_path,
+                ))
+
+    return OrphanDetectionResult(
+        orphans=orphans,
+        total_traces_scanned=len(traces),
+        total_episodes_found=total_episodes,
+        total_orphans_found=len(orphans),
+        scanned_at=scanned_at,
+    )
+
+
+def check_episode_health(
+    store: AssayStore,
+    *,
+    max_traces: int = 1000,
+    loud: bool = True,
+) -> bool:
+    """Run orphan detection and optionally print findings.
+
+    Returns True if the store is clean (no orphans).
+    Returns False if orphaned episodes are found.
+
+    This is the entry point for CI/startup health checks.
+    """
+    result = detect_orphaned_episodes(store, max_traces=max_traces)
+
+    if loud and not result.clean:
+        import sys
+        print(
+            f"[CONSTITUTIONAL VIOLATION] {result.total_orphans_found} orphaned episode(s) detected",
+            file=sys.stderr,
+        )
+        for orphan in result.orphans:
+            print(
+                f"  orphan: episode_id={orphan.episode_id} "
+                f"trace={orphan.trace_id} "
+                f"opened_at={orphan.opened_at} "
+                f"receipts={orphan.receipt_count} "
+                f"last={orphan.last_receipt_type}",
+                file=sys.stderr,
+            )
+
+    return result.clean

--- a/tests/assay/test_episode_abandoned.py
+++ b/tests/assay/test_episode_abandoned.py
@@ -1,0 +1,276 @@
+"""
+Episode ABANDONED Receipt Tests
+
+Kernel Gap Ledger Row #1: Episode Termination
+Bypass class: silent terminal state (ABANDONED)
+Proof of closure: these tests prove ABANDONED can never be silent epistemic death.
+
+Constitutional law:
+    No episode may enter a terminal state without emitting a typed receipt.
+    ABANDONED is a terminal state. It must leave a forensic trace.
+    Closed episodes reject all transitions (no zombie emission).
+"""
+
+import pytest
+from assay.episode import (
+    Episode,
+    EpisodeClosedError,
+    EpisodeState,
+    EpisodeStateError,
+    open_episode,
+)
+from assay.store import AssayStore
+
+
+@pytest.fixture
+def tmp_store(tmp_path):
+    """Create a temporary AssayStore for test isolation."""
+    return AssayStore(base_dir=tmp_path / "assay_store")
+
+
+def _find_receipts_by_type(ep: Episode, receipt_type: str):
+    """Find all receipts of a given type in the episode."""
+    return [r for r in ep.receipts if r.receipt_type == receipt_type]
+
+
+# ---------------------------------------------------------------------------
+# 1. ABANDONED emits typed receipt from every source state
+# ---------------------------------------------------------------------------
+
+class TestAbandonedEmitsReceipt:
+    """Entering ABANDONED must always emit a typed episode.abandoned receipt."""
+
+    def test_abandon_from_open(self, tmp_store):
+        """OPEN -> ABANDONED emits episode.abandoned with abandoned_from='open'."""
+        ep = open_episode(store=tmp_store)
+        ep.transition(EpisodeState.ABANDONED)
+
+        abandoned = _find_receipts_by_type(ep, "episode.abandoned")
+        assert len(abandoned) == 1
+        assert abandoned[0].payload["abandoned_from"] == "open"
+        assert ep.state == EpisodeState.ABANDONED
+        assert ep._closed is True
+
+    def test_abandon_from_executing(self, tmp_store):
+        """EXECUTING -> ABANDONED emits episode.abandoned with abandoned_from='executing'."""
+        ep = open_episode(store=tmp_store)
+        ep.transition(EpisodeState.EXECUTING)
+        ep.transition(EpisodeState.ABANDONED)
+
+        abandoned = _find_receipts_by_type(ep, "episode.abandoned")
+        assert len(abandoned) == 1
+        assert abandoned[0].payload["abandoned_from"] == "executing"
+
+    def test_abandon_from_awaiting_guardian(self, tmp_store):
+        """AWAITING_GUARDIAN -> ABANDONED records source state."""
+        ep = open_episode(store=tmp_store)
+        ep.transition(EpisodeState.EXECUTING)
+        ep.transition(EpisodeState.AWAITING_GUARDIAN)
+        ep.transition(EpisodeState.ABANDONED)
+
+        abandoned = _find_receipts_by_type(ep, "episode.abandoned")
+        assert len(abandoned) == 1
+        assert abandoned[0].payload["abandoned_from"] == "awaiting_guardian"
+
+    def test_abandon_from_settled(self, tmp_store):
+        """SETTLED -> ABANDONED records source state."""
+        ep = open_episode(store=tmp_store)
+        ep.transition(EpisodeState.EXECUTING)
+        ep.transition(EpisodeState.AWAITING_GUARDIAN)
+        ep.transition(EpisodeState.SETTLED)
+        ep.transition(EpisodeState.ABANDONED)
+
+        abandoned = _find_receipts_by_type(ep, "episode.abandoned")
+        assert len(abandoned) == 1
+        assert abandoned[0].payload["abandoned_from"] == "settled"
+
+
+# ---------------------------------------------------------------------------
+# 2. ABANDONED receipt has correct forensic content
+# ---------------------------------------------------------------------------
+
+class TestAbandonedReceiptContent:
+    """The abandoned receipt must contain full forensic information."""
+
+    def test_abandoned_receipt_has_episode_id(self, tmp_store):
+        """episode.abandoned receipt has the correct episode_id."""
+        ep = open_episode(store=tmp_store)
+        episode_id = ep.episode_id
+        ep.transition(EpisodeState.ABANDONED)
+
+        abandoned = _find_receipts_by_type(ep, "episode.abandoned")
+        assert len(abandoned) == 1
+        assert abandoned[0].episode_id == episode_id
+
+    def test_abandoned_receipt_has_abandoned_at(self, tmp_store):
+        """episode.abandoned receipt records the abandonment timestamp."""
+        ep = open_episode(store=tmp_store)
+        ep.transition(EpisodeState.ABANDONED)
+
+        abandoned = _find_receipts_by_type(ep, "episode.abandoned")
+        assert "abandoned_at" in abandoned[0].payload
+
+    def test_abandoned_receipt_has_receipt_count(self, tmp_store):
+        """episode.abandoned receipt records how many receipts existed at abandon time."""
+        ep = open_episode(store=tmp_store)
+        ep.emit("model.invoked", {"model": "test"})
+        ep.transition(EpisodeState.ABANDONED)
+
+        abandoned = _find_receipts_by_type(ep, "episode.abandoned")
+        # receipt_count should reflect receipts before abandon (opened + model.invoked = 2)
+        assert abandoned[0].payload["receipt_count"] >= 2
+
+    def test_abandon_also_emits_episode_closed(self, tmp_store):
+        """Transitioning to ABANDONED also emits episode.closed with status=abandoned."""
+        ep = open_episode(store=tmp_store)
+        ep.transition(EpisodeState.ABANDONED)
+
+        closed = _find_receipts_by_type(ep, "episode.closed")
+        assert len(closed) == 1
+        assert closed[0].payload["status"] == "abandoned"
+
+
+# ---------------------------------------------------------------------------
+# 3. ABANDONED closes the episode (immutability)
+# ---------------------------------------------------------------------------
+
+class TestAbandonedClosesEpisode:
+    """After ABANDONED, the episode is closed and immutable."""
+
+    def test_abandon_sets_closed_flag(self, tmp_store):
+        """ABANDONED sets _closed=True."""
+        ep = open_episode(store=tmp_store)
+        ep.transition(EpisodeState.ABANDONED)
+        assert ep._closed is True
+
+    def test_abandon_prevents_further_emission(self, tmp_store):
+        """After ABANDONED, emit() raises EpisodeClosedError."""
+        ep = open_episode(store=tmp_store)
+        ep.transition(EpisodeState.ABANDONED)
+
+        with pytest.raises(EpisodeClosedError):
+            ep.emit("test.receipt", {"data": "should fail"})
+
+    def test_abandon_is_idempotent_on_close(self, tmp_store):
+        """Calling close() after abandon doesn't emit duplicate receipts."""
+        ep = open_episode(store=tmp_store)
+        ep.transition(EpisodeState.ABANDONED)
+        receipts_after_abandon = len(ep.receipts)
+
+        ep.close(status="abandoned")  # should be idempotent
+        assert len(ep.receipts) == receipts_after_abandon
+
+
+# ---------------------------------------------------------------------------
+# 4. P1 REGRESSION: closed episodes reject all transitions (no zombies)
+# ---------------------------------------------------------------------------
+
+class TestClosedEpisodeRejectsTransition:
+    """A closed episode must reject all state transitions.
+
+    This is the P1 regression guard. Without this, a caller could:
+        ep.close()
+        ep.transition(EpisodeState.ABANDONED)  # zombie emission!
+    """
+
+    def test_close_then_abandon_raises(self, tmp_store):
+        """close() then transition(ABANDONED) raises EpisodeStateError."""
+        ep = open_episode(store=tmp_store)
+        ep.close(status="completed")
+
+        with pytest.raises(EpisodeStateError, match="closed"):
+            ep.transition(EpisodeState.ABANDONED)
+
+    def test_close_then_any_transition_raises(self, tmp_store):
+        """close() then any transition raises."""
+        ep = open_episode(store=tmp_store)
+        ep.close(status="completed")
+
+        for state in [EpisodeState.EXECUTING, EpisodeState.ABANDONED]:
+            with pytest.raises(EpisodeStateError, match="closed"):
+                ep.transition(state)
+
+    def test_abandon_then_second_abandon_raises(self, tmp_store):
+        """Double abandon raises (first abandon closes, second is rejected)."""
+        ep = open_episode(store=tmp_store)
+        ep.transition(EpisodeState.ABANDONED)
+
+        with pytest.raises(EpisodeStateError, match="closed"):
+            ep.transition(EpisodeState.ABANDONED)
+
+    def test_no_receipts_emitted_after_close(self, tmp_store):
+        """No new receipts are added when transition is rejected on closed episode."""
+        ep = open_episode(store=tmp_store)
+        ep.close(status="completed")
+        count_after_close = len(ep.receipts)
+
+        with pytest.raises(EpisodeStateError):
+            ep.transition(EpisodeState.ABANDONED)
+
+        assert len(ep.receipts) == count_after_close  # nothing added
+
+
+# ---------------------------------------------------------------------------
+# 5. Context manager interaction
+# ---------------------------------------------------------------------------
+
+class TestAbandonedContextManager:
+    """ABANDONED interacts correctly with context manager."""
+
+    def test_context_manager_exception_closes_episode(self, tmp_store):
+        """Exception in with block emits episode.closed with status=failed."""
+        with pytest.raises(ValueError):
+            with open_episode(store=tmp_store) as ep:
+                raise ValueError("boom")
+
+        assert ep._closed is True
+        closed = _find_receipts_by_type(ep, "episode.closed")
+        assert len(closed) == 1
+        assert closed[0].payload["status"] == "failed"
+
+    def test_bare_open_then_abandon_works(self, tmp_store):
+        """open_episode() without with, then explicit abandon, works."""
+        ep = open_episode(store=tmp_store)
+        ep.emit("model.invoked", {"model": "test"})
+        ep.transition(EpisodeState.ABANDONED)
+
+        assert ep._closed is True
+        abandoned = _find_receipts_by_type(ep, "episode.abandoned")
+        assert len(abandoned) == 1
+        closed = _find_receipts_by_type(ep, "episode.closed")
+        assert len(closed) == 1
+
+
+# ---------------------------------------------------------------------------
+# 6. No silent epistemic death
+# ---------------------------------------------------------------------------
+
+class TestNoSilentEpistemicDeath:
+    """The constitutional invariant: no episode disappears without trace."""
+
+    def test_every_abandon_path_produces_typed_receipts(self, tmp_store):
+        """Any path to ABANDONED produces exactly one episode.abandoned + one episode.closed."""
+        for source_states in [
+            [],                    # OPEN -> ABANDONED
+            [EpisodeState.EXECUTING],  # EXECUTING -> ABANDONED
+        ]:
+            ep = open_episode(store=tmp_store)
+            for s in source_states:
+                ep.transition(s)
+            ep.transition(EpisodeState.ABANDONED)
+
+            abandoned = _find_receipts_by_type(ep, "episode.abandoned")
+            closed = _find_receipts_by_type(ep, "episode.closed")
+            assert len(abandoned) == 1, f"Expected 1 abandoned receipt, got {len(abandoned)}"
+            assert len(closed) == 1, f"Expected 1 closed receipt, got {len(closed)}"
+
+    def test_opened_receipt_always_present(self, tmp_store):
+        """Even the most minimal episode has episode.opened."""
+        ep = open_episode(store=tmp_store)
+        opened = _find_receipts_by_type(ep, "episode.opened")
+        assert len(opened) == 1
+
+        ep.transition(EpisodeState.ABANDONED)
+        # Still has the opened receipt
+        opened = _find_receipts_by_type(ep, "episode.opened")
+        assert len(opened) == 1

--- a/tests/assay/test_orphan_detector.py
+++ b/tests/assay/test_orphan_detector.py
@@ -1,0 +1,292 @@
+"""
+Episode Orphan Detection Tests
+
+Kernel Gap Ledger Row #1, Bypass #4: Assay optional context manager.
+Proof that the orphan detector correctly identifies episodes that
+were opened but never terminalized.
+
+Constitutional law:
+    Every episode must terminate constitutionally: either by a typed
+    terminal receipt, or by an explicit detector-reported constitutional
+    violation.
+
+These tests prove:
+    1. Bare open_episode() without close is detected as orphan
+    2. Context-manager episodes are NOT flagged
+    3. Explicitly abandoned episodes are NOT flagged
+    4. Explicitly closed episodes are NOT flagged
+    5. Mixed stores (some orphaned, some healthy) report correctly
+    6. Empty stores report clean
+    7. Legacy traces (no episode.opened) are not false positives
+    8. Detector is pure-read (store not mutated)
+    9. check_episode_health returns correct boolean
+    10. Multiple orphans in the same store are all reported
+"""
+
+import pytest
+
+from assay.episode import (
+    Episode,
+    EpisodeState,
+    open_episode,
+)
+from assay.orphan_detector import (
+    OrphanDetectionResult,
+    OrphanedEpisode,
+    check_episode_health,
+    detect_orphaned_episodes,
+)
+from assay.store import AssayStore
+
+
+@pytest.fixture
+def tmp_store(tmp_path):
+    """Create a temporary AssayStore for test isolation."""
+    return AssayStore(base_dir=tmp_path / "assay_store")
+
+
+# ---------------------------------------------------------------------------
+# 1. Orphan detection: bare open_episode without close
+# ---------------------------------------------------------------------------
+
+
+class TestOrphanDetection:
+    """Detector finds episodes opened but never closed."""
+
+    def test_bare_open_episode_is_detected(self, tmp_store):
+        """An episode opened without close/abandon is an orphan."""
+        ep = open_episode(store=tmp_store)
+        ep.emit("model.invoked", {"model": "test"})
+        # Deliberately NOT closing -- this is the orphan scenario
+        episode_id = ep.episode_id
+
+        result = detect_orphaned_episodes(tmp_store)
+
+        assert not result.clean
+        assert result.total_orphans_found == 1
+        assert result.orphans[0].episode_id == episode_id
+
+    def test_bare_open_no_emit_is_detected(self, tmp_store):
+        """Even an episode with zero user receipts (just episode.opened) is an orphan."""
+        ep = open_episode(store=tmp_store)
+        episode_id = ep.episode_id
+
+        result = detect_orphaned_episodes(tmp_store)
+
+        assert not result.clean
+        assert result.total_orphans_found == 1
+        assert result.orphans[0].episode_id == episode_id
+        assert result.orphans[0].receipt_count == 1  # just episode.opened
+
+    def test_multiple_orphans_all_reported(self, tmp_store):
+        """Multiple orphaned episodes in the same store are all found."""
+        ep1 = open_episode(store=tmp_store)
+        ep2 = open_episode(store=tmp_store)
+        ep3 = open_episode(store=tmp_store)
+
+        result = detect_orphaned_episodes(tmp_store)
+
+        assert result.total_orphans_found == 3
+        orphan_ids = {o.episode_id for o in result.orphans}
+        assert ep1.episode_id in orphan_ids
+        assert ep2.episode_id in orphan_ids
+        assert ep3.episode_id in orphan_ids
+
+
+# ---------------------------------------------------------------------------
+# 2. Healthy episodes are NOT flagged
+# ---------------------------------------------------------------------------
+
+
+class TestHealthyEpisodesNotFlagged:
+    """Properly closed/abandoned episodes are not false positives."""
+
+    def test_context_manager_episode_not_flagged(self, tmp_store):
+        """Episode used with `with` block is closed by __exit__."""
+        with open_episode(store=tmp_store) as ep:
+            ep.emit("model.invoked", {"model": "test"})
+
+        result = detect_orphaned_episodes(tmp_store)
+        assert result.clean
+        assert result.total_orphans_found == 0
+
+    def test_explicitly_closed_episode_not_flagged(self, tmp_store):
+        """Episode explicitly closed is not an orphan."""
+        ep = open_episode(store=tmp_store)
+        ep.emit("model.invoked", {"model": "test"})
+        ep.close()
+
+        result = detect_orphaned_episodes(tmp_store)
+        assert result.clean
+
+    def test_explicitly_abandoned_episode_not_flagged(self, tmp_store):
+        """Episode abandoned via transition(ABANDONED) is not an orphan."""
+        ep = open_episode(store=tmp_store)
+        ep.emit("model.invoked", {"model": "test"})
+        ep.transition(EpisodeState.ABANDONED)
+
+        result = detect_orphaned_episodes(tmp_store)
+        assert result.clean
+
+    def test_context_manager_with_exception_not_flagged(self, tmp_store):
+        """Episode where context manager catches exception is still closed."""
+        with pytest.raises(ValueError):
+            with open_episode(store=tmp_store) as ep:
+                ep.emit("model.invoked", {"model": "test"})
+                raise ValueError("boom")
+
+        result = detect_orphaned_episodes(tmp_store)
+        assert result.clean
+
+    def test_settled_and_closed_episode_not_flagged(self, tmp_store):
+        """Episode that goes through full lifecycle is not an orphan."""
+        with open_episode(store=tmp_store) as ep:
+            ep.emit("model.invoked", {"model": "test"})
+            ep.emit("guardian.approved", {"action": "test"})
+
+        result = detect_orphaned_episodes(tmp_store)
+        assert result.clean
+
+
+# ---------------------------------------------------------------------------
+# 3. Mixed stores
+# ---------------------------------------------------------------------------
+
+
+class TestMixedStores:
+    """Stores with both healthy and orphaned episodes report correctly."""
+
+    def test_mixed_healthy_and_orphaned(self, tmp_store):
+        """One healthy + one orphaned = 1 orphan reported."""
+        # Healthy
+        with open_episode(store=tmp_store) as ep1:
+            ep1.emit("model.invoked", {"model": "test"})
+
+        # Orphan
+        ep2 = open_episode(store=tmp_store)
+        ep2.emit("model.invoked", {"model": "test"})
+
+        result = detect_orphaned_episodes(tmp_store)
+
+        assert not result.clean
+        assert result.total_orphans_found == 1
+        assert result.total_episodes_found == 2
+        assert result.orphans[0].episode_id == ep2.episode_id
+
+    def test_mixed_abandoned_and_orphaned(self, tmp_store):
+        """One abandoned + one orphaned = 1 orphan reported."""
+        # Abandoned (healthy)
+        ep1 = open_episode(store=tmp_store)
+        ep1.transition(EpisodeState.ABANDONED)
+
+        # Orphan
+        ep2 = open_episode(store=tmp_store)
+
+        result = detect_orphaned_episodes(tmp_store)
+
+        assert result.total_orphans_found == 1
+        assert result.orphans[0].episode_id == ep2.episode_id
+
+
+# ---------------------------------------------------------------------------
+# 4. Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Edge cases: empty stores, legacy traces, detector purity."""
+
+    def test_empty_store_is_clean(self, tmp_store):
+        """An empty store has no orphans."""
+        result = detect_orphaned_episodes(tmp_store)
+
+        assert result.clean
+        assert result.total_traces_scanned == 0
+        assert result.total_episodes_found == 0
+        assert result.total_orphans_found == 0
+
+    def test_detector_does_not_mutate_store(self, tmp_store):
+        """Detector is pure-read: running it doesn't change the trace."""
+        ep = open_episode(store=tmp_store)
+        ep.emit("model.invoked", {"model": "test"})
+
+        trace_before = tmp_store.read_trace(ep.trace_id)
+        detect_orphaned_episodes(tmp_store)
+        trace_after = tmp_store.read_trace(ep.trace_id)
+
+        assert len(trace_before) == len(trace_after)
+        for before, after in zip(trace_before, trace_after):
+            # Exclude runtime metadata that might differ
+            b = {k: v for k, v in before.items() if not k.startswith("_")}
+            a = {k: v for k, v in after.items() if not k.startswith("_")}
+            assert b == a
+
+    def test_result_has_scanned_at(self, tmp_store):
+        """Result includes a scan timestamp."""
+        result = detect_orphaned_episodes(tmp_store)
+        assert result.scanned_at != ""
+
+    def test_orphan_has_forensic_fields(self, tmp_store):
+        """Orphaned episode report has all forensic fields populated."""
+        ep = open_episode(store=tmp_store)
+        ep.emit("model.invoked", {"model": "test"})
+
+        result = detect_orphaned_episodes(tmp_store)
+        orphan = result.orphans[0]
+
+        assert orphan.episode_id == ep.episode_id
+        assert orphan.trace_id == ep.trace_id
+        assert orphan.opened_at != ""
+        assert orphan.receipt_count == 2  # episode.opened + model.invoked
+        assert orphan.last_receipt_type == "model.invoked"
+        assert orphan.last_receipt_at != ""
+
+    def test_to_dict_round_trips(self, tmp_store):
+        """OrphanDetectionResult.to_dict() returns serializable data."""
+        ep = open_episode(store=tmp_store)
+
+        result = detect_orphaned_episodes(tmp_store)
+        d = result.to_dict()
+
+        assert isinstance(d, dict)
+        assert d["clean"] is False
+        assert d["total_orphans_found"] == 1
+        assert len(d["orphans"]) == 1
+        assert d["orphans"][0]["episode_id"] == ep.episode_id
+
+
+# ---------------------------------------------------------------------------
+# 5. check_episode_health integration
+# ---------------------------------------------------------------------------
+
+
+class TestCheckEpisodeHealth:
+    """The CI/startup entry point returns correct booleans."""
+
+    def test_health_check_returns_true_for_clean_store(self, tmp_store):
+        """Clean store returns True."""
+        with open_episode(store=tmp_store) as ep:
+            ep.emit("model.invoked", {"model": "test"})
+
+        assert check_episode_health(tmp_store, loud=False) is True
+
+    def test_health_check_returns_false_for_orphaned_store(self, tmp_store):
+        """Orphaned store returns False."""
+        ep = open_episode(store=tmp_store)
+        ep.emit("model.invoked", {"model": "test"})
+
+        assert check_episode_health(tmp_store, loud=False) is False
+
+    def test_health_check_loud_prints_to_stderr(self, tmp_store, capsys):
+        """Loud mode prints orphan details to stderr."""
+        ep = open_episode(store=tmp_store)
+
+        check_episode_health(tmp_store, loud=True)
+
+        captured = capsys.readouterr()
+        assert "CONSTITUTIONAL VIOLATION" in captured.err
+        assert ep.episode_id in captured.err
+
+    def test_health_check_empty_store_is_clean(self, tmp_store):
+        """Empty store is healthy."""
+        assert check_episode_health(tmp_store, loud=False) is True


### PR DESCRIPTION
## Summary
- Enforce closed episode immutability — reject transitions after close, including same-state re-close
- Emit typed ABANDONED receipt only on valid pre-close path
- Episode orphan detector: detect bare `open_episode()` calls that were never closed/abandoned/settled
- `check_episode_health()` for CI/operator integrity checks

Kernel Gap Ledger Row #1, Bypass #4.

## Test plan
- [ ] 38 episode lifecycle tests pass (`pytest tests/assay/test_episode_abandoned.py tests/assay/test_orphan_detector.py`)
- [ ] Orphan detector does not mutate store (read-only check)
- [ ] Context-managed and explicitly-closed episodes are not false-flagged
- [ ] Mixed healthy + orphaned stores correctly partitioned

🤖 Generated with [Claude Code](https://claude.com/claude-code)