### PR TITLE
feat(decision-receipt): assert_tier_monotonic — Row 3, Stage 2

### DIFF
--- a/src/assay/decision_receipt.py
+++ b/src/assay/decision_receipt.py
@@ -106,10 +106,48 @@ class TierEscalationError(ValueError):
     """
 
 
+@dataclass(frozen=True)
+class JudgmentPathDeclaration:
+    """Typed declaration that an authorized judgment path was on the predecessor chain.
+
+    Use this instead of a bare boolean to make authority provenance explicit and
+    auditable. Passing this to assert_tier_monotonic means the caller is making a
+    constitutional declaration: governance was reached through authorized judgment,
+    not through composition of evidence receipts alone.
+
+    This is an assertion, not a receipt. It does not replace proper lineage
+    tracking but makes the declaration legible in operator context.
+
+    Fields:
+        reason: Non-empty description of why governance authority is declared.
+            Must be substantive — empty or whitespace-only strings are rejected.
+        authority_ref: Optional reference to the authorizing receipt ID, Guardian
+            judgment ID, or policy reference that grounds this declaration.
+        declared_by: Optional identifier of the subsystem or agent making this
+            declaration (e.g. "ccio:guardian:settlement_seat").
+
+    Future hardening (not enforced now):
+        - reason length / substantiveness check (reject "x", "override", etc.)
+        - authority_ref presence required for OVERRIDING authority class
+        - serialization of declaration context into the Decision Receipt payload
+    """
+    reason: str
+    authority_ref: Optional[str] = None
+    declared_by: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not self.reason.strip():
+            raise ValueError(
+                "JudgmentPathDeclaration.reason must be non-empty. "
+                "Provide a substantive description of why governance authority "
+                "is declared on this path."
+            )
+
+
 def assert_tier_monotonic(
     predecessor_authority_layers: List[str],
     *,
-    authorized_judgment_path: bool = False,
+    authorized_judgment_path: Optional[JudgmentPathDeclaration] = None,
 ) -> None:
     """Assert that a Decision Receipt (GOVERNANCE tier) may be emitted from
     the given predecessor authority layers.
@@ -122,20 +160,27 @@ def assert_tier_monotonic(
         predecessor_authority_layers: Authority layer of each predecessor
             receipt in the chain. Values: "EVIDENCE", "CONTINUITY",
             "GOVERNANCE". An empty list is treated as unchecked (no-op).
-        authorized_judgment_path: Set True when an authorized judgment
-            (Guardian, settlement) was on the path — even if not reflected
-            as a GOVERNANCE predecessor in the layer list. This is a
-            declaration by the caller, not a silent bypass.
+
+            Note: [] (empty) is currently conflated with "lineage unknown",
+            "lineage complete but empty", and "lineage redacted". These are
+            distinct organism states. See predecessor_completeness planning note
+            in ROW3_RECEIPT_COMPOSITION_DRAFT.md.
+
+        authorized_judgment_path: A JudgmentPathDeclaration when an authorized
+            judgment (Guardian, settlement) was on the path — even if not
+            reflected as a GOVERNANCE predecessor in the layer list. Requires
+            a non-empty reason. This is a typed declaration by the caller,
+            not a silent boolean bypass.
 
     Raises:
         TierEscalationError: if no predecessor is GOVERNANCE-tier and
-            authorized_judgment_path is False.
+            authorized_judgment_path is None.
     """
     if not predecessor_authority_layers:
         return  # No predecessors provided — no assertion possible
 
-    if authorized_judgment_path:
-        return  # Caller declares an authorized judgment path exists
+    if authorized_judgment_path is not None:
+        return  # Caller provided a typed JudgmentPathDeclaration
 
     governance_rank = AUTHORITY_LAYER_RANK["GOVERNANCE"]
     has_governance_predecessor = any(
@@ -380,6 +425,7 @@ __all__ = [
     "PROOF_TIER_RANK",
     "AUTHORITY_LAYER_RANK",
     "TierEscalationError",
+    "JudgmentPathDeclaration",
     "assert_tier_monotonic",
     "ValidationError",
     "ValidationResult",

--- a/tests/assay/test_decision_receipt.py
+++ b/tests/assay/test_decision_receipt.py
@@ -17,6 +17,7 @@ from assay.decision_receipt import (
     LAYER_INVARIANTS,
     LAYER_SHAPE,
     PROOF_TIER_RANK,
+    JudgmentPathDeclaration,
     TierEscalationError,
     assert_tier_monotonic,
     validate_decision_receipt,
@@ -460,6 +461,60 @@ class TestTierEscalationError:
         assert TierEscalationError is not ValueError
 
 
+class TestJudgmentPathDeclaration:
+    """JudgmentPathDeclaration is a typed, validated, auditable override assertion."""
+
+    def test_valid_reason_accepted(self):
+        decl = JudgmentPathDeclaration(reason="Guardian evaluated evidence and issued judgment")
+        assert decl.reason == "Guardian evaluated evidence and issued judgment"
+
+    def test_empty_reason_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            JudgmentPathDeclaration(reason="")
+
+    def test_whitespace_only_reason_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            JudgmentPathDeclaration(reason="   ")
+
+    def test_authority_ref_defaults_to_none(self):
+        decl = JudgmentPathDeclaration(reason="settlement judgment issued")
+        assert decl.authority_ref is None
+
+    def test_declared_by_defaults_to_none(self):
+        decl = JudgmentPathDeclaration(reason="settlement judgment issued")
+        assert decl.declared_by is None
+
+    def test_authority_ref_can_be_set(self):
+        decl = JudgmentPathDeclaration(
+            reason="settlement judgment issued",
+            authority_ref="receipt:guardian-judgment-abc123",
+        )
+        assert decl.authority_ref == "receipt:guardian-judgment-abc123"
+
+    def test_declared_by_can_be_set(self):
+        decl = JudgmentPathDeclaration(
+            reason="settlement judgment issued",
+            declared_by="ccio:guardian:settlement_seat",
+        )
+        assert decl.declared_by == "ccio:guardian:settlement_seat"
+
+    def test_is_frozen(self):
+        """Declaration is immutable — not patchable after construction."""
+        decl = JudgmentPathDeclaration(reason="settlement judgment issued")
+        with pytest.raises((AttributeError, TypeError)):
+            decl.reason = "something else"  # type: ignore[misc]
+
+    def test_equality_by_value(self):
+        d1 = JudgmentPathDeclaration(reason="same reason", authority_ref="ref-1")
+        d2 = JudgmentPathDeclaration(reason="same reason", authority_ref="ref-1")
+        assert d1 == d2
+
+    def test_inequality_on_reason_difference(self):
+        d1 = JudgmentPathDeclaration(reason="reason A")
+        d2 = JudgmentPathDeclaration(reason="reason B")
+        assert d1 != d2
+
+
 class TestAssertTierMonotonic:
     """assert_tier_monotonic enforces: GOVERNANCE cannot be emitted from EVIDENCE-only chain."""
 
@@ -490,12 +545,28 @@ class TestAssertTierMonotonic:
     def test_all_three_layers_passes(self):
         assert_tier_monotonic(["EVIDENCE", "CONTINUITY", "GOVERNANCE"])  # must not raise
 
-    # Pass cases — authorized judgment path declared
-    def test_evidence_with_authorized_path_passes(self):
-        assert_tier_monotonic(["EVIDENCE"], authorized_judgment_path=True)  # must not raise
+    # Pass cases — typed JudgmentPathDeclaration
+    def test_evidence_with_declaration_passes(self):
+        decl = JudgmentPathDeclaration(
+            reason="Guardian evaluated evidence and issued settlement judgment",
+            authority_ref="receipt:guardian-judgment-001",
+            declared_by="ccio:guardian:settlement_seat",
+        )
+        assert_tier_monotonic(["EVIDENCE"], authorized_judgment_path=decl)  # must not raise
 
-    def test_continuity_with_authorized_path_passes(self):
-        assert_tier_monotonic(["CONTINUITY"], authorized_judgment_path=True)  # must not raise
+    def test_continuity_with_declaration_passes(self):
+        decl = JudgmentPathDeclaration(reason="Settlement outcome authorized this emission")
+        assert_tier_monotonic(["CONTINUITY"], authorized_judgment_path=decl)  # must not raise
+
+    def test_declaration_without_authority_ref_passes(self):
+        """authority_ref is optional — minimal valid declaration still passes."""
+        decl = JudgmentPathDeclaration(reason="Guardian judgment on file")
+        assert_tier_monotonic(["EVIDENCE"], authorized_judgment_path=decl)  # must not raise
+
+    def test_none_declaration_does_not_pass_evidence_chain(self):
+        """Explicit None is not a declaration — same as omitting it."""
+        with pytest.raises(TierEscalationError):
+            assert_tier_monotonic(["EVIDENCE"], authorized_judgment_path=None)
 
     def test_empty_list_passes(self):
         """Empty predecessor list is unchecked — no assertion possible."""


### PR DESCRIPTION
## Summary

- Implements proof-tier monotonicity guard at Decision Receipt emitter boundary
- Core invariant: **aggregation does not create authority** (RECEIPT_AUTHORITY_LADDER.md)
- `TierEscalationError(ValueError)` — named, non-swallowable  
- `AUTHORITY_LAYER_RANK` — ordinal map `{EVIDENCE: 0, CONTINUITY: 1, GOVERNANCE: 2}`
- `assert_tier_monotonic(predecessor_authority_layers, *, authorized_judgment_path=False)` — raises if all predecessors below GOVERNANCE and no authorized path declared

## What this closes

Row 3, Stage 2 of the enforcement checklist in `ccio/docs/constitution/ROW3_RECEIPT_COMPOSITION_DRAFT.md`. The companion ccio commit wires this guard into `build_canonical_decision_receipt`.

## Test plan

- [ ] `TestAuthorityLayerRank` (3): ordinal table correctness
- [ ] `TestTierEscalationError` (3): is ValueError, message preserved, distinct type
- [ ] `TestAssertTierMonotonic` (11): evidence-only raises, continuity-only raises, mixed raises; GOVERNANCE passes; authorized_judgment_path=True passes; empty list no-op; error message quality
- [ ] 68 total tests, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)