### PR TITLE
Transaction A: correctness + truthfulness fixes

### DIFF
--- a/docs/README_quickstart.md
+++ b/docs/README_quickstart.md
@@ -332,7 +332,7 @@ trust faster than bugs.
 | `assay demo-challenge` | CTF-style good + tampered pack pair |
 | `assay demo-pack` | Generate demo packs (no config needed) |
 | `assay onboard` | Guided setup: doctor -> scan -> first run plan |
-| `assay scan` | Find uninstrumented LLM call sites (`--report` for HTML) |
+| `assay scan` | Find uninstrumented LLM call sites via static analysis (`--report` for HTML; dynamic dispatch not covered) |
 | `assay patch` | Auto-insert SDK integration patches into your entrypoint |
 | `assay run` | Wrap command, collect receipts, build signed pack |
 | `assay verify-pack` | Verify a Proof Pack (integrity + claims) |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -86,7 +86,7 @@ Receipting proxy between MCP clients and servers. Zero server changes.
 
 **Goal**: Get strangers from curiosity to first proof pack in 10 minutes.
 
-All deliverables complete. 2,987+ tests passing (as of 2026-03-29). v1.19.0 on PyPI.
+All deliverables complete. 2,990 tests passing, 12 skipped (as of 2026-03-29). v1.19.0 on PyPI.
 
 ### Phase 1: Temporal Intelligence (Mar 2026) — In Progress
 

--- a/docs/outbound/HONEST_FAILURE.md
+++ b/docs/outbound/HONEST_FAILURE.md
@@ -56,6 +56,16 @@ the system denied an invalid claim, and here is the signed evidence.
 Honest failure is not a bug. It is the proof that the governance
 layer is working.
 
+## "How do I know the evidence wasn't fabricated?"
+
+This is the right question to ask. The honest answer is attack cost, not impossibility.
+
+Fabricating a valid Assay proof pack requires: running an instrumented process that produces matching content hashes for real model inputs and outputs, token counts consistent with the actual API response, timestamps in a plausible sequence — and holding the private signing key. An adversary who controls all of that is not quietly editing a log entry. They are re-executing the entire governed run to produce a fake one that will verify. The cost of fabricating a complete, internally consistent proof pack is comparable to the cost of doing the real run honestly. That is not a casual attack.
+
+What T0 (current tier) does not provide: independent witnessing. The operator holds the private signing key — the same organization that ran the eval signs the evidence. That is the trust assumption, stated plainly. T1 (RFC 3161 time-anchor) and T2 (Rekor transparency log) raise the fabrication cost further and add independent witnesses — both tiers are specified and the upgrade path is defined. See [WHAT_ASSAY_DOES_TODAY.md](../WHAT_ASSAY_DOES_TODAY.md) for current trust posture.
+
+The working answer for a compliance buyer: current packs are self-signed, not independently witnessed. Fabricating a consistent trail costs as much as running the eval honestly. Here is what an adversary would need to control. Here is what T1 adds. Here is when T1 ships.
+
 ## What changes after you install this
 
 **Week 1:** Every governed operation produces a signed evidence pack.

--- a/src/assay/comparability/match_rules.py
+++ b/src/assay/comparability/match_rules.py
@@ -29,7 +29,14 @@ def _exact(a: Any, b: Any, **kwargs: Any) -> bool:
 
     Python's ``True == 1`` is True, but for parity comparison
     a boolean and an integer are semantically different field values.
+
+    None is not a value — absence of a value. Two missing fields do not
+    constitute a match. The engine's missing-field path handles declared
+    absence; this guard catches the case where a field key exists but its
+    value is None.
     """
+    if a is None or b is None:
+        return False
     if type(a) is not type(b):
         return False
     return a == b


### PR DESCRIPTION
## Summary

Bounded correctness/truthfulness packet for the buyer-facing trust surface.

**Code fixes:**
- Reject all-OPTIONAL parity field lists at contract load time (empty evidence = credibility leak)
- None guard in content_hash matching prevents absent/absent false-positive
- "tamper-resistant" → "tamper-detectable" in compliance output

**Doc fixes:**
- Scanner claim narrowed: "static AST analysis" + link to SCANNER_LIMITATIONS.md + "dynamic dispatch not covered" caveat
- ROADMAP: test count updated to 2,990 passed, 12 skipped
- HONEST_FAILURE.md: added "How do I know the evidence wasn't fabricated?" section — states T0 trust assumption plainly, frames security as attack-cost, names T0/T1/T2 upgrade path

**Governance:**
- GOVERNANCE_TIGHTENING_PACKET.md: enforce_admins sweep execution packet for 22 repos

**Tests:** 2,990 passed, 12 skipped, 0 failures.

## Test plan
- [x] All-OPTIONAL contract rejection
- [x] Mixed OPTIONAL+REQUIRED contract allowed
- [x] None content_hash guard
- [x] Full suite green (2990/0/12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)