### PR TITLE
ci(actionlint): drop unused ASSAY_HOME from ci-org-trust-gate env

### DIFF
--- a/.github/workflows/ci-org-trust-gate.yml
+++ b/.github/workflows/ci-org-trust-gate.yml
@@ -48,7 +48,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      ASSAY_HOME: ${{ runner.temp }}/.assay
       ASSAY_CI_ORG_MAIN_SIGNER_ID: ci-org-main
       ASSAY_CI_ORG_MAIN_PUB_B64: ${{ secrets.ASSAY_CI_ORG_MAIN_PUB_B64 }}
       ASSAY_CI_ORG_MAIN_KEY_B64: ${{ secrets.ASSAY_CI_ORG_MAIN_KEY_B64 }}


### PR DESCRIPTION
## Summary

One-line deletion that restores the `workflow-lint.yml` (`actionlint`) workflow to green on `main`. Has been failing for 9 consecutive runs going back to 2026-03-19.

## The defect

`.github/workflows/ci-org-trust-gate.yml` line 51:

\`\`\`yaml
    env:
      ASSAY_HOME: \${{ runner.temp }}/.assay   # ← actionlint rejects this
      ASSAY_CI_ORG_MAIN_SIGNER_ID: ci-org-main
\`\`\`

\`runner.*\` context is only available at step level inside \`env:\` or \`run:\`, not at workflow or job-level \`env:\` blocks. \`actionlint\` is correctly flagging this.

## The fix

Delete the line. \`ASSAY_HOME\` was declared but **never read by any step in this workflow**. The four \`run:\` steps reference \`\$RUNNER_TEMP\` directly:
- \`\$RUNNER_TEMP/ci-org-material\`
- \`\$RUNNER_TEMP/ci-org-trust\`

Repo-wide grep for \`ASSAY_HOME\`:
- this line (the unused declaration)
- \`docs/ci-integration.md:88\` (prose mention only)

No scripts, no Python modules, no other workflow consumes it. Deletion is safe.

## What this changes

- One file: \`.github/workflows/ci-org-trust-gate.yml\`
- One line removed (line 51 in the pre-PR file)

## What this does not change

- \`ci-org-trust-gate.yml\` itself does not currently run on \`main\` — its \`push\` trigger is commented out (lines 4–20) and the job is gated on \`vars.ASSAY_CI_ORG_MAIN_FINGERPRINT != ''\` which is currently empty. This PR only affects what \`actionlint\` lints, not what executes.
- No other workflow files touched.
- No scripts, no docs (the prose mention in \`ci-integration.md\` describes the intended use; if/when \`ci-org-trust-gate.yml\` actually runs, the doc can be updated alongside the workflow re-enablement).

## Why this matters

A permanently red lint check is dead signal. While \`workflow-lint.yml\` is red on this issue, any **new** \`runner.*\` anti-pattern introduced anywhere in \`.github/workflows/\` would hide behind the existing failure. This restores \`actionlint\` to a working signal channel.

## Test plan

- [ ] CI run on this PR is green for \`workflow-lint\`
- [ ] No other check regresses