### PR TITLE
feat(doctor): Stage 3a — contradiction closure check in assay doctor

### DIFF
--- a/src/assay/commands.py
+++ b/src/assay/commands.py
@@ -7309,6 +7309,10 @@ def doctor_cmd(
         False, "--fix",
         help="Apply safe automatic fixes (generate key, write lockfile)",
     ),
+    check_orphans: bool = typer.Option(
+        False, "--check-orphans",
+        help="Also detect orphaned episodes and open contradictions (store-backed checks)",
+    ),
 ):
     """Check if Assay is installed, configured, and ready to use.
 
@@ -7317,6 +7321,10 @@ def doctor_cmd(
     2. Can this machine create and verify packs?
     3. Is this repo configured for your claimed workflow?
     4. What is the single next command to become "green"?
+
+    Use --check-orphans to also detect constitutional integrity violations:
+    orphaned episodes (opened but never closed) and open contradictions
+    (registered but never resolved).
     """
     from pathlib import Path
 
@@ -7333,7 +7341,13 @@ def doctor_cmd(
     lock_path = Path(lock) if lock else None
 
     # Run checks
-    report = run_doctor(prof, pack_dir=pack_dir, lock_path=lock_path, strict=strict)
+    report = run_doctor(
+        prof,
+        pack_dir=pack_dir,
+        lock_path=lock_path,
+        strict=strict,
+        check_orphans=check_orphans,
+    )
 
     # Apply fixes if requested
     if fix:

--- a/src/assay/contradiction_detector.py
+++ b/src/assay/contradiction_detector.py
@@ -1,0 +1,225 @@
+"""
+Contradiction closure detector -- constitutional integrity check.
+
+Row #3 Receipt Composition Law (ROW3_RECEIPT_COMPOSITION_DRAFT.md), Stage 3a:
+Wire "cannot imply" violations into assay doctor.
+
+Closure law (from ROW3 Part 2):
+    contradiction.registered is closed by contradiction.resolved.
+    Remaining if not closed: Open conflict -- blocks proof tier cap removal.
+
+This module provides a store-backed detector that:
+1. Scans all traces in an AssayStore
+2. Identifies contradiction.registered receipts without a paired
+   contradiction.resolved (matched by contradiction_id within the same trace)
+3. Reports them loudly without mutating store state
+
+Constitutional law:
+    Every contradiction.registered receipt must have a corresponding
+    contradiction.resolved receipt with the same contradiction_id.
+    An open conflict is a constitutional violation that blocks proof-tier
+    cap removal and must be surfaced explicitly.
+
+Design constraints:
+    - Pure read. Never mutates the store.
+    - Explicit surfacing over magical cleanup.
+    - Auditable: returns structured results, not boolean.
+    - Mirrors orphan_detector.py pattern exactly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Set
+
+from assay.store import AssayStore
+
+
+# Receipt types for the contradiction lifecycle.
+REGISTERED_RECEIPT_TYPE = "contradiction.registered"
+RESOLVED_RECEIPT_TYPE = "contradiction.resolved"
+
+
+@dataclass(frozen=True)
+class OpenContradiction:
+    """A detected open contradiction -- registered but never resolved."""
+
+    contradiction_id: str
+    trace_id: str
+    episode_id: str
+    registered_at: str
+    claim_a_id: str
+    claim_b_id: str
+    severity: str
+    trace_path: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "contradiction_id": self.contradiction_id,
+            "trace_id": self.trace_id,
+            "episode_id": self.episode_id,
+            "registered_at": self.registered_at,
+            "claim_a_id": self.claim_a_id,
+            "claim_b_id": self.claim_b_id,
+            "severity": self.severity,
+            "trace_path": self.trace_path,
+        }
+
+
+@dataclass(frozen=True)
+class ContradictionClosureResult:
+    """Result of scanning a store for open (unresolved) contradictions."""
+
+    open_contradictions: List[OpenContradiction] = field(default_factory=list)
+    total_traces_scanned: int = 0
+    total_registered_found: int = 0
+    total_open_found: int = 0
+    scanned_at: str = ""
+
+    @property
+    def clean(self) -> bool:
+        """True if no open contradictions were found."""
+        return self.total_open_found == 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "clean": self.clean,
+            "total_traces_scanned": self.total_traces_scanned,
+            "total_registered_found": self.total_registered_found,
+            "total_open_found": self.total_open_found,
+            "scanned_at": self.scanned_at,
+            "open_contradictions": [c.to_dict() for c in self.open_contradictions],
+        }
+
+
+def _extract_receipt_type(entry: Dict[str, Any]) -> str:
+    """Extract receipt type from a trace entry."""
+    return str(entry.get("type") or entry.get("receipt_type") or "")
+
+
+def _extract_timestamp(entry: Dict[str, Any]) -> str:
+    """Extract timestamp from a trace entry."""
+    return str(entry.get("timestamp") or entry.get("_stored_at") or "")
+
+
+def detect_open_contradictions(
+    store: AssayStore,
+    *,
+    max_traces: int = 1000,
+) -> ContradictionClosureResult:
+    """Scan a store for open (unresolved) contradictions.
+
+    An open contradiction is one that has a `contradiction.registered` receipt
+    but no `contradiction.resolved` receipt with the same contradiction_id
+    in the same trace.
+
+    This is a pure-read operation. It never mutates the store.
+
+    Args:
+        store: The AssayStore to scan.
+        max_traces: Maximum number of traces to scan (most recent first).
+
+    Returns:
+        ContradictionClosureResult with all findings.
+    """
+    scanned_at = datetime.now(timezone.utc).isoformat()
+    traces = store.list_traces(limit=max_traces)
+
+    open_contradictions: List[OpenContradiction] = []
+    total_registered = 0
+
+    for trace_meta in traces:
+        trace_id = trace_meta["trace_id"]
+        trace_path = trace_meta.get("path")
+        entries = store.read_trace(trace_id)
+        if not entries:
+            continue
+
+        # Track registered contradictions within this trace: id -> info dict
+        registered: Dict[str, Dict[str, Any]] = {}
+        resolved_ids: Set[str] = set()
+
+        for entry in entries:
+            receipt_type = _extract_receipt_type(entry)
+            contradiction_id = entry.get("contradiction_id")
+
+            if receipt_type == REGISTERED_RECEIPT_TYPE and contradiction_id:
+                if contradiction_id not in registered:
+                    registered[contradiction_id] = {
+                        "episode_id": str(entry.get("episode_id") or ""),
+                        "registered_at": _extract_timestamp(entry),
+                        "claim_a_id": str(entry.get("claim_a_id") or ""),
+                        "claim_b_id": str(entry.get("claim_b_id") or ""),
+                        "severity": str(entry.get("severity") or "unknown"),
+                    }
+
+            elif receipt_type == RESOLVED_RECEIPT_TYPE and contradiction_id:
+                resolved_ids.add(contradiction_id)
+
+        total_registered += len(registered)
+
+        for ctr_id, info in registered.items():
+            if ctr_id not in resolved_ids:
+                open_contradictions.append(OpenContradiction(
+                    contradiction_id=ctr_id,
+                    trace_id=trace_id,
+                    episode_id=info["episode_id"],
+                    registered_at=info["registered_at"],
+                    claim_a_id=info["claim_a_id"],
+                    claim_b_id=info["claim_b_id"],
+                    severity=info["severity"],
+                    trace_path=trace_path,
+                ))
+
+    return ContradictionClosureResult(
+        open_contradictions=open_contradictions,
+        total_traces_scanned=len(traces),
+        total_registered_found=total_registered,
+        total_open_found=len(open_contradictions),
+        scanned_at=scanned_at,
+    )
+
+
+def check_contradiction_health(
+    store: AssayStore,
+    *,
+    max_traces: int = 1000,
+    loud: bool = True,
+) -> bool:
+    """Run contradiction detection and optionally print findings.
+
+    Returns True if the store is clean (no open contradictions).
+    Returns False if open contradictions are found.
+
+    This is the entry point for CI/startup health checks.
+    """
+    result = detect_open_contradictions(store, max_traces=max_traces)
+
+    if loud and not result.clean:
+        import sys
+        print(
+            f"[CONSTITUTIONAL VIOLATION] {result.total_open_found} open contradiction(s) detected",
+            file=sys.stderr,
+        )
+        for contradiction in result.open_contradictions:
+            print(
+                f"  open: contradiction_id={contradiction.contradiction_id} "
+                f"trace={contradiction.trace_id} "
+                f"episode_id={contradiction.episode_id} "
+                f"registered_at={contradiction.registered_at} "
+                f"severity={contradiction.severity}",
+                file=sys.stderr,
+            )
+
+    return result.clean
+
+
+__all__ = [
+    "REGISTERED_RECEIPT_TYPE",
+    "RESOLVED_RECEIPT_TYPE",
+    "OpenContradiction",
+    "ContradictionClosureResult",
+    "detect_open_contradictions",
+    "check_contradiction_health",
+]

--- a/src/assay/doctor.py
+++ b/src/assay/doctor.py
@@ -18,7 +18,7 @@ import os
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 
 # ---------------------------------------------------------------------------
@@ -740,6 +740,108 @@ def _check_witness_001(strict: bool = False) -> DoctorCheckResult:
     )
 
 
+def _check_orphan_001(store: Any = None) -> DoctorCheckResult:
+    """Detect orphaned episodes (opened but never terminally closed).
+
+    Requires a store. When store=None, uses the default AssayStore.
+    Enabled via --check-orphans (not in default profiles).
+
+    Constitutional law: every episode.opened must have a terminal receipt
+    (episode.closed or episode.abandoned). Orphans are constitutional violations
+    detectable at read time.
+    """
+    try:
+        from assay.orphan_detector import detect_orphaned_episodes
+        from assay.store import get_default_store
+        s = store if store is not None else get_default_store()
+        result = detect_orphaned_episodes(s)
+        if result.clean:
+            return DoctorCheckResult(
+                id="DOCTOR_ORPHAN_001",
+                status=CheckStatus.PASS,
+                severity=Severity.INFO,
+                message=f"No orphaned episodes ({result.total_traces_scanned} traces scanned)",
+                evidence={
+                    "traces_scanned": result.total_traces_scanned,
+                    "episodes_found": result.total_episodes_found,
+                },
+            )
+        return DoctorCheckResult(
+            id="DOCTOR_ORPHAN_001",
+            status=CheckStatus.FAIL,
+            severity=Severity.HIGH,
+            message=f"{result.total_orphans_found} orphaned episode(s) detected",
+            evidence={
+                "total_orphans": result.total_orphans_found,
+                "total_episodes": result.total_episodes_found,
+                "orphans": [o.to_dict() for o in result.orphans],
+            },
+            fix="assay doctor --check-orphans  # then trace and close each orphaned episode",
+        )
+    except Exception as e:
+        return DoctorCheckResult(
+            id="DOCTOR_ORPHAN_001",
+            status=CheckStatus.FAIL,
+            severity=Severity.HIGH,
+            message=f"Orphan check error: {e}",
+            evidence={"error": str(e)},
+        )
+
+
+def _check_contradiction_001(store: Any = None) -> DoctorCheckResult:
+    """Detect open contradictions (registered but never resolved).
+
+    Requires a store. When store=None, uses the default AssayStore.
+    Enabled via --check-orphans (not in default profiles).
+
+    Constitutional law: every contradiction.registered receipt must have a
+    paired contradiction.resolved receipt with the same contradiction_id.
+    An open conflict blocks proof-tier cap removal.
+    """
+    try:
+        from assay.contradiction_detector import detect_open_contradictions
+        from assay.store import get_default_store
+        s = store if store is not None else get_default_store()
+        result = detect_open_contradictions(s)
+        if result.clean:
+            return DoctorCheckResult(
+                id="DOCTOR_CONTRADICTION_001",
+                status=CheckStatus.PASS,
+                severity=Severity.INFO,
+                message=(
+                    f"No open contradictions ({result.total_traces_scanned} traces scanned, "
+                    f"{result.total_registered_found} registered)"
+                ),
+                evidence={
+                    "traces_scanned": result.total_traces_scanned,
+                    "registered_found": result.total_registered_found,
+                },
+            )
+        return DoctorCheckResult(
+            id="DOCTOR_CONTRADICTION_001",
+            status=CheckStatus.FAIL,
+            severity=Severity.HIGH,
+            message=(
+                f"{result.total_open_found} open contradiction(s) detected "
+                f"(blocks proof-tier cap removal)"
+            ),
+            evidence={
+                "total_open": result.total_open_found,
+                "total_registered": result.total_registered_found,
+                "open_contradictions": [c.to_dict() for c in result.open_contradictions],
+            },
+            fix="# Resolve each open contradiction via emit_contradiction_resolution()",
+        )
+    except Exception as e:
+        return DoctorCheckResult(
+            id="DOCTOR_CONTRADICTION_001",
+            status=CheckStatus.FAIL,
+            severity=Severity.HIGH,
+            message=f"Contradiction check error: {e}",
+            evidence={"error": str(e)},
+        )
+
+
 # ---------------------------------------------------------------------------
 # Check dispatch
 # ---------------------------------------------------------------------------
@@ -760,6 +862,8 @@ _CHECK_FUNCTIONS = {
     "DOCTOR_CI_003": lambda **kw: _check_ci_003(),
     "DOCTOR_LEDGER_001": lambda **kw: _check_ledger_001(),
     "DOCTOR_WITNESS_001": lambda **kw: _check_witness_001(kw.get("strict", False)),
+    "DOCTOR_ORPHAN_001": lambda **kw: _check_orphan_001(kw.get("store")),
+    "DOCTOR_CONTRADICTION_001": lambda **kw: _check_contradiction_001(kw.get("store")),
 }
 
 
@@ -794,17 +898,38 @@ def run_doctor(
     pack_dir: Optional[Path] = None,
     lock_path: Optional[Path] = None,
     strict: bool = False,
+    check_orphans: bool = False,
+    store: Any = None,
 ) -> DoctorReport:
-    """Run all checks for the given profile and return a report."""
+    """Run all checks for the given profile and return a report.
+
+    Args:
+        profile: Which check profile to run (local, ci, release, ledger).
+        pack_dir: Proof Pack directory to inspect.
+        lock_path: Lockfile path to inspect.
+        strict: Treat warnings as failures.
+        check_orphans: Also run DOCTOR_ORPHAN_001 and DOCTOR_CONTRADICTION_001.
+            These are store-backed checks not included in any default profile.
+            When store=None, they use the default AssayStore.
+        store: Optional AssayStore to use for store-backed checks. When None,
+            store-backed checks (orphan, contradiction) use get_default_store().
+    """
     from assay import __version__
 
     report = DoctorReport(profile=profile, version=__version__)
-    check_ids = _PROFILE_CHECKS.get(profile, _PROFILE_CHECKS[Profile.LOCAL])
+    check_ids: List[str] = list(_PROFILE_CHECKS.get(profile, _PROFILE_CHECKS[Profile.LOCAL]))
+
+    if check_orphans:
+        if "DOCTOR_ORPHAN_001" not in check_ids:
+            check_ids.append("DOCTOR_ORPHAN_001")
+        if "DOCTOR_CONTRADICTION_001" not in check_ids:
+            check_ids.append("DOCTOR_CONTRADICTION_001")
 
     kwargs = {
         "pack_dir": pack_dir,
         "lock_path": lock_path,
         "strict": strict,
+        "store": store,
     }
 
     for check_id in check_ids:

--- a/tests/assay/test_contradiction_detector.py
+++ b/tests/assay/test_contradiction_detector.py
@@ -1,0 +1,434 @@
+"""
+Contradiction Closure Detection Tests
+
+Row #3 Receipt Composition Law, Stage 3a:
+Wire "cannot imply" violations into assay doctor.
+
+Closure law: contradiction.registered must be closed by contradiction.resolved.
+An open contradiction is a constitutional violation.
+
+These tests prove:
+    1. Registered without resolved is detected as open conflict
+    2. Registered with matching resolved is NOT flagged
+    3. Multiple open contradictions are all reported
+    4. Only the contradiction_id with no matching resolved is open (not others)
+    5. Mixed stores (some open, some resolved) report correctly
+    6. Empty stores report clean
+    7. Traces without contradiction receipts are not false positives
+    8. Detector is pure-read (store not mutated)
+    9. check_contradiction_health returns correct boolean
+    10. Result has scanned_at timestamp
+    11. OpenContradiction has all forensic fields populated
+    12. to_dict round-trips correctly
+    13. DOCTOR_CONTRADICTION_001 check integrates into run_doctor
+    14. DOCTOR_ORPHAN_001 check integrates into run_doctor
+    15. check_orphans=False does not include store-backed checks
+"""
+
+import pytest
+
+from assay.contradiction_detector import (
+    ContradictionClosureResult,
+    OpenContradiction,
+    check_contradiction_health,
+    detect_open_contradictions,
+)
+from assay.store import AssayStore
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_store(tmp_path):
+    """Create a temporary AssayStore for test isolation."""
+    return AssayStore(base_dir=tmp_path / "assay_store")
+
+
+# ---------------------------------------------------------------------------
+# Helpers: write contradiction receipts to the store
+# ---------------------------------------------------------------------------
+
+
+def _write_registered(store, contradiction_id, *, episode_id="ep_test", severity="medium"):
+    """Write a contradiction.registered receipt to the current trace."""
+    store.append_dict({
+        "type": "contradiction.registered",
+        "contradiction_id": contradiction_id,
+        "episode_id": episode_id,
+        "claim_a_id": "claim_a",
+        "claim_b_id": "claim_b",
+        "severity": severity,
+        "timestamp": "2026-01-01T00:00:00.000Z",
+    })
+
+
+def _write_resolved(store, contradiction_id, *, episode_id="ep_test"):
+    """Write a contradiction.resolved receipt to the current trace."""
+    store.append_dict({
+        "type": "contradiction.resolved",
+        "contradiction_id": contradiction_id,
+        "episode_id": episode_id,
+        "timestamp": "2026-01-01T00:01:00.000Z",
+    })
+
+
+def _start_new_trace(store):
+    """Start a fresh trace and return the trace_id."""
+    return store.start_trace()
+
+
+# ---------------------------------------------------------------------------
+# 1. Open contradictions are detected
+# ---------------------------------------------------------------------------
+
+
+class TestOpenContradictionDetection:
+    """Detector finds contradiction.registered without paired contradiction.resolved."""
+
+    def test_registered_without_resolved_is_open(self, tmp_store):
+        """A contradiction.registered with no resolved is an open conflict."""
+        _start_new_trace(tmp_store)
+        _write_registered(tmp_store, "ctr_001")
+
+        result = detect_open_contradictions(tmp_store)
+
+        assert not result.clean
+        assert result.total_open_found == 1
+        assert result.open_contradictions[0].contradiction_id == "ctr_001"
+
+    def test_multiple_open_contradictions_all_reported(self, tmp_store):
+        """Multiple open contradictions in one trace are all found."""
+        _start_new_trace(tmp_store)
+        _write_registered(tmp_store, "ctr_001")
+        _write_registered(tmp_store, "ctr_002")
+        _write_registered(tmp_store, "ctr_003")
+
+        result = detect_open_contradictions(tmp_store)
+
+        assert result.total_open_found == 3
+        ids = {c.contradiction_id for c in result.open_contradictions}
+        assert "ctr_001" in ids
+        assert "ctr_002" in ids
+        assert "ctr_003" in ids
+
+    def test_only_unresolved_contradiction_is_open(self, tmp_store):
+        """When one is resolved and one is not, only the open one is reported."""
+        _start_new_trace(tmp_store)
+        _write_registered(tmp_store, "ctr_open")
+        _write_registered(tmp_store, "ctr_closed")
+        _write_resolved(tmp_store, "ctr_closed")
+
+        result = detect_open_contradictions(tmp_store)
+
+        assert result.total_open_found == 1
+        assert result.open_contradictions[0].contradiction_id == "ctr_open"
+
+
+# ---------------------------------------------------------------------------
+# 2. Resolved contradictions are NOT flagged
+# ---------------------------------------------------------------------------
+
+
+class TestResolvedContradictionsNotFlagged:
+    """Properly resolved contradictions are not false positives."""
+
+    def test_registered_then_resolved_is_clean(self, tmp_store):
+        """A contradiction.registered followed by contradiction.resolved is healthy."""
+        _start_new_trace(tmp_store)
+        _write_registered(tmp_store, "ctr_001")
+        _write_resolved(tmp_store, "ctr_001")
+
+        result = detect_open_contradictions(tmp_store)
+
+        assert result.clean
+        assert result.total_open_found == 0
+
+    def test_multiple_resolved_all_clean(self, tmp_store):
+        """Multiple registered+resolved pairs are all clean."""
+        _start_new_trace(tmp_store)
+        _write_registered(tmp_store, "ctr_001")
+        _write_resolved(tmp_store, "ctr_001")
+        _write_registered(tmp_store, "ctr_002")
+        _write_resolved(tmp_store, "ctr_002")
+
+        result = detect_open_contradictions(tmp_store)
+
+        assert result.clean
+        assert result.total_registered_found == 2
+        assert result.total_open_found == 0
+
+    def test_resolved_before_registered_still_closes(self, tmp_store):
+        """resolved appearing before registered in the same trace still closes it."""
+        _start_new_trace(tmp_store)
+        _write_resolved(tmp_store, "ctr_001")
+        _write_registered(tmp_store, "ctr_001")
+
+        result = detect_open_contradictions(tmp_store)
+
+        assert result.clean
+
+
+# ---------------------------------------------------------------------------
+# 3. Mixed stores
+# ---------------------------------------------------------------------------
+
+
+class TestMixedStores:
+    """Stores with both open and resolved contradictions report correctly."""
+
+    def test_mixed_open_and_resolved(self, tmp_store):
+        """One open + one resolved = 1 open reported."""
+        _start_new_trace(tmp_store)
+        _write_registered(tmp_store, "ctr_open")
+        _write_registered(tmp_store, "ctr_resolved")
+        _write_resolved(tmp_store, "ctr_resolved")
+
+        result = detect_open_contradictions(tmp_store)
+
+        assert not result.clean
+        assert result.total_open_found == 1
+        assert result.total_registered_found == 2
+        assert result.open_contradictions[0].contradiction_id == "ctr_open"
+
+    def test_open_contradiction_across_separate_traces(self, tmp_store):
+        """Open contradictions in different traces are both detected."""
+        _start_new_trace(tmp_store)
+        _write_registered(tmp_store, "ctr_001")
+
+        _start_new_trace(tmp_store)
+        _write_registered(tmp_store, "ctr_002")
+
+        result = detect_open_contradictions(tmp_store)
+
+        assert result.total_open_found == 2
+        ids = {c.contradiction_id for c in result.open_contradictions}
+        assert "ctr_001" in ids
+        assert "ctr_002" in ids
+
+
+# ---------------------------------------------------------------------------
+# 4. Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Edge cases: empty stores, legacy traces, detector purity."""
+
+    def test_empty_store_is_clean(self, tmp_store):
+        """An empty store has no open contradictions."""
+        result = detect_open_contradictions(tmp_store)
+
+        assert result.clean
+        assert result.total_traces_scanned == 0
+        assert result.total_registered_found == 0
+        assert result.total_open_found == 0
+
+    def test_trace_without_contradiction_receipts_not_flagged(self, tmp_store):
+        """Traces with only other receipt types are not false positives."""
+        _start_new_trace(tmp_store)
+        tmp_store.append_dict({
+            "type": "model.invoked",
+            "episode_id": "ep_test",
+        })
+        tmp_store.append_dict({
+            "type": "episode.opened",
+            "episode_id": "ep_test",
+        })
+
+        result = detect_open_contradictions(tmp_store)
+
+        assert result.clean
+        assert result.total_registered_found == 0
+
+    def test_detector_does_not_mutate_store(self, tmp_store):
+        """Detector is pure-read: running it doesn't change the trace."""
+        _start_new_trace(tmp_store)
+        _write_registered(tmp_store, "ctr_001")
+
+        trace_id = tmp_store.trace_id
+        trace_before = tmp_store.read_trace(trace_id)
+        detect_open_contradictions(tmp_store)
+        trace_after = tmp_store.read_trace(trace_id)
+
+        assert len(trace_before) == len(trace_after)
+        for before, after in zip(trace_before, trace_after):
+            b = {k: v for k, v in before.items() if not k.startswith("_")}
+            a = {k: v for k, v in after.items() if not k.startswith("_")}
+            assert b == a
+
+    def test_result_has_scanned_at(self, tmp_store):
+        """Result includes a scan timestamp."""
+        result = detect_open_contradictions(tmp_store)
+        assert result.scanned_at != ""
+
+    def test_open_contradiction_has_forensic_fields(self, tmp_store):
+        """OpenContradiction report has all forensic fields populated."""
+        _start_new_trace(tmp_store)
+        _write_registered(
+            tmp_store, "ctr_forensic",
+            episode_id="ep_forensic",
+            severity="critical",
+        )
+
+        result = detect_open_contradictions(tmp_store)
+        c = result.open_contradictions[0]
+
+        assert c.contradiction_id == "ctr_forensic"
+        assert c.episode_id == "ep_forensic"
+        assert c.severity == "critical"
+        assert c.claim_a_id == "claim_a"
+        assert c.claim_b_id == "claim_b"
+        assert c.registered_at != ""
+        assert c.trace_id != ""
+
+    def test_to_dict_round_trips(self, tmp_store):
+        """ContradictionClosureResult.to_dict() returns serializable data."""
+        _start_new_trace(tmp_store)
+        _write_registered(tmp_store, "ctr_dict_test")
+
+        result = detect_open_contradictions(tmp_store)
+        d = result.to_dict()
+
+        assert isinstance(d, dict)
+        assert d["clean"] is False
+        assert d["total_open_found"] == 1
+        assert len(d["open_contradictions"]) == 1
+        assert d["open_contradictions"][0]["contradiction_id"] == "ctr_dict_test"
+
+    def test_resolved_only_no_registered_is_clean(self, tmp_store):
+        """A resolved receipt with no registered is not an error."""
+        _start_new_trace(tmp_store)
+        _write_resolved(tmp_store, "ctr_orphan_resolved")
+
+        result = detect_open_contradictions(tmp_store)
+
+        assert result.clean
+        assert result.total_registered_found == 0
+
+
+# ---------------------------------------------------------------------------
+# 5. check_contradiction_health integration
+# ---------------------------------------------------------------------------
+
+
+class TestCheckContradictionHealth:
+    """The CI/startup entry point returns correct booleans."""
+
+    def test_health_check_returns_true_for_clean_store(self, tmp_store):
+        """Clean store returns True."""
+        _start_new_trace(tmp_store)
+        _write_registered(tmp_store, "ctr_001")
+        _write_resolved(tmp_store, "ctr_001")
+
+        assert check_contradiction_health(tmp_store, loud=False) is True
+
+    def test_health_check_returns_false_for_open_contradiction(self, tmp_store):
+        """Open contradiction returns False."""
+        _start_new_trace(tmp_store)
+        _write_registered(tmp_store, "ctr_001")
+
+        assert check_contradiction_health(tmp_store, loud=False) is False
+
+    def test_health_check_loud_prints_to_stderr(self, tmp_store, capsys):
+        """Loud mode prints open contradiction details to stderr."""
+        _start_new_trace(tmp_store)
+        _write_registered(tmp_store, "ctr_loud_test")
+
+        check_contradiction_health(tmp_store, loud=True)
+
+        captured = capsys.readouterr()
+        assert "CONSTITUTIONAL VIOLATION" in captured.err
+        assert "ctr_loud_test" in captured.err
+
+    def test_health_check_empty_store_is_clean(self, tmp_store):
+        """Empty store is healthy."""
+        assert check_contradiction_health(tmp_store, loud=False) is True
+
+
+# ---------------------------------------------------------------------------
+# 6. Doctor integration: DOCTOR_CONTRADICTION_001 and DOCTOR_ORPHAN_001
+# ---------------------------------------------------------------------------
+
+
+class TestDoctorIntegration:
+    """DOCTOR_CONTRADICTION_001 and DOCTOR_ORPHAN_001 wire into run_doctor."""
+
+    def test_contradiction_check_not_in_default_run(self, tmp_store):
+        """DOCTOR_CONTRADICTION_001 is not run by default."""
+        from assay.doctor import run_doctor, Profile
+
+        _start_new_trace(tmp_store)
+        _write_registered(tmp_store, "ctr_not_default")
+
+        report = run_doctor(Profile.LOCAL, store=tmp_store, check_orphans=False)
+
+        ids = [c.id for c in report.checks]
+        assert "DOCTOR_CONTRADICTION_001" not in ids
+        assert "DOCTOR_ORPHAN_001" not in ids
+
+    def test_contradiction_check_runs_with_check_orphans(self, tmp_store):
+        """With check_orphans=True, DOCTOR_CONTRADICTION_001 runs."""
+        from assay.doctor import run_doctor, Profile, CheckStatus
+
+        _start_new_trace(tmp_store)
+        _write_registered(tmp_store, "ctr_flagged")
+
+        report = run_doctor(Profile.LOCAL, store=tmp_store, check_orphans=True)
+
+        ids = [c.id for c in report.checks]
+        assert "DOCTOR_CONTRADICTION_001" in ids
+        assert "DOCTOR_ORPHAN_001" in ids
+
+        contradiction_result = next(c for c in report.checks if c.id == "DOCTOR_CONTRADICTION_001")
+        assert contradiction_result.status == CheckStatus.FAIL
+        assert "1 open contradiction" in contradiction_result.message
+
+    def test_contradiction_check_passes_when_clean(self, tmp_store):
+        """DOCTOR_CONTRADICTION_001 passes when all contradictions are resolved."""
+        from assay.doctor import run_doctor, Profile, CheckStatus
+
+        _start_new_trace(tmp_store)
+        _write_registered(tmp_store, "ctr_clean")
+        _write_resolved(tmp_store, "ctr_clean")
+
+        report = run_doctor(Profile.LOCAL, store=tmp_store, check_orphans=True)
+
+        contradiction_result = next(c for c in report.checks if c.id == "DOCTOR_CONTRADICTION_001")
+        assert contradiction_result.status == CheckStatus.PASS
+
+    def test_orphan_check_passes_when_no_orphans(self, tmp_store):
+        """DOCTOR_ORPHAN_001 passes when store has only closed episodes."""
+        from assay.doctor import run_doctor, Profile, CheckStatus
+        from assay.episode import open_episode
+
+        with open_episode(store=tmp_store) as ep:
+            ep.emit("model.invoked", {"model": "test"})
+
+        report = run_doctor(Profile.LOCAL, store=tmp_store, check_orphans=True)
+
+        orphan_result = next(c for c in report.checks if c.id == "DOCTOR_ORPHAN_001")
+        assert orphan_result.status == CheckStatus.PASS
+
+    def test_check_orphans_false_keeps_normal_profile_checks(self, tmp_store):
+        """check_orphans=False runs the normal profile checks without modification."""
+        from assay.doctor import run_doctor, Profile, _PROFILE_CHECKS
+
+        report = run_doctor(Profile.LOCAL, store=tmp_store, check_orphans=False)
+
+        ids = [c.id for c in report.checks]
+        expected_ids = _PROFILE_CHECKS[Profile.LOCAL]
+        for expected in expected_ids:
+            assert expected in ids
+
+    def test_check_orphans_true_appends_store_checks(self, tmp_store):
+        """check_orphans=True appends DOCTOR_ORPHAN_001 and DOCTOR_CONTRADICTION_001."""
+        from assay.doctor import run_doctor, Profile
+
+        report = run_doctor(Profile.LOCAL, store=tmp_store, check_orphans=True)
+
+        ids = [c.id for c in report.checks]
+        assert "DOCTOR_ORPHAN_001" in ids
+        assert "DOCTOR_CONTRADICTION_001" in ids


### PR DESCRIPTION
## Summary

- **New module**: `src/assay/contradiction_detector.py` — pure-read scanner for `contradiction.registered` without paired `contradiction.resolved`. Mirrors `orphan_detector.py` exactly (structured results, never mutates store).
- **New doctor checks**: `DOCTOR_ORPHAN_001` (wraps orphan detector) + `DOCTOR_CONTRADICTION_001` (wraps contradiction detector). Both are store-backed and opt-in — not in any default profile.
- **New CLI flag**: `assay doctor --check-orphans` enables both checks.

## Row 3 Stage 3a closure

Acceptance condition from `ROW3_RECEIPT_COMPOSITION_DRAFT.md`:
> `assay doctor --check-orphans` also reports open `contradiction.registered` receipts without a paired `contradiction.resolved`.

✅ Met. 25 new tests in `test_contradiction_detector.py`. 91 combined with orphan + doctor, 0 regressions.

## Test plan

- [ ] `python3 -m pytest tests/assay/test_contradiction_detector.py -v` — 25 pass
- [ ] `python3 -m pytest tests/assay/test_orphan_detector.py tests/assay/test_doctor.py -v` — 66 pass
- [ ] `assay doctor --check-orphans` on a clean store shows PASS on both new checks
- [ ] `assay doctor` (no flag) does not run store-backed checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)