### PR TITLE
chore: bump version to 1.21.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "assay-ai"
-version = "1.20.2"
+version = "1.21.0"
 description = "AI evidence that's harder to fake and easier to verify"
 authors = [
     { name = "Tim Bhaserjian", email = "tim2208@gmail.com" }


### PR DESCRIPTION
Version bump for the rce-verify release. Triggers PyPI publish via the release workflow once a GitHub Release is created against this commit.