### PR TITLE
docs(rce): note protocol authority split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- RCE authority split made explicit: `assay-protocol` is the normative home for the RCE profile and Episode Contract schema, while Assay keeps the verifier-facing schema as an implementation mirror.
+
 ## [1.20.1] - 2026-04-03
 
 ### Fixed

--- a/src/assay/rce_verify.py
+++ b/src/assay/rce_verify.py
@@ -2,6 +2,9 @@
 
 This module implements the minimal v0 verifier described by the RCE profile:
 
+- normative profile home: Haserjian/assay-protocol
+- local contract schema: implementation mirror used by the verifier/runtime
+
 - Phase 1: script validation
 - Phase 2: proof-pack integrity
 - Phase 3: artifact and receipt completeness

--- a/src/assay/schemas/rce_episode_contract.schema.json
+++ b/src/assay/schemas/rce_episode_contract.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/Haserjian/assay/schemas/rce_episode_contract.schema.json",
+  "$id": "https://github.com/Haserjian/assay-protocol/schemas/rce_episode_contract.schema.json",
   "title": "RCE Episode Contract v0.1",
-  "description": "Schema for a Replay-Constrained Episode Contract. The replay-normative view determines episode_spec_hash.",
+  "description": "Implementation-local mirror of the Assay Protocol RCE Episode Contract schema. The replay-normative view determines episode_spec_hash.",
   "type": "object",
   "required": [
     "schema_version",


### PR DESCRIPTION
## Summary
- make the protocol-vs-implementation split explicit for RCE surfaces
- point the local Episode Contract schema mirror at the assay-protocol canonical schema id
- annotate the verifier module so Assay is clearly the implementation/runtime mirror, not the normative home

## Why
`assay-protocol` now carries the normative RCE profile and schema. This PR closes the loop on the Assay side so the verifier/runtime copy is explicitly treated as a mirror rather than silent co-authority.

## Validation
- `/Users/timmymacbookpro/assay-toolkit/.venv/bin/python -m json.tool src/assay/schemas/rce_episode_contract.schema.json`
- `/Users/timmymacbookpro/assay-toolkit/.venv/bin/python -m pytest tests/assay/test_rce_verify.py -q`
- `9 passed`
