### PR TITLE
ci(rce): add schema mirror drift guard against assay-protocol, refs #62

### DIFF
--- a/.github/workflows/protocol-mirror-drift.yml
+++ b/.github/workflows/protocol-mirror-drift.yml
@@ -1,0 +1,45 @@
+name: Protocol Mirror Drift Guard
+
+# Fails CI when the mirrored RCE protocol files in this repo no longer
+# byte-equal the canonical files in Haserjian/assay-protocol at the
+# pinned commit, after applying the declared transform.
+#
+# Authority: assay-protocol is normative; this repo is verifier/runtime
+# mirror. The check lives here (the consumer) by design.
+#
+# Refresh ritual: bump canonical_ref in tools/protocol_mirror/manifest.json,
+# run the script with --mode=refresh, commit both files together.
+
+on:
+  pull_request:
+    paths:
+      - 'src/assay/schemas/rce_episode_contract.schema.json'
+      - 'tools/protocol_mirror/**'
+      - 'scripts/check_protocol_mirror_drift.py'
+      - '.github/workflows/protocol-mirror-drift.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'src/assay/schemas/rce_episode_contract.schema.json'
+      - 'tools/protocol_mirror/**'
+      - 'scripts/check_protocol_mirror_drift.py'
+      - '.github/workflows/protocol-mirror-drift.yml'
+  workflow_dispatch:
+
+jobs:
+  drift:
+    name: RCE schema mirror drift check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout assay
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Verify protocol mirror byte-equals canonical at pinned ref
+        run: python scripts/check_protocol_mirror_drift.py tools/protocol_mirror/manifest.json
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/check_protocol_mirror_drift.py
+++ b/scripts/check_protocol_mirror_drift.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""
+Drift guard for protocol mirrors.
+
+Assay's verifier and runtime work mirrors a small set of normative files from
+``Haserjian/assay-protocol`` (canonical) into this repository. The mirror can
+silently drift from the canonical source. This script makes that drift
+detectable in CI.
+
+Modes
+-----
+``--mode=check`` (default)
+    For every mirror entry in the manifest, fetch the canonical file from
+    ``Haserjian/assay-protocol`` at the pinned commit, apply the declared
+    transform, and byte-compare the result against the checked-in mirror.
+    Exit 1 on any drift.
+
+``--mode=refresh``
+    For every mirror entry, fetch + transform as above, then **write** the
+    result to the mirror path. Used by maintainers to deliberately bump the
+    pin and re-sync the mirror. The script does not commit; that's a separate
+    deliberate human action.
+
+Manifest format
+---------------
+JSON file with this shape:
+
+.. code-block:: json
+
+    {
+      "canonical_repo": "Haserjian/assay-protocol",
+      "canonical_ref": "<full commit sha>",
+      "mirrors": [
+        {
+          "canonical_path": "schemas/rce_episode_contract.schema.json",
+          "mirror_path":    "src/assay/schemas/rce_episode_contract.schema.json",
+          "transform":      "rewrite_schema_id",
+          "transform_args": {
+            "from_url": "https://github.com/Haserjian/assay-protocol/schemas/rce_episode_contract.schema.json",
+            "to_url":   "https://github.com/Haserjian/assay/schemas/rce_episode_contract.schema.json"
+          }
+        }
+      ]
+    }
+
+The pin must be a full commit SHA. Tags or moving refs like ``main`` are
+forbidden because they break the determinism premise.
+
+Refresh ritual
+--------------
+1. Bump ``canonical_ref`` in the manifest to the new commit SHA.
+2. Run ``python scripts/check_protocol_mirror_drift.py --mode=refresh
+   tools/protocol_mirror/manifest.json``.
+3. Commit both the manifest bump and the updated mirror file in one PR.
+4. CI re-runs the check on the new state.
+
+Network
+-------
+Uses ``gh api`` for canonical fetches. In CI, the default ``GITHUB_TOKEN``
+is sufficient because ``Haserjian/assay-protocol`` is public.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# ---------------------------------------------------------------------------
+# Transforms
+# ---------------------------------------------------------------------------
+
+TRANSFORMS: dict[str, Callable[..., bytes]] = {}
+
+
+def _register(name: str) -> Callable[[Callable[..., bytes]], Callable[..., bytes]]:
+    def decorator(fn: Callable[..., bytes]) -> Callable[..., bytes]:
+        TRANSFORMS[name] = fn
+        return fn
+
+    return decorator
+
+
+@_register("identity")
+def _identity(content: bytes, **_: Any) -> bytes:
+    """Return content unchanged."""
+    return content
+
+
+@_register("rewrite_schema_id")
+def _rewrite_schema_id(content: bytes, *, from_url: str, to_url: str, **_: Any) -> bytes:
+    """Replace ``from_url`` with ``to_url`` in the canonical bytes.
+
+    The canonical schema's ``$id`` field points at the protocol repo's URL
+    space; the mirror legitimately serves the same schema under the assay
+    repo's URL space. This transform swaps that one substring and leaves
+    every other byte intact.
+
+    Fails loudly if ``from_url`` is not present in the canonical content,
+    so a stale or mis-targeted manifest entry is caught immediately rather
+    than silently passing.
+    """
+    from_bytes = from_url.encode("utf-8")
+    to_bytes = to_url.encode("utf-8")
+    if from_bytes not in content:
+        raise ValueError(
+            f"transform 'rewrite_schema_id' could not find from_url={from_url!r} "
+            "in canonical content (manifest is stale or mis-targeted)"
+        )
+    return content.replace(from_bytes, to_bytes)
+
+
+# ---------------------------------------------------------------------------
+# Canonical fetch
+# ---------------------------------------------------------------------------
+
+
+def fetch_canonical(repo: str, ref: str, path: str) -> bytes:
+    """Fetch a file from a public GitHub repo at a pinned ref via ``gh api``.
+
+    Returns the raw file bytes (base64-decoded from the contents API
+    response). Raises ``subprocess.CalledProcessError`` on API failure.
+
+    Uses the query-string form ``?ref=<sha>`` because the GitHub contents
+    API ignores form-field arguments on GET requests for this endpoint.
+    """
+    endpoint = f"repos/{repo}/contents/{path}?ref={ref}"
+    cmd = ["gh", "api", endpoint, "--jq", ".content"]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return base64.b64decode(result.stdout)
+
+
+def apply_transform(canonical: bytes, entry: dict[str, Any]) -> bytes:
+    name = entry["transform"]
+    if name not in TRANSFORMS:
+        raise KeyError(f"unknown transform: {name!r} (known: {sorted(TRANSFORMS)})")
+    args = entry.get("transform_args") or {}
+    return TRANSFORMS[name](canonical, **args)
+
+
+# ---------------------------------------------------------------------------
+# Diff reporting
+# ---------------------------------------------------------------------------
+
+
+def report_drift(entry: dict[str, Any], expected: bytes, actual: bytes, manifest: dict[str, Any]) -> None:
+    """Print a human-readable drift report for a single mirror entry."""
+    print(f"DRIFT: {entry['mirror_path']}")
+    print(f"  canonical: {manifest['canonical_repo']}@{manifest['canonical_ref'][:8]}:{entry['canonical_path']}")
+    print(f"  transform: {entry['transform']}")
+    print(f"  expected size: {len(expected)} bytes")
+    print(f"  actual size:   {len(actual)} bytes")
+    if not actual:
+        print("  (mirror file is missing or empty)")
+        return
+
+    # Try to give a useful first-difference hint without dumping the whole file.
+    try:
+        expected_lines = expected.decode("utf-8").splitlines()
+        actual_lines = actual.decode("utf-8").splitlines()
+        for i, (e, a) in enumerate(zip(expected_lines, actual_lines)):
+            if e != a:
+                print(f"  first differing line: {i + 1}")
+                print(f"    expected: {e[:120]}")
+                print(f"    actual:   {a[:120]}")
+                break
+        else:
+            if len(expected_lines) != len(actual_lines):
+                print(f"  line counts differ: expected={len(expected_lines)}, actual={len(actual_lines)}")
+    except UnicodeDecodeError:
+        print("  (binary diff — line-level summary skipped)")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Drift guard for protocol mirrors. Compares checked-in mirror files "
+        "against canonical sources at a pinned ref.",
+    )
+    parser.add_argument("manifest", type=Path, help="Path to manifest JSON file.")
+    parser.add_argument(
+        "--mode",
+        choices=["check", "refresh"],
+        default="check",
+        help="check (default): fail on drift. refresh: rewrite mirror files from canonical.",
+    )
+    args = parser.parse_args()
+
+    manifest_path = args.manifest if args.manifest.is_absolute() else REPO_ROOT / args.manifest
+    if not manifest_path.exists():
+        print(f"ERROR: manifest not found: {manifest_path}", file=sys.stderr)
+        return 2
+
+    manifest = json.loads(manifest_path.read_text())
+    canonical_repo = manifest["canonical_repo"]
+    canonical_ref = manifest["canonical_ref"]
+
+    if len(canonical_ref) != 40 or not all(c in "0123456789abcdef" for c in canonical_ref):
+        print(
+            f"ERROR: canonical_ref must be a full 40-char commit SHA, got {canonical_ref!r}. "
+            "Tags or moving refs like 'main' are forbidden.",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(f"Manifest: {manifest_path.relative_to(REPO_ROOT)}")
+    print(f"Canonical: {canonical_repo}@{canonical_ref[:8]}")
+    print(f"Mode: {args.mode}")
+    print()
+
+    failed = False
+    for entry in manifest["mirrors"]:
+        canonical_path = entry["canonical_path"]
+        mirror_path = REPO_ROOT / entry["mirror_path"]
+
+        try:
+            canonical_bytes = fetch_canonical(canonical_repo, canonical_ref, canonical_path)
+        except subprocess.CalledProcessError as e:
+            print(f"ERROR: failed to fetch {canonical_repo}:{canonical_path}@{canonical_ref[:8]}", file=sys.stderr)
+            print(f"  gh api stderr: {e.stderr}", file=sys.stderr)
+            failed = True
+            continue
+
+        try:
+            expected = apply_transform(canonical_bytes, entry)
+        except (ValueError, KeyError) as e:
+            print(f"ERROR: transform failed for {entry['mirror_path']}: {e}", file=sys.stderr)
+            failed = True
+            continue
+
+        if args.mode == "refresh":
+            mirror_path.parent.mkdir(parents=True, exist_ok=True)
+            mirror_path.write_bytes(expected)
+            print(f"REFRESH: wrote {entry['mirror_path']} ({len(expected)} bytes) "
+                  f"from {canonical_repo}@{canonical_ref[:8]}:{canonical_path}")
+            continue
+
+        # check mode
+        actual = mirror_path.read_bytes() if mirror_path.exists() else b""
+        if expected != actual:
+            report_drift(entry, expected, actual, manifest)
+            failed = True
+        else:
+            print(f"OK: {entry['mirror_path']} byte-equals expected ({len(expected)} bytes)")
+
+    if failed:
+        print()
+        print(
+            "Mirror drift detected. To reconcile, run:",
+            file=sys.stderr,
+        )
+        print(
+            f"  python scripts/check_protocol_mirror_drift.py --mode=refresh {args.manifest}",
+            file=sys.stderr,
+        )
+        print(
+            "Then review the changes and commit the manifest pin and the updated mirror file together.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print()
+    print("All mirrors byte-equal expected. No drift.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/assay/schemas/rce_episode_contract.schema.json
+++ b/src/assay/schemas/rce_episode_contract.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/Haserjian/assay/schemas/rce_episode_contract.schema.json",
   "title": "RCE Episode Contract v0.1",
-  "description": "Schema for a Replay-Constrained Episode Contract. The replay-normative view determines episode_spec_hash.",
+  "description": "Schema for a Replay-Constrained Episode Contract. The replay-normative view (inputs, replay_script, replay_policy, identity-bearing environment subset) determines episode_spec_hash.",
   "type": "object",
   "required": [
     "schema_version",
@@ -15,30 +15,37 @@
   "properties": {
     "schema_version": {
       "type": "string",
-      "const": "rce/0.1"
+      "const": "rce/0.1",
+      "description": "Envelope version. Not part of replay-normative view."
     },
     "episode_id": {
       "type": "string",
-      "pattern": "^ep_[0-9a-f]{24}$"
+      "pattern": "^ep_[0-9a-f]{24}$",
+      "description": "AgentMesh-native time-sortable identifier. Not part of replay-normative view."
     },
     "objective": {
-      "type": "string"
+      "type": "string",
+      "description": "Human-readable episode objective. Descriptive only — MUST NOT affect episode_spec_hash or replay verification."
     },
     "inputs": {
       "type": "array",
       "minItems": 1,
       "items": {
         "$ref": "#/definitions/input_ref"
-      }
+      },
+      "description": "Immutable input references. Part of replay-normative view."
     },
     "replay_script": {
-      "$ref": "#/definitions/replay_script"
+      "$ref": "#/definitions/replay_script",
+      "description": "Typed step DAG. Part of replay-normative view."
     },
     "replay_policy": {
-      "$ref": "#/definitions/replay_policy"
+      "$ref": "#/definitions/replay_policy",
+      "description": "Comparator and replay basis configuration. Part of replay-normative view."
     },
     "environment": {
-      "$ref": "#/definitions/environment"
+      "$ref": "#/definitions/environment",
+      "description": "Execution environment. Identity-bearing subset (provider, model_id, tool_versions, container_digest) is part of replay-normative view."
     }
   },
   "additionalProperties": false,
@@ -48,14 +55,17 @@
       "required": ["ref", "hash"],
       "properties": {
         "ref": {
-          "type": "string"
+          "type": "string",
+          "description": "Logical input name"
         },
         "hash": {
           "type": "string",
-          "pattern": "^sha256:[0-9a-f]{64}$"
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "description": "SHA-256 of input bytes"
         },
         "media_type": {
-          "type": "string"
+          "type": "string",
+          "description": "MIME type of input"
         }
       },
       "additionalProperties": false
@@ -83,22 +93,117 @@
       "required": ["step_id", "opcode", "params", "depends_on"],
       "properties": {
         "step_id": {
-          "type": "string"
+          "type": "string",
+          "description": "Unique step identifier within this script. Verifier MUST enforce uniqueness across steps (JSON Schema cannot express cross-item field uniqueness)."
         },
         "opcode": {
           "type": "string",
           "enum": ["LOAD_INPUT", "ASSERT_HASH", "APPLY_TRANSFORM", "EMIT_OUTPUT"]
         },
         "params": {
-          "type": "object"
+          "type": "object",
+          "description": "Opcode-specific parameters. The machine-readable schema enforces per-opcode parameter shapes."
         },
         "depends_on": {
           "type": "array",
+          "uniqueItems": true,
           "items": {
             "type": "string"
-          }
+          },
+          "description": "Step IDs this step depends on. Empty array for root steps. No duplicate entries."
         },
-        "output_schema": {}
+        "output_schema": {
+          "type": "object",
+          "description": "Optional JSON Schema (draft-07) for step output validation. Must be a valid JSON Schema object if present."
+        }
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": { "properties": { "opcode": { "const": "LOAD_INPUT" } } },
+          "then": { "properties": { "params": { "$ref": "#/definitions/load_input_params" } } }
+        },
+        {
+          "if": { "properties": { "opcode": { "const": "ASSERT_HASH" } } },
+          "then": { "properties": { "params": { "$ref": "#/definitions/assert_hash_params" } } }
+        },
+        {
+          "if": { "properties": { "opcode": { "const": "APPLY_TRANSFORM" } } },
+          "then": { "properties": { "params": { "$ref": "#/definitions/apply_transform_params" } } }
+        },
+        {
+          "if": { "properties": { "opcode": { "const": "EMIT_OUTPUT" } } },
+          "then": { "properties": { "params": { "$ref": "#/definitions/emit_output_params" } } }
+        }
+      ]
+    },
+    "load_input_params": {
+      "type": "object",
+      "required": ["ref"],
+      "properties": {
+        "ref": {
+          "type": "string",
+          "description": "Logical input reference to load."
+        }
+      },
+      "additionalProperties": false
+    },
+    "assert_hash_params": {
+      "type": "object",
+      "required": ["target", "expected_hash"],
+      "properties": {
+        "target": {
+          "type": "string",
+          "description": "Upstream step identifier whose output hash is being asserted."
+        },
+        "expected_hash": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "description": "Expected canonical output hash for the target step."
+        }
+      },
+      "additionalProperties": false
+    },
+    "apply_transform_params": {
+      "type": "object",
+      "required": ["transform"],
+      "properties": {
+        "transform": {
+          "type": "string",
+          "description": "Named recorded-trace transform to apply."
+        },
+        "provider": {
+          "type": "string",
+          "description": "Optional provider metadata for the transform."
+        },
+        "model_id": {
+          "type": "string",
+          "description": "Optional model identifier metadata for the transform."
+        },
+        "config_hash": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "description": "Optional opaque transform configuration hash."
+        },
+        "system_fingerprint": {
+          "type": ["string", "null"],
+          "description": "Optional runtime-reported fingerprint metadata."
+        }
+      },
+      "additionalProperties": false
+    },
+    "emit_output_params": {
+      "type": "object",
+      "required": ["claim_type", "output_ref"],
+      "properties": {
+        "claim_type": {
+          "type": "string",
+          "description": "Type label for the emitted structured claim."
+        },
+        "output_ref": {
+          "type": "string",
+          "description": "Upstream step whose output is emitted as a final claim."
+        }
       },
       "additionalProperties": false
     },
@@ -108,56 +213,60 @@
       "properties": {
         "replay_basis": {
           "type": "string",
-          "enum": ["recorded_trace"]
+          "enum": ["recorded_trace"],
+          "description": "v0.1 supports recorded_trace only"
         },
         "comparator_tier": {
           "type": "string",
-          "enum": ["A"]
+          "enum": ["A"],
+          "description": "v0.1 supports Tier A only"
         },
         "comparator_tiers_by_step": {
           "type": "object",
           "additionalProperties": {
             "type": "string",
             "enum": ["A"]
-          }
+          },
+          "description": "Per-step comparator tier overrides. All must be A in v0.1."
         }
       },
       "additionalProperties": false
     },
     "environment": {
       "type": "object",
-      "required": [
-        "env_fingerprint_hash",
-        "provider",
-        "model_id",
-        "tool_versions",
-        "container_digest"
-      ],
+      "required": ["env_fingerprint_hash", "provider", "model_id", "tool_versions", "container_digest"],
       "properties": {
         "env_fingerprint_hash": {
           "type": "string",
-          "pattern": "^sha256:[0-9a-f]{64}$"
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "description": "SHA-256 of JCS({provider, model_id, tool_versions, container_digest}). Derived cross-check — not a direct identity input."
         },
         "provider": {
-          "type": "string"
+          "type": "string",
+          "description": "Model provider identifier. Identity-bearing."
         },
         "model_id": {
-          "type": "string"
+          "type": "string",
+          "description": "Model identifier. Identity-bearing."
         },
         "model_version_hint": {
-          "type": ["string", "null"]
+          "type": ["string", "null"],
+          "description": "Advisory model version. NOT identity-bearing."
         },
         "system_fingerprint": {
-          "type": ["string", "null"]
+          "type": ["string", "null"],
+          "description": "Runtime-reported fingerprint. NOT identity-bearing."
         },
         "tool_versions": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
-          }
+          },
+          "description": "Tool name to semver mapping. Identity-bearing."
         },
         "container_digest": {
-          "type": ["string", "null"]
+          "type": ["string", "null"],
+          "description": "Container digest if applicable. Identity-bearing."
         }
       },
       "additionalProperties": false

--- a/tools/protocol_mirror/README.md
+++ b/tools/protocol_mirror/README.md
@@ -1,0 +1,118 @@
+# Protocol Mirror
+
+This directory holds the manifest for files in `assay` that mirror normative
+content from [`Haserjian/assay-protocol`](https://github.com/Haserjian/assay-protocol).
+
+## Which side is canonical
+
+**`Haserjian/assay-protocol` is canonical.** It is the normative source of
+truth for the RCE (Replay-Constrained Episode) profile and its schemas.
+
+This repo (`assay`) keeps an implementation-local copy of selected protocol
+files because the verifier and runtime need to load them at import time
+without a cross-repo network call. The mirror is a convenience artifact, not
+an authority.
+
+## Why the mirror exists
+
+- Assay's verifier (`src/assay/rce_verify.py`) loads
+  `rce_episode_contract.schema.json` at module-load time. Bundling the
+  schema in this repo avoids a network dependency on
+  `Haserjian/assay-protocol`.
+- Test fixtures and conformance vectors reference the schema by relative
+  path.
+- The mirror lets `pip install assay-ai` ship a self-contained verifier.
+
+The trade-off is that the mirror can silently drift from canonical. The
+drift guard in this directory + `scripts/check_protocol_mirror_drift.py` +
+`.github/workflows/protocol-mirror-drift.yml` makes that drift detectable in
+CI.
+
+## What's in scope (current slice)
+
+Only the schema mirror is currently guarded:
+
+| Mirror path | Canonical | Transform |
+|---|---|---|
+| `src/assay/schemas/rce_episode_contract.schema.json` | `Haserjian/assay-protocol:schemas/rce_episode_contract.schema.json` | `rewrite_schema_id` |
+
+The `rewrite_schema_id` transform is the **only** legitimate divergence
+between canonical and mirror. It rewrites the JSON Schema `$id` field from
+the protocol repo's URL space to this repo's URL space, so each repo
+legitimately serves the schema under its own canonical URL. Every other
+byte must match exactly.
+
+`RCE_PROFILE.md` is **not** mirrored in this slice. That can be added later
+by appending an entry to `manifest.json` with `transform: identity` (no
+URL rewrite needed for prose documents).
+
+## How drift gets detected
+
+`.github/workflows/protocol-mirror-drift.yml` runs
+`scripts/check_protocol_mirror_drift.py` on every PR that touches:
+
+- `src/assay/schemas/rce_episode_contract.schema.json`
+- `tools/protocol_mirror/**`
+- `scripts/check_protocol_mirror_drift.py`
+- The workflow file itself
+
+The script:
+
+1. Reads the manifest (`manifest.json` here).
+2. For each mirror entry, fetches the canonical file from `Haserjian/assay-protocol`
+   at the pinned commit SHA via `gh api` (no special token — `assay-protocol`
+   is public).
+3. Applies the declared transform.
+4. Byte-compares the result against the checked-in mirror file.
+5. Exits non-zero on any drift, with a human-readable diff hint.
+
+The pin must be a full 40-character commit SHA. Tags and moving refs like
+`main` are forbidden because they break the determinism premise.
+
+## How to refresh the mirror intentionally
+
+When the canonical updates and you want to bring the mirror current:
+
+1. Identify the new canonical commit SHA in `Haserjian/assay-protocol`.
+2. Bump `canonical_ref` in `tools/protocol_mirror/manifest.json` to that SHA.
+3. Run the script in refresh mode:
+
+   ```bash
+   python scripts/check_protocol_mirror_drift.py --mode=refresh tools/protocol_mirror/manifest.json
+   ```
+
+4. Verify the result with `git diff` — confirm the changes are what you
+   expected (e.g. new schema fields, updated descriptions, no surprise
+   structural changes).
+5. Run the existing RCE-related tests to make sure runtime still loads
+   cleanly:
+
+   ```bash
+   pytest tests/assay/test_rce_verify.py -q
+   ```
+
+6. Commit the manifest bump and the updated mirror file **in one PR**.
+   Do not split them across multiple commits — they're the atomic record
+   of an intentional sync.
+
+The CI drift guard re-runs on the PR and confirms the new mirror is still
+byte-equal to the new canonical at the new pin.
+
+## How to run the check locally
+
+```bash
+python scripts/check_protocol_mirror_drift.py tools/protocol_mirror/manifest.json
+```
+
+Exit 0 = no drift. Exit 1 = drift detected (with diff hint). Requires `gh`
+on PATH and authenticated for public read.
+
+## What this guard does not cover
+
+- **Pin freshness.** The guard does not enforce that the pin is current with
+  `assay-protocol/main`. A stale-but-honest pin is fine; updating it is a
+  deliberate human action via the refresh ritual.
+- **Semantic correctness of the canonical.** Whether the canonical schema
+  itself encodes the right contract is the protocol repo's responsibility.
+- **Other normative files.** Only files listed in `manifest.json` are
+  guarded. Adding more is a one-line manifest change.

--- a/tools/protocol_mirror/manifest.json
+++ b/tools/protocol_mirror/manifest.json
@@ -1,0 +1,15 @@
+{
+  "canonical_repo": "Haserjian/assay-protocol",
+  "canonical_ref": "3ced8af47326e9a9ac3c8b08cbe0943e782145af",
+  "mirrors": [
+    {
+      "canonical_path": "schemas/rce_episode_contract.schema.json",
+      "mirror_path": "src/assay/schemas/rce_episode_contract.schema.json",
+      "transform": "rewrite_schema_id",
+      "transform_args": {
+        "from_url": "https://github.com/Haserjian/assay-protocol/schemas/rce_episode_contract.schema.json",
+        "to_url": "https://github.com/Haserjian/assay/schemas/rce_episode_contract.schema.json"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the executable drift guard that issue #62 names. CI now fails when
`src/assay/schemas/rce_episode_contract.schema.json` no longer byte-equals
the canonical file in `Haserjian/assay-protocol` at the pinned commit, after
applying a single documented transform.

This makes the protocol authority executable: the normative RCE schema lives
in `assay-protocol`, this repo holds an implementation-local mirror, and the
mirror cannot silently diverge anymore.

## Authority direction

`Haserjian/assay-protocol` is **canonical**. This repo (`assay`) is the
**verifier/runtime mirror**. The drift check lives here (the consumer) by
design — the canonical never imports a check from a downstream consumer.

## What's new

- `scripts/check_protocol_mirror_drift.py` — deterministic check + refresh
  modes. Reads the manifest, fetches canonical via `gh api` at the pinned
  ref, applies the declared transform, byte-compares against the checked-in
  mirror. Forbids tags or moving refs in the pin.
- `tools/protocol_mirror/manifest.json` — declares the canonical repo,
  pinned commit SHA (`3ced8af47326e9a9ac3c8b08cbe0943e782145af`), and the
  mirror entry. Schema-only in this slice.
- `tools/protocol_mirror/README.md` — declares which side is canonical, why
  the mirror exists, the refresh ritual, and what's intentionally out of
  scope (`RCE_PROFILE.md` not mirrored in this slice).
- `.github/workflows/protocol-mirror-drift.yml` — triggers on PRs touching
  the schema mirror, manifest, script, or workflow itself. Uses the default
  `${{ secrets.GITHUB_TOKEN }}` — `assay-protocol` is public, no extra
  secret needed.

## Mirror reconciliation

The previous mirror was 165 lines / 3940 bytes / sha `9b14d05…` and was
missing roughly 110 lines of `description` fields the canonical has. After
applying the `rewrite_schema_id` transform to the canonical at the pinned
ref, the post-transform expected bytes are 9193 bytes / sha `7d158c9…`.

Per transform doctrine, descriptions are documentation-only and do not
affect validation. The existing `tests/assay/test_rce_verify.py` suite
(9 tests) passes against the reconciled schema — verified locally before
this PR was opened.

The single intentional difference between canonical and mirror is the
JSON Schema `$id` URL: each repo legitimately serves the schema under its
own canonical URL. The `rewrite_schema_id` transform handles exactly that
substitution and nothing else.

## Transform discipline

Only **one** named transform is allowed in this slice:

| Transform | Purpose |
|---|---|
| `rewrite_schema_id` | Substitute the JSON Schema `$id` from `assay-protocol`'s URL space to `assay`'s URL space. |

`identity` is registered for future prose mirrors but is not used by any
current entry. Adding a third transform is the explicit escalation signal
that the mirror is hiding semantic drift, not just packaging difference.

## Out of scope (deliberate)

- **No `RCE_PROFILE.md` mirror.** That file does not currently exist in
  this repo, and creating one is a separate decision. Adding it later is a
  one-line manifest entry with `transform: identity`.
- **No automatic syncing.** Refresh is a deliberate human action via the
  ritual documented in `tools/protocol_mirror/README.md`. Pin bumps are
  governance events, not silent slides.
- **No pin-freshness enforcement.** A stale-but-honest pin is fine. Updating
  the pin is a separate sprint slice.
- **No protocol-side changes.** This PR touches only the consumer repo.

## Verified locally before opening

- `python scripts/check_protocol_mirror_drift.py tools/protocol_mirror/manifest.json` → exit 0, "All mirrors byte-equal expected. No drift."
- `pytest tests/assay/test_rce_verify.py -q` → 9 passed
- The script's check mode correctly detected the original drift before reconciliation (exit 1, with line-level diff hint)
- The script's refresh mode correctly produced the expected bytes (verified by re-running check mode after)

## Test plan

- [ ] CI run on this PR is green (the new drift guard passes against the reconciled mirror)
- [ ] Existing CI workflows still pass (the schema reconciliation does not break them)
- [ ] Visual review of the manifest (correct pin, correct transform, correct path mapping)
- [ ] Visual review of the README's refresh ritual

Refs #62.