### PR TITLE
feat(openclaw): add release gates and bump assay-ai to 1.22.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ challenge_pack/
 *.jsonl
 !tests/contracts/vectors/**/*.jsonl
 assay.lock
+assay_openclaw_demo/
 
 # Package manager lock (library, not app -- consumers use their own lock)
 uv.lock

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ assay demo-challenge
 
 - **[Verify a proof pack in your browser](https://haserjian.github.io/assay-proof-gallery/verify.html)** — no install, no account
 - **MCP demo:** `assay try-mcp` — MCP tool calls with signed receipts (30 seconds)
+- **OpenClaw demo:** `assay try-openclaw` — deterministic subprocess-membrane demo + receipt adapter + signed proof pack
 - **[See the before/after specimen](https://github.com/Haserjian/assay-proof-gallery/tree/main/gallery/07-contested-decision)** — contested decision, reconstruction vs verification
 
 Assay turns AI runs into signed proof packs another team can verify offline. It makes tampering visible and preserves honest failure.
@@ -535,8 +536,12 @@ assay reviewer census reviewer_packet_demo --json
 Canonical handoff flow:
 
 ```text
-proof pack -> reviewer packet -> assay reviewer verify -> browser verify
+proof pack -> reviewer packet -> assay reviewer verify
 ```
+
+Browser verification remains proof-pack-only today. If you want client-side
+verification for a reviewer handoff, upload the nested `proof_pack/` folder,
+not the reviewer packet wrapper.
 
 Buyer verdicts and CLI exit codes are different layers:
 
@@ -548,7 +553,10 @@ evidence packet when another team needs a bounded artifact they can inspect,
 forward, and challenge.
 
 **Verify online**: [Browser verifier](https://haserjian.github.io/assay-proof-gallery/verify.html) —
-drop in a proof pack or reviewer packet and check it client-side.
+drop in a signed proof pack and check it client-side. Reviewer packets
+currently remain CLI-only; run `assay reviewer verify <reviewer_packet_dir>`
+for packet settlement, or upload the nested `proof_pack/` folder here for
+canonical browser verification.
 
 </details>
 
@@ -693,12 +701,15 @@ Restart your shell after installing. Tab completion works for all commands and o
 - **Developers** — scan existing code, instrument LLM calls, get a signed artifact per run
 - **Security and CI teams** — gate on evidence quality, fail builds without tamper-evident proof packs
 - **MCP and agent operators** — `assay try-mcp`, transparent MCP proxy, per-tool-call receipts
+- **OpenClaw operators** — subprocess membrane + receipt adapter for selected tool actions and exported session logs; proof-pack verification of emitted evidence
 - **Auditors, compliance teams, and reviewers** — offline verification, reviewer packets, HTML evidence reports
 
 ## Documentation
 
 - **[Start Here](docs/START_HERE.md) -- 6 steps from install to evidence in CI**
 - [Evidence Packets](docs/reviewer-packets.md) -- compile, verify, and hand off reviewer-ready evidence packets
+- [OpenClaw v1 Claim Sheet](docs/openclaw-v1-claim-sheet.md) -- tight public claim: proofs, non-proofs, trust assumptions, and required artifacts
+- [OpenClaw Support](docs/openclaw-support.md) -- current supported posture, proof boundary, and non-goals for OpenClaw integrations
 - [What Assay Does Today](docs/WHAT_ASSAY_DOES_TODAY.md) -- the plain-language founder memo
 - [Boundary Map](docs/BOUNDARY_MAP.md) -- Assay vs VendorQ vs AgentMesh vs Loom/CCIO
 - [Full Picture](docs/FULL_PICTURE.md) -- architecture, trust tiers, repo boundaries, release history

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Assay Roadmap
 
-**As of**: v1.20.2 (April 2026)
+**As of**: v1.22.0 (April 2026)
 **Launch**: Feb 18, 2026
 
 ---

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -109,6 +109,8 @@ Open a PR and you'll see all three checks in your GitHub status checks.
 
 - `assay explain ./proof_pack_*/` -- plain-English summary of any evidence pack
 - [Reviewer Packets](reviewer-packets.md) -- compile and verify the buyer-facing reviewer-ready evidence packet
+- [OpenClaw v1 Claim Sheet](openclaw-v1-claim-sheet.md) -- short statement of current proofs, non-proofs, trust assumptions, and required artifacts
+- [OpenClaw Support](openclaw-support.md) -- current subprocess membrane posture, proof boundary, and non-goals
 - `assay diff` -- compare packs for cost/latency regressions
 - [Integrity surface spec](specs/INTEGRITY_SURFACE_SPEC_V1.md) and [port compatibility checklist](specs/INTEGRITY_PORT_COMPATIBILITY_CHECKLIST.md) -- the normative contract for verifier ports
 - [CI integration](ci-integration.md) -- why CI matters and how to enforce evidence discipline

--- a/docs/openclaw-support.md
+++ b/docs/openclaw-support.md
@@ -1,0 +1,180 @@
+# OpenClaw Support
+
+**Status:** current public support contract
+**Date:** 2026-04-08
+**Scope:** supported integration posture and trust boundary, not a frozen Python API
+
+---
+
+## One-line contract
+
+Assay can sit in front of OpenClaw as a subprocess membrane for selected tool
+actions and exported session activity. It enforces a narrow policy boundary,
+emits tamper-evident receipts for allowed and denied actions, and packages
+those receipts into proof artifacts another team can verify offline.
+
+For a shorter external-facing summary of proofs, non-proofs, trust assumptions,
+and required artifacts, see [OpenClaw v1 Claim Sheet](openclaw-v1-claim-sheet.md).
+
+---
+
+## Supported posture today
+
+Two shipped code surfaces define the current OpenClaw support boundary:
+
+- `src/assay/bridge.py` is the enforcement membrane.
+- `src/assay/openclaw_bridge.py` is the OpenClaw-specific receipt adapter.
+
+Together they support:
+
+- tool-policy checks before invocation
+- default deny for unknown or dangerous tools
+- SSRF/private-network denial for `web_fetch`
+- deterministic subprocess invocation with captured output
+- receipt emission for allow and deny outcomes
+- domain allowlist checks for browser operations
+- explicit approval requirements for sensitive browser actions
+- parsing exported OpenClaw session logs into Assay web-tool receipts
+
+This behavior is covered by `tests/assay/test_bridge.py` and
+`tests/assay/test_openclaw_bridge.py`.
+
+---
+
+## Supported artifact flow
+
+```text
+OpenClaw tool request or exported session log
+-> Assay policy check
+-> allow/deny receipt or web-tool receipt
+-> optional proof pack build
+-> assay verify-pack
+```
+
+Browser verification remains proof-pack-only today. If you want a browser
+check in an OpenClaw workflow, verify the proof pack, not a higher-level
+wrapper.
+
+## Deterministic demo
+
+Run:
+
+```bash
+assay try-openclaw
+assay verify-pack ./assay_openclaw_demo/proof_pack
+```
+
+The demo produces one deterministic artifact set behind this contract:
+
+- one allowed public web fetch through the subprocess membrane
+- one denied localhost web fetch blocked by policy
+- one imported OpenClaw session-log event
+- one blocked sensitive browser action through the receipt adapter
+- one signed proof pack built from lower-case proof-pack entries projected from
+  that emitted evidence
+
+The subprocess invocation in this demo is deterministic and synthetic. It does
+not require a live OpenClaw install. That keeps the proof path reproducible on
+clean machines while still exercising the supported membrane and receipt-adapter
+surfaces.
+
+The raw bridge JSON artifacts and the exported session log stay beside the demo
+pack for inspection. The proof pack remains the trust root for offline
+verification.
+
+## Current session-log import semantics
+
+Exported session logs are treated as evidence inputs, not as automatically
+trusted truth.
+
+Today the importer:
+
+- emits receipts only for rows it can parse and validate against the supported
+  `web_search`, `web_fetch`, and `browser` shapes
+- surfaces malformed JSON, unsupported tools, and invalid supported-tool rows
+  as explicit skipped entries in the import report
+- keeps imported vs skipped counts plus a `clean` vs `partial` import status
+  visible in the deterministic demo summary and JSON output
+- keeps projected proof-pack entries explicit about whether they came from
+  membrane execution, live receipt adaptation, or imported session-log evidence
+
+Those skipped-entry diagnostics improve hostile-reading honesty, but they do not
+change the core proof boundary: Assay still does not prove that an imported
+session log was complete or honest before import.
+
+---
+
+## What Assay proves at this boundary
+
+At the current OpenClaw boundary, Assay proves:
+
+- which request crossed the Assay boundary
+- whether Assay policy allowed or denied it
+- what Assay recorded about the resulting subprocess invocation or imported
+  session-log event
+- whether the recorded evidence came from membrane execution, live receipt
+  adaptation, or imported session-log evidence
+- whether the emitted evidence was tampered with after it was packaged into a
+  proof pack
+
+The proof-pack verifier proves the proof-pack contract and the bytes admitted
+into the pack. It does not become a blanket verifier for the whole OpenClaw
+runtime.
+
+---
+
+## What Assay does not prove at this boundary
+
+Assay does not currently prove:
+
+- live OpenClaw Gateway or WebSocket interception
+- full CDP or browser governance on every action
+- OpenClaw internal planner truth or browser-page semantic truth
+- that every OpenClaw action was faithfully exported unless it crossed the
+  Assay boundary or appeared in the imported session log
+- that an imported session log was complete or honest before Assay receipted it
+- a multi-tenant security boundary for hostile shared users
+
+---
+
+## Authority split
+
+- `bridge.py`: enforcement membrane for subprocess invocation and deny paths
+- `openclaw_bridge.py`: OpenClaw-specific receipt adapter and session-log parser
+- proof packs: trust root for exported evidence
+- reviewer and compiled packets: higher-order packaging layers, not the
+  OpenClaw bridge itself
+
+---
+
+## API posture
+
+The current public promise is behavioral and documentary:
+
+- the supported boundary claim in this document
+- the emitted receipt and proof-pack posture
+- the verification path for emitted evidence
+
+The shipped Python modules are currently classified in `docs/catalog.yaml` as
+bridge/internal surfaces, so import-level compatibility is not yet the public
+contract.
+
+---
+
+## Not current
+
+Do not describe current Assay support as:
+
+- live Gateway or WebSocket interception
+- gatebook-backed OpenClaw runtime governance
+- constitutional control of every browser action in real time
+
+Those are roadmap directions, not shipped support claims.
+
+---
+
+## Recommended wording
+
+Use this wording for current public surfaces:
+
+> Assay can sit in front of OpenClaw as a subprocess membrane for selected tool actions and exported session activity. It enforces a narrow policy boundary, emits tamper-evident receipts for allowed and denied actions, and packages those receipts into proof artifacts another team can verify offline.

--- a/docs/openclaw-v1-claim-sheet.md
+++ b/docs/openclaw-v1-claim-sheet.md
@@ -1,0 +1,154 @@
+# OpenClaw v1 Claim Sheet
+
+**Status:** current public claim sheet
+**Date:** 2026-04-09
+**Purpose:** short external statement of what Assay does and does not claim at the OpenClaw boundary
+
+---
+
+## One-line claim
+
+Assay records and packages a bounded subset of OpenClaw-relevant actions and
+imported session evidence into a tamper-evident proof pack. It does not claim
+full runtime completeness or hostile multi-tenant enforcement.
+
+---
+
+## What This Proves
+
+At the current v1 boundary, Assay can prove:
+
+- which selected request crossed the Assay boundary
+- whether current policy allowed or denied it
+- what Assay recorded about the resulting subprocess invocation or imported
+  session-log event
+- whether the recorded evidence came from membrane execution, live receipt
+  adaptation, or imported session-log evidence
+- whether the packaged evidence was tampered with after signing
+
+---
+
+## What This Does Not Prove
+
+Assay does not currently prove:
+
+- complete coverage of all OpenClaw runtime activity
+- live OpenClaw Gateway or WebSocket interception
+- full browser-runtime or CDP governance on every action
+- OpenClaw planner correctness or browser-page semantic truth
+- that an imported session log was complete or honest before Assay receipted it
+- a hostile multi-tenant security boundary for shared operators
+
+---
+
+## Trust Assumptions
+
+Use this surface only with these assumptions stated explicitly:
+
+- the OpenClaw/Gateway side is still a single trusted operator boundary, not an
+  adversarial shared-runtime boundary
+- the proof pack is the trust root for exported evidence
+- browser verification currently applies to proof packs, not higher-level
+  wrappers
+- imported session logs are evidence inputs, not automatically trusted truth
+- the deterministic `assay try-openclaw` path is a reproducible synthetic demo,
+  not a claim of live runtime interception
+- pack verification proves integrity of admitted evidence after signing; it does
+  not by itself prove independent attestation or semantic correctness
+
+---
+
+## Required Artifacts For A Credible v1 Claim
+
+For the current OpenClaw claim to be externally reviewable, keep these artifacts
+available:
+
+- a proof pack directory that verifies with `assay verify-pack`
+- the emitted `verify_report.json` or equivalent verification output
+- explicit evidence-source distinction in the projected entries:
+  - membrane execution
+  - live receipt adaptation
+  - imported session-log evidence
+- when imported session evidence is present:
+  - `clean` vs `partial` import state
+  - imported vs skipped counts
+  - skipped-row reasons
+  - the exported session log itself when review requires source inspection
+- when membrane execution or denials are material to the claim:
+  - the raw bridge artifacts beside the pack
+
+If those artifacts are missing, the surface may still be useful internally, but
+the external claim is weaker.
+
+---
+
+## Explicit Non-Goals
+
+OpenClaw v1 is not:
+
+- a full browser-governance product
+- a claim of complete runtime capture
+- a multi-user or hostile-tenant containment story
+- a compliance certification claim
+- a Loom-first or organism-first public handshake
+
+Lead with Assay as the trust surface. Treat OpenClaw as the forcing function
+that makes the boundary legible.
+
+---
+
+## Release-Branch Gate Before Version Bump
+
+Treat this claim as release-ready only when the exported review slice, not the
+mixed source tree, satisfies all of the following:
+
+Shortcut: run `python3 scripts/check_openclaw_release_branch_gate.py` inside
+the exported review branch. That script should stay green before any OpenClaw
+version bump work begins.
+
+- export an isolated review slice first:
+  `python3 scripts/export_openclaw_release_slice.py --output <dir> --branch <review-branch>`
+- inside that exported slice, the executable branch gate stays green:
+  `python3 scripts/check_openclaw_release_branch_gate.py --json`
+- that gate must prove all of the following in one path:
+  - branch-backed review slice
+  - untouched `pyproject.toml`
+  - isolated OpenClaw slice
+  - passing package smoke
+- the packaged CLI proves the current narrow surface:
+  - `assay --help` exposes `try-openclaw`
+  - `assay try-openclaw --json` returns `PASS`
+  - `assay verify-pack ./assay_openclaw_demo/proof_pack` succeeds for the
+    emitted pack
+- the shipped docs still match the packaged behavior:
+  - `README.md`
+  - `docs/openclaw-support.md`
+  - this claim sheet
+- only after those checks are green may `pyproject.toml` change for an
+  OpenClaw release bump
+
+Hold release if any of the following becomes true in the review slice:
+
+- the checker reports out-of-scope paths
+- package smoke fails
+- the docs imply broader runtime control than the shipped surface proves
+- the packaged CLI diverges from the documented commands or artifacts
+
+---
+
+## Recommended Wording
+
+Use this sentence for current external surfaces:
+
+> Assay is a trust layer for agentic systems that turns risky tool use into policy-bound, offline-verifiable evidence.
+
+If you need the OpenClaw-specific version:
+
+> Assay can sit in front of OpenClaw as a narrow evidence membrane for selected tool actions and exported session activity, emitting tamper-evident receipts and proof packs another team can verify offline.
+
+---
+
+## See Also
+
+- [OpenClaw Support](openclaw-support.md) — full support contract and boundary detail
+- [Start Here](START_HERE.md) — current first-run and documentation map

--- a/docs/security/RELEASE_SECURITY_CHECKLIST.md
+++ b/docs/security/RELEASE_SECURITY_CHECKLIST.md
@@ -4,6 +4,12 @@ Run before any version bump or PyPI publish.
 
 ---
 
+- [ ] **OpenClaw slice gate first**: For any `try-openclaw` or OpenClaw-support
+      release, run `python3 scripts/check_openclaw_release_slice.py` before
+      review, before `scripts/smoke_openclaw_package.sh`, and before touching
+      `pyproject.toml` for a version bump. If the checker reports out-of-scope
+      paths, stop and split the slice first.
+
 - [ ] **Trust wording audit**: Does any CLI output, badge, or help text
       overstate what the system actually verifies? (See REMEDIATION_DOCTRINE.md
       rule 3.)

--- a/docs/specs/OPENCLAW_BRIDGE_GAP_ANALYSIS_V1.md
+++ b/docs/specs/OPENCLAW_BRIDGE_GAP_ANALYSIS_V1.md
@@ -1,0 +1,20 @@
+# OpenClaw Bridge Gap Analysis v1
+
+**Status:** historical planning note; superseded by [../openclaw-support.md](../openclaw-support.md)
+**Date:** 2026-04-08
+
+This file captured the build-week gap analysis used to decide the Day 2
+OpenClaw posture.
+
+The canonical public contract now lives at
+[../openclaw-support.md](../openclaw-support.md).
+
+Use the public contract for:
+
+- current supported posture
+- proof boundary
+- non-goals
+- integration wording
+
+This note is kept only as a promotion marker so older references do not keep
+pointing at planning language.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "assay-ai"
-version = "1.21.0"
+version = "1.22.0"
 description = "AI evidence that's harder to fake and easier to verify"
 authors = [
     { name = "Tim Bhaserjian", email = "tim2208@gmail.com" }

--- a/scripts/check_openclaw_metadata_floor.py
+++ b/scripts/check_openclaw_metadata_floor.py
@@ -1,0 +1,790 @@
+#!/usr/bin/env python3
+"""Validate the OpenClaw v1 metadata floor against emitted demo artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+ALLOWED_EVIDENCE_SOURCES = frozenset(
+    {
+        "membrane_execution",
+        "imported_session_log",
+        "live_receipt_adapter",
+    }
+)
+
+
+@dataclass(frozen=True)
+class MetadataIssue:
+    """One metadata-floor validation failure."""
+
+    location: str
+    field: str
+    message: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "location": self.location,
+            "field": self.field,
+            "message": self.message,
+        }
+
+
+@dataclass(frozen=True)
+class OpenClawMetadataFloorResult:
+    """Result of checking one emitted OpenClaw artifact set."""
+
+    pack_dir: str
+    summary_path: str
+    entry_count: int
+    import_status: Optional[str]
+    issues: list[MetadataIssue]
+
+    @property
+    def passed(self) -> bool:
+        return not self.issues
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "pack_dir": self.pack_dir,
+            "summary_path": self.summary_path,
+            "entry_count": self.entry_count,
+            "import_status": self.import_status,
+            "issue_count": len(self.issues),
+            "issues": [issue.to_dict() for issue in self.issues],
+            "passed": self.passed,
+        }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate the OpenClaw v1 metadata floor for a generated proof pack "
+            "and demo summary."
+        )
+    )
+    parser.add_argument(
+        "--openclaw-json",
+        type=Path,
+        help=(
+            "Path to the JSON emitted by 'assay try-openclaw --json'. "
+            "When provided, summary and pack-dir paths are resolved from it."
+        ),
+    )
+    parser.add_argument(
+        "--pack-dir",
+        type=Path,
+        help="Path to the generated proof-pack directory.",
+    )
+    parser.add_argument(
+        "--summary",
+        type=Path,
+        help="Path to DEMO_SUMMARY.json for the emitted artifact set.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a machine-readable report.",
+    )
+    args = parser.parse_args()
+    if args.openclaw_json is None and (args.pack_dir is None or args.summary is None):
+        parser.error("Provide --openclaw-json or both --pack-dir and --summary.")
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    if args.openclaw_json is not None:
+        result = check_openclaw_metadata_floor_from_openclaw_json(args.openclaw_json)
+    else:
+        assert args.pack_dir is not None and args.summary is not None
+        result = check_openclaw_metadata_floor(
+            pack_dir=args.pack_dir,
+            summary_path=args.summary,
+        )
+
+    if args.json:
+        print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+        return 0 if result.passed else 1
+
+    print("=== OpenClaw Metadata Floor ===")
+    print(f"Pack dir:    {result.pack_dir}")
+    print(f"Summary:     {result.summary_path}")
+    print(f"Entry count: {result.entry_count}")
+    if result.import_status is not None:
+        print(f"Import:      {result.import_status}")
+    print(f"Result:      {'PASS' if result.passed else 'HOLD'}")
+    if result.issues:
+        print()
+        for issue in result.issues:
+            print(f"- {issue.location} :: {issue.field} :: {issue.message}")
+    return 0 if result.passed else 1
+
+
+def check_openclaw_metadata_floor_from_openclaw_json(
+    openclaw_json_path: Path,
+) -> OpenClawMetadataFloorResult:
+    pack_dir, summary_path = resolve_openclaw_artifact_paths(openclaw_json_path)
+    return check_openclaw_metadata_floor(pack_dir=pack_dir, summary_path=summary_path)
+
+
+def resolve_openclaw_artifact_paths(openclaw_json_path: Path) -> tuple[Path, Path]:
+    payload = _load_json(Path(openclaw_json_path))
+    base_dir = Path(openclaw_json_path).resolve().parent
+    pack_dir = _resolve_path(base_dir, payload.get("pack_dir"), "pack_dir")
+    summary_path = _resolve_path(base_dir, payload.get("summary"), "summary")
+    return pack_dir, summary_path
+
+
+def check_openclaw_metadata_floor(
+    *,
+    pack_dir: Path,
+    summary_path: Path,
+) -> OpenClawMetadataFloorResult:
+    issues: list[MetadataIssue] = []
+    pack_dir = Path(pack_dir).resolve()
+    summary_path = Path(summary_path).resolve()
+
+    summary = _safe_load_json(summary_path, f"summary:{summary_path.name}", issues)
+    entries = _load_receipt_pack_entries(pack_dir, issues)
+
+    entry_types: list[str] = []
+    evidence_counts: Counter[str] = Counter()
+    imported_count = 0
+
+    for index, entry in enumerate(entries):
+        location = f"receipt_pack[{index}]"
+        _validate_common_entry_fields(entry, location, issues)
+        entry_type = _value_as_non_empty_string(entry, "type", location, issues)
+        if entry_type is not None:
+            entry_types.append(entry_type)
+
+        evidence_source = _value_as_non_empty_string(
+            entry,
+            "evidence_source",
+            location,
+            issues,
+        )
+        if evidence_source is None:
+            continue
+        if evidence_source not in ALLOWED_EVIDENCE_SOURCES:
+            issues.append(
+                MetadataIssue(
+                    location=location,
+                    field="evidence_source",
+                    message=(
+                        "Unexpected evidence_source; expected one of "
+                        f"{sorted(ALLOWED_EVIDENCE_SOURCES)}"
+                    ),
+                )
+            )
+            continue
+
+        evidence_counts[evidence_source] += 1
+        if evidence_source == "membrane_execution":
+            _validate_membrane_entry(entry, location, issues)
+        elif evidence_source == "imported_session_log":
+            imported_count += 1
+            _validate_imported_session_log_entry(entry, location, issues)
+        elif evidence_source == "live_receipt_adapter":
+            _validate_live_receipt_entry(entry, location, issues)
+
+    import_status = None
+    if summary is not None:
+        import_status = _validate_summary(
+            summary,
+            entry_count=len(entries),
+            entry_types=entry_types,
+            evidence_counts=evidence_counts,
+            imported_entry_count=imported_count,
+            issues=issues,
+        )
+
+    return OpenClawMetadataFloorResult(
+        pack_dir=str(pack_dir),
+        summary_path=str(summary_path),
+        entry_count=len(entries),
+        import_status=import_status,
+        issues=issues,
+    )
+
+
+def _validate_common_entry_fields(
+    entry: dict[str, Any],
+    location: str,
+    issues: list[MetadataIssue],
+) -> None:
+    for field in (
+        "receipt_id",
+        "type",
+        "timestamp",
+        "schema_version",
+        "run_id",
+        "provider",
+        "integration_source",
+        "source_receipt_type",
+        "source_receipt_id",
+        "evidence_source",
+        "agent_id",
+        "outcome",
+    ):
+        _value_as_non_empty_string(entry, field, location, issues)
+
+    _value_as_int(entry, "seq", location, issues)
+    _value_as_bool(entry, "allowed", location, issues)
+
+
+def _validate_membrane_entry(
+    entry: dict[str, Any],
+    location: str,
+    issues: list[MetadataIssue],
+) -> None:
+    _value_as_non_empty_string(entry, "tool_name", location, issues)
+    _value_as_non_empty_string(entry, "arguments_sha256", location, issues)
+
+    policy_ref = _optional_non_empty_string(entry, "policy_ref")
+    policy_hash = _optional_non_empty_string(entry, "policy_hash")
+    if policy_ref is None and policy_hash is None:
+        issues.append(
+            MetadataIssue(
+                location=location,
+                field="policy_ref|policy_hash",
+                message="At least one policy link must remain present for membrane_execution.",
+            )
+        )
+
+    outcome = entry.get("outcome")
+    if outcome == "blocked":
+        _value_as_non_empty_string(entry, "denial_reason", location, issues)
+
+
+def _validate_imported_session_log_entry(
+    entry: dict[str, Any],
+    location: str,
+    issues: list[MetadataIssue],
+) -> None:
+    _value_as_int(entry, "source_line_number", location, issues)
+    _value_as_bool(entry, "allowed", location, issues)
+    _value_as_non_empty_string(entry, "outcome", location, issues)
+
+    tool = _optional_non_empty_string(entry, "tool")
+    entry_type = _optional_non_empty_string(entry, "type")
+    if tool is None and entry_type not in {
+        "openclaw.web_search/v1",
+        "openclaw.web_fetch/v1",
+        "openclaw.browser/v1",
+    }:
+        issues.append(
+            MetadataIssue(
+                location=location,
+                field="tool|type",
+                message="Imported session-log entry must preserve tool identity.",
+            )
+        )
+        return
+
+    if tool == "browser" or entry_type == "openclaw.browser/v1":
+        _value_as_non_empty_string(entry, "policy_rule", location, issues)
+        _value_as_non_empty_string(entry, "target_domain", location, issues)
+
+
+def _validate_live_receipt_entry(
+    entry: dict[str, Any],
+    location: str,
+    issues: list[MetadataIssue],
+) -> None:
+    _value_as_non_empty_string(entry, "tool", location, issues)
+    _value_as_non_empty_string(entry, "policy_rule", location, issues)
+    _value_as_bool(entry, "allowed", location, issues)
+    _value_as_non_empty_string(entry, "outcome", location, issues)
+
+    sensitive_attempted = entry.get("sensitive_action_attempted")
+    sensitive_type = entry.get("sensitive_action_type")
+    if sensitive_attempted or sensitive_type is not None:
+        _value_as_bool(entry, "sensitive_action_attempted", location, issues)
+        _value_as_non_empty_string(entry, "sensitive_action_type", location, issues)
+        _value_as_bool(entry, "sensitive_action_approved", location, issues)
+
+
+def _validate_summary(
+    summary: dict[str, Any],
+    *,
+    entry_count: int,
+    entry_types: list[str],
+    evidence_counts: Counter[str],
+    imported_entry_count: int,
+    issues: list[MetadataIssue],
+) -> Optional[str]:
+    location = "summary"
+
+    verification = _value_as_non_empty_string(summary, "verification", location, issues)
+    if verification is not None and verification != "PASS":
+        issues.append(
+            MetadataIssue(
+                location=location,
+                field="verification",
+                message="Release-candidate summary must report verification PASS.",
+            )
+        )
+
+    projected_receipt_count = _value_as_int(
+        summary,
+        "projected_receipt_count",
+        location,
+        issues,
+    )
+    if projected_receipt_count is not None and projected_receipt_count != entry_count:
+        issues.append(
+            MetadataIssue(
+                location=location,
+                field="projected_receipt_count",
+                message=(
+                    f"Summary count {projected_receipt_count} does not match receipt pack count {entry_count}."
+                ),
+            )
+        )
+
+    projected_receipt_types = _value_as_list(
+        summary,
+        "projected_receipt_types",
+        location,
+        issues,
+    )
+    if projected_receipt_types is not None:
+        normalized_types = [str(value) for value in projected_receipt_types]
+        if normalized_types != entry_types:
+            issues.append(
+                MetadataIssue(
+                    location=location,
+                    field="projected_receipt_types",
+                    message="Summary receipt types no longer match the emitted receipt pack order.",
+                )
+            )
+
+    summary_evidence_sources = _value_as_dict(
+        summary,
+        "projected_evidence_sources",
+        location,
+        issues,
+    )
+    if summary_evidence_sources is not None:
+        normalized_counts = {
+            str(key): int(value) for key, value in summary_evidence_sources.items()
+        }
+        if normalized_counts != dict(evidence_counts):
+            issues.append(
+                MetadataIssue(
+                    location=location,
+                    field="projected_evidence_sources",
+                    message="Summary evidence-source counts do not match emitted receipt entries.",
+                )
+            )
+
+    cases = _value_as_dict(summary, "cases", location, issues)
+    if cases is not None:
+        _value_as_dict(cases, "membrane_allowed", "summary.cases", issues)
+        _value_as_dict(cases, "membrane_denied", "summary.cases", issues)
+        session_log_import = _value_as_dict(
+            cases,
+            "session_log_import",
+            "summary.cases",
+            issues,
+        )
+        _value_as_dict(cases, "sensitive_action_blocked", "summary.cases", issues)
+        if session_log_import is not None:
+            _value_as_non_empty_string(
+                session_log_import,
+                "path",
+                "summary.cases.session_log_import",
+                issues,
+            )
+            case_status = _value_as_non_empty_string(
+                session_log_import,
+                "status",
+                "summary.cases.session_log_import",
+                issues,
+            )
+            if case_status is not None and case_status not in {"clean", "partial"}:
+                issues.append(
+                    MetadataIssue(
+                        location="summary.cases.session_log_import",
+                        field="status",
+                        message="Session-log import status must stay explicit as 'clean' or 'partial'.",
+                    )
+                )
+            case_receipt_count = _value_as_int(
+                session_log_import,
+                "receipt_count",
+                "summary.cases.session_log_import",
+                issues,
+            )
+            case_imported_count = _value_as_int(
+                session_log_import,
+                "imported_count",
+                "summary.cases.session_log_import",
+                issues,
+            )
+            for field in ("total_lines", "blank_lines", "skipped_count"):
+                _value_as_int(
+                    session_log_import,
+                    field,
+                    "summary.cases.session_log_import",
+                    issues,
+                )
+            if (
+                case_receipt_count is not None
+                and case_receipt_count != imported_entry_count
+            ):
+                issues.append(
+                    MetadataIssue(
+                        location="summary.cases.session_log_import",
+                        field="receipt_count",
+                        message="Session-log receipt_count no longer matches imported_session_log entries.",
+                    )
+                )
+            if (
+                case_imported_count is not None
+                and case_imported_count != imported_entry_count
+            ):
+                issues.append(
+                    MetadataIssue(
+                        location="summary.cases.session_log_import",
+                        field="imported_count",
+                        message="Session-log imported_count no longer matches imported_session_log entries.",
+                    )
+                )
+
+    import_report = _value_as_dict(summary, "import_report", location, issues)
+    if import_report is None:
+        return None
+
+    import_status = _value_as_non_empty_string(
+        import_report,
+        "status",
+        "summary.import_report",
+        issues,
+    )
+    if import_status is not None and import_status not in {"clean", "partial"}:
+        issues.append(
+            MetadataIssue(
+                location="summary.import_report",
+                field="status",
+                message="Import report status must stay explicit as 'clean' or 'partial'.",
+            )
+        )
+
+    imported_count = _value_as_int(
+        import_report,
+        "imported_count",
+        "summary.import_report",
+        issues,
+    )
+    if imported_count is not None and imported_count != imported_entry_count:
+        issues.append(
+            MetadataIssue(
+                location="summary.import_report",
+                field="imported_count",
+                message="Import report imported_count no longer matches imported_session_log entries.",
+            )
+        )
+
+    for field in ("total_lines", "blank_lines", "skipped_count"):
+        _value_as_int(import_report, field, "summary.import_report", issues)
+
+    if import_status == "partial":
+        skipped_entries = _value_as_list(
+            import_report,
+            "skipped_entries",
+            "summary.import_report",
+            issues,
+        )
+        if skipped_entries is None:
+            return import_status
+        if not skipped_entries:
+            issues.append(
+                MetadataIssue(
+                    location="summary.import_report",
+                    field="skipped_entries",
+                    message="Partial import status requires explicit skipped-row entries.",
+                )
+            )
+            return import_status
+        for index, skipped in enumerate(skipped_entries):
+            if not isinstance(skipped, dict):
+                issues.append(
+                    MetadataIssue(
+                        location=f"summary.import_report.skipped_entries[{index}]",
+                        field="entry",
+                        message="Skipped-entry details must remain structured objects.",
+                    )
+                )
+                continue
+            entry_location = f"summary.import_report.skipped_entries[{index}]"
+            _value_as_int(skipped, "line_number", entry_location, issues)
+            _value_as_non_empty_string(skipped, "reason", entry_location, issues)
+            _value_as_non_empty_string(skipped, "message", entry_location, issues)
+
+    return import_status
+
+
+def _load_receipt_pack_entries(
+    pack_dir: Path,
+    issues: list[MetadataIssue],
+) -> list[dict[str, Any]]:
+    receipt_pack_path = pack_dir / "receipt_pack.jsonl"
+    if not pack_dir.exists():
+        issues.append(
+            MetadataIssue(
+                location="pack_dir",
+                field="path",
+                message=f"Pack directory does not exist: {pack_dir}",
+            )
+        )
+        return []
+    if not receipt_pack_path.exists():
+        issues.append(
+            MetadataIssue(
+                location="pack_dir",
+                field="receipt_pack.jsonl",
+                message=f"Missing receipt_pack.jsonl in {pack_dir}",
+            )
+        )
+        return []
+
+    entries: list[dict[str, Any]] = []
+    for line_number, raw_line in enumerate(
+        receipt_pack_path.read_text(encoding="utf-8").splitlines(),
+        start=1,
+    ):
+        if not raw_line.strip():
+            continue
+        try:
+            entry = json.loads(raw_line)
+        except json.JSONDecodeError as exc:
+            issues.append(
+                MetadataIssue(
+                    location=f"receipt_pack.jsonl:{line_number}",
+                    field="json",
+                    message=f"Invalid JSON: {exc.msg}",
+                )
+            )
+            continue
+        if not isinstance(entry, dict):
+            issues.append(
+                MetadataIssue(
+                    location=f"receipt_pack.jsonl:{line_number}",
+                    field="entry",
+                    message="Receipt-pack rows must remain JSON objects.",
+                )
+            )
+            continue
+        entries.append(entry)
+    return entries
+
+
+def _safe_load_json(
+    path: Path,
+    location: str,
+    issues: list[MetadataIssue],
+) -> Optional[dict[str, Any]]:
+    if not path.exists():
+        issues.append(
+            MetadataIssue(
+                location=location,
+                field="path",
+                message=f"Missing JSON file: {path}",
+            )
+        )
+        return None
+    try:
+        payload = _load_json(path)
+    except json.JSONDecodeError as exc:
+        issues.append(
+            MetadataIssue(
+                location=location,
+                field="json",
+                message=f"Invalid JSON: {exc.msg}",
+            )
+        )
+        return None
+    if not isinstance(payload, dict):
+        issues.append(
+            MetadataIssue(
+                location=location,
+                field="root",
+                message="Expected a JSON object.",
+            )
+        )
+        return None
+    return payload
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _resolve_path(base_dir: Path, raw_path: Any, field: str) -> Path:
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        raise ValueError(f"OpenClaw JSON is missing a usable {field} path.")
+    candidate = Path(raw_path)
+    if not candidate.is_absolute():
+        candidate = (base_dir / candidate).resolve()
+    return candidate.resolve()
+
+
+def _optional_non_empty_string(mapping: dict[str, Any], field: str) -> Optional[str]:
+    if field not in mapping:
+        return None
+    value = mapping[field]
+    if value is None or not isinstance(value, str) or not value.strip():
+        return None
+    return value
+
+
+def _value_as_non_empty_string(
+    mapping: dict[str, Any],
+    field: str,
+    location: str,
+    issues: list[MetadataIssue],
+) -> Optional[str]:
+    if field not in mapping:
+        issues.append(
+            MetadataIssue(
+                location=location,
+                field=field,
+                message="Missing required field.",
+            )
+        )
+        return None
+    value = mapping[field]
+    if not isinstance(value, str) or not value.strip():
+        issues.append(
+            MetadataIssue(
+                location=location,
+                field=field,
+                message="Field must be present as a non-empty string.",
+            )
+        )
+        return None
+    return value
+
+
+def _value_as_int(
+    mapping: dict[str, Any],
+    field: str,
+    location: str,
+    issues: list[MetadataIssue],
+) -> Optional[int]:
+    if field not in mapping:
+        issues.append(
+            MetadataIssue(
+                location=location,
+                field=field,
+                message="Missing required field.",
+            )
+        )
+        return None
+    value = mapping[field]
+    if not isinstance(value, int) or isinstance(value, bool):
+        issues.append(
+            MetadataIssue(
+                location=location,
+                field=field,
+                message="Field must be present as an integer.",
+            )
+        )
+        return None
+    return value
+
+
+def _value_as_bool(
+    mapping: dict[str, Any],
+    field: str,
+    location: str,
+    issues: list[MetadataIssue],
+) -> Optional[bool]:
+    if field not in mapping:
+        issues.append(
+            MetadataIssue(
+                location=location,
+                field=field,
+                message="Missing required field.",
+            )
+        )
+        return None
+    value = mapping[field]
+    if not isinstance(value, bool):
+        issues.append(
+            MetadataIssue(
+                location=location,
+                field=field,
+                message="Field must be present as a boolean.",
+            )
+        )
+        return None
+    return value
+
+
+def _value_as_list(
+    mapping: dict[str, Any],
+    field: str,
+    location: str,
+    issues: list[MetadataIssue],
+) -> Optional[list[Any]]:
+    if field not in mapping:
+        issues.append(
+            MetadataIssue(
+                location=location,
+                field=field,
+                message="Missing required field.",
+            )
+        )
+        return None
+    value = mapping[field]
+    if not isinstance(value, list):
+        issues.append(
+            MetadataIssue(
+                location=location,
+                field=field,
+                message="Field must remain a list.",
+            )
+        )
+        return None
+    return value
+
+
+def _value_as_dict(
+    mapping: dict[str, Any],
+    field: str,
+    location: str,
+    issues: list[MetadataIssue],
+) -> Optional[dict[str, Any]]:
+    if field not in mapping:
+        issues.append(
+            MetadataIssue(
+                location=location,
+                field=field,
+                message="Missing required field.",
+            )
+        )
+        return None
+    value = mapping[field]
+    if not isinstance(value, dict):
+        issues.append(
+            MetadataIssue(
+                location=location,
+                field=field,
+                message="Field must remain an object.",
+            )
+        )
+        return None
+    return value
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_openclaw_release_branch_gate.py
+++ b/scripts/check_openclaw_release_branch_gate.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Run the OpenClaw pre-version-bump gate inside an exported review branch."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SLICE_MODULE_PATH = REPO_ROOT / "src" / "assay" / "_openclaw_release_slice.py"
+SMOKE_SCRIPT_PATH = REPO_ROOT / "scripts" / "smoke_openclaw_package.sh"
+
+
+@dataclass(frozen=True)
+class OpenClawReleaseBranchGateResult:
+    """Result of the pre-version-bump gate for an exported OpenClaw slice."""
+
+    repository: str
+    branch_name: str
+    branch_backed: bool
+    staged_pyproject_paths: list[str]
+    unstaged_pyproject_paths: list[str]
+    slice_report: dict[str, object]
+    slice_isolated: bool
+    smoke_ran: bool
+    smoke_passed: bool
+    smoke_exit_code: Optional[int]
+
+    @property
+    def pyproject_touched(self) -> bool:
+        return bool(self.staged_pyproject_paths or self.unstaged_pyproject_paths)
+
+    @property
+    def passed(self) -> bool:
+        return (
+            self.branch_backed
+            and not self.pyproject_touched
+            and self.slice_isolated
+            and self.smoke_passed
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "repository": self.repository,
+            "branch_name": self.branch_name,
+            "branch_backed": self.branch_backed,
+            "pyproject_touched": self.pyproject_touched,
+            "staged_pyproject_paths": self.staged_pyproject_paths,
+            "unstaged_pyproject_paths": self.unstaged_pyproject_paths,
+            "slice_isolated": self.slice_isolated,
+            "slice_report": self.slice_report,
+            "smoke_ran": self.smoke_ran,
+            "smoke_passed": self.smoke_passed,
+            "smoke_exit_code": self.smoke_exit_code,
+            "passed": self.passed,
+        }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run the OpenClaw release-branch gate inside an exported review slice "
+            "before any version bump work."
+        )
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a machine-readable gate report.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    result = run_openclaw_release_branch_gate(REPO_ROOT)
+
+    if args.json:
+        print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+        return 0 if result.passed else 1
+
+    print("=== OpenClaw Release-Branch Gate ===")
+    print(f"Repository: {result.repository}")
+    print(f"Branch:     {result.branch_name}")
+    print(f"Result:     {'PASS' if result.passed else 'HOLD'}")
+    print(f"Branch-backed slice: {'yes' if result.branch_backed else 'no'}")
+    print(f"Slice isolated:      {'yes' if result.slice_isolated else 'no'}")
+    print(
+        f"pyproject.toml untouched: {'yes' if not result.pyproject_touched else 'no'}"
+    )
+    if result.smoke_ran:
+        print(f"Artifact checks:     {'PASS' if result.smoke_passed else 'FAIL'}")
+    else:
+        print("Artifact checks:     blocked")
+
+    if not result.branch_backed:
+        print()
+        print(
+            "Export a branch-backed review slice first with "
+            "python3 scripts/export_openclaw_release_slice.py --output <dir> --branch <review-branch>."
+        )
+    if result.pyproject_touched:
+        print()
+        print("pyproject.toml has already changed in this checkout:")
+        for path in result.staged_pyproject_paths:
+            print(f"  staged:   {path}")
+        for path in result.unstaged_pyproject_paths:
+            print(f"  unstaged: {path}")
+        print("Reset or recreate the exported slice before running the pre-bump gate.")
+    if not result.slice_isolated:
+        print()
+        print(
+            "The slice checker still sees out-of-scope drift. Run "
+            "python3 scripts/check_openclaw_release_slice.py --json for details."
+        )
+    if result.smoke_ran and not result.smoke_passed:
+        print()
+        print(
+            "Packaged artifact checks failed. Fix the exported slice until "
+            "scripts/smoke_openclaw_package.sh passes; that path now includes "
+            "metadata-floor validation via scripts/check_openclaw_metadata_floor.py."
+        )
+
+    return 0 if result.passed else 1
+
+
+def run_openclaw_release_branch_gate(
+    repo_root: Path,
+) -> OpenClawReleaseBranchGateResult:
+    module = _load_slice_module()
+    build_report = module.build_openclaw_release_slice_report
+    report = build_report(repo_root.resolve())
+
+    branch_name = _git_stdout(repo_root, "rev-parse", "--abbrev-ref", "HEAD")
+    branch_backed = is_branch_backed(branch_name)
+    staged_pyproject_paths = _git_name_list(
+        repo_root,
+        "diff",
+        "--name-only",
+        "--cached",
+        "--",
+        "pyproject.toml",
+    )
+    unstaged_pyproject_paths = _git_name_list(
+        repo_root,
+        "diff",
+        "--name-only",
+        "--",
+        "pyproject.toml",
+    )
+
+    smoke_ran = False
+    smoke_passed = False
+    smoke_exit_code: Optional[int] = None
+
+    if (
+        branch_backed
+        and not has_pyproject_changes(
+            staged_pyproject_paths,
+            unstaged_pyproject_paths,
+        )
+        and report.is_isolated
+    ):
+        smoke_ran = True
+        smoke = subprocess.run(
+            ["bash", str(SMOKE_SCRIPT_PATH)],
+            check=False,
+            cwd=repo_root,
+        )
+        smoke_exit_code = smoke.returncode
+        smoke_passed = smoke.returncode == 0
+
+    return OpenClawReleaseBranchGateResult(
+        repository=str(repo_root.resolve()),
+        branch_name=branch_name,
+        branch_backed=branch_backed,
+        staged_pyproject_paths=staged_pyproject_paths,
+        unstaged_pyproject_paths=unstaged_pyproject_paths,
+        slice_report=report.to_dict(),
+        slice_isolated=report.is_isolated,
+        smoke_ran=smoke_ran,
+        smoke_passed=smoke_passed,
+        smoke_exit_code=smoke_exit_code,
+    )
+
+
+def is_branch_backed(branch_name: str) -> bool:
+    return bool(branch_name and branch_name != "HEAD")
+
+
+def has_pyproject_changes(
+    staged_paths: Iterable[str],
+    unstaged_paths: Iterable[str],
+) -> bool:
+    return any(
+        _normalize_repo_path(path) == "pyproject.toml"
+        for path in [*staged_paths, *unstaged_paths]
+    )
+
+
+def _load_slice_module():
+    spec = importlib.util.spec_from_file_location(
+        "_openclaw_release_branch_gate",
+        SLICE_MODULE_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(
+            f"Could not load OpenClaw slice module from {SLICE_MODULE_PATH}"
+        )
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _git_stdout(repo_root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _git_name_list(repo_root: Path, *args: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [
+        _normalize_repo_path(line)
+        for line in result.stdout.splitlines()
+        if line.strip()
+    ]
+
+
+def _normalize_repo_path(path: str) -> str:
+    normalized = path.strip().replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized.lstrip("/")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_openclaw_release_slice.py
+++ b/scripts/check_openclaw_release_slice.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Check whether the current Assay worktree is isolated to the OpenClaw slice."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT / "src" / "assay" / "_openclaw_release_slice.py"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Classify staged, unstaged, and untracked paths against the "
+            "intended OpenClaw release slice."
+        )
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a machine-readable report.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    build_openclaw_release_slice_report = _load_build_report()
+
+    report = build_openclaw_release_slice_report(REPO_ROOT)
+
+    if args.json:
+        print(json.dumps(report.to_dict(), indent=2, sort_keys=True))
+        return 0 if report.is_isolated else 1
+
+    print("=== OpenClaw Release Slice Check ===")
+    print(f"Repository: {report.repository}")
+    print(
+        "Result: isolated"
+        if report.is_isolated
+        else "Result: HOLD — out-of-scope changes are still present"
+    )
+
+    if not report.has_changes:
+        print("No staged, unstaged, or untracked changes were found.")
+        return 0
+
+    _print_bucket("Staged in scope", report.staged_in_scope)
+    _print_bucket("Staged out of scope", report.staged_out_of_scope)
+    _print_bucket("Unstaged in scope", report.unstaged_in_scope)
+    _print_bucket("Unstaged out of scope", report.unstaged_out_of_scope)
+    _print_bucket("Untracked in scope", report.untracked_in_scope)
+    _print_bucket("Untracked out of scope", report.untracked_out_of_scope)
+
+    if not report.is_isolated:
+        print(
+            "Remove or split the out-of-scope paths before treating this checkout "
+            "as an OpenClaw release slice."
+        )
+        print(
+            "Do not run package smoke, review the slice, or touch pyproject.toml "
+            "for versioning until this check returns isolated."
+        )
+        print(
+            "If you are starting from a mixed tree, export an isolated review slice with "
+            "python3 scripts/export_openclaw_release_slice.py --output <dir> --run-smoke."
+        )
+    return 0 if report.is_isolated else 1
+
+
+def _load_build_report():
+    spec = importlib.util.spec_from_file_location(
+        "_openclaw_release_slice",
+        MODULE_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load OpenClaw slice module from {MODULE_PATH}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module.build_openclaw_release_slice_report
+
+
+def _print_bucket(label: str, paths: list[str]) -> None:
+    if not paths:
+        return
+    print()
+    print(f"{label}:")
+    for path in paths:
+        print(f"  - {path}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/export_openclaw_release_slice.py
+++ b/scripts/export_openclaw_release_slice.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Create an isolated OpenClaw release-slice worktree from the current checkout."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT / "src" / "assay" / "_openclaw_release_slice.py"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Create an isolated worktree at HEAD and overlay only the in-scope "
+            "OpenClaw release-slice paths from the current checkout."
+        )
+    )
+    parser.add_argument(
+        "--branch",
+        help=(
+            "Optional branch name for the exported review slice. "
+            "If omitted, the worktree stays detached at HEAD."
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Output directory for the isolated review slice.",
+    )
+    parser.add_argument(
+        "--run-smoke",
+        action="store_true",
+        help="Run scripts/smoke_openclaw_package.sh in the exported slice.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a machine-readable result summary.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    module = _load_slice_module()
+    build_report = module.build_openclaw_release_slice_report
+    collect_paths = module.collect_openclaw_release_slice_paths
+
+    report = build_report(REPO_ROOT)
+    in_scope_paths = collect_paths(report)
+    head_commit = _run_git("rev-parse", "HEAD").stdout.strip()
+    if not in_scope_paths:
+        print(
+            "No in-scope OpenClaw paths were found in the current checkout.",
+            file=sys.stderr,
+        )
+        return 1
+
+    output_dir = Path(args.output).expanduser().resolve()
+    if output_dir.exists():
+        if any(output_dir.iterdir()):
+            print(f"Output directory is not empty: {output_dir}", file=sys.stderr)
+            return 1
+    else:
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+    _run_git(*_build_worktree_add_args(output_dir, branch_name=args.branch))
+    try:
+        for rel_path in in_scope_paths:
+            _overlay_path(REPO_ROOT / rel_path, output_dir / rel_path)
+
+        export_report = build_report(output_dir)
+        smoke_ran = False
+        smoke_passed = False
+        if export_report.is_isolated and args.run_smoke:
+            smoke_ran = True
+            run_kwargs: dict[str, object] = {
+                "args": ["bash", str(output_dir / "scripts" / "smoke_openclaw_package.sh")],
+                "check": True,
+                "cwd": output_dir,
+            }
+            if args.json:
+                run_kwargs["stdout"] = sys.stderr
+                run_kwargs["stderr"] = sys.stderr
+            subprocess.run(**run_kwargs)
+            smoke_passed = True
+
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "source_repository": str(REPO_ROOT),
+                        "source_head": head_commit,
+                        "output_directory": str(output_dir),
+                        "branch_name": args.branch,
+                        "worktree_mode": "branch" if args.branch else "detached",
+                        "copied_paths": in_scope_paths,
+                        "source_report": report.to_dict(),
+                        "export_report": export_report.to_dict(),
+                        "smoke_ran": smoke_ran,
+                        "smoke_passed": smoke_passed,
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+        else:
+            print("=== OpenClaw Release Slice Export ===")
+            print(f"Source repo: {REPO_ROOT}")
+            print(f"Source HEAD: {head_commit}")
+            print(f"Output dir:  {output_dir}")
+            print(f"Branch:      {args.branch if args.branch else '(detached HEAD)'}")
+            print(f"Copied paths: {len(in_scope_paths)}")
+            print(f"Slice isolated: {'yes' if export_report.is_isolated else 'no'}")
+            print(f"Package smoke: {'PASS' if smoke_passed else 'not run'}")
+            if not export_report.is_isolated:
+                print(
+                    "Exported slice is still not isolated; inspect the export report."
+                )
+        return 0 if export_report.is_isolated else 1
+    except Exception:
+        _run_git("worktree", "remove", "--force", str(output_dir), check=False)
+        raise
+
+
+def _load_slice_module():
+    spec = importlib.util.spec_from_file_location(
+        "_openclaw_release_slice_export",
+        MODULE_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load OpenClaw slice module from {MODULE_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _build_worktree_add_args(output_dir: Path, *, branch_name: str | None) -> list[str]:
+    if branch_name:
+        return ["worktree", "add", "-b", branch_name, str(output_dir), "HEAD"]
+    return ["worktree", "add", "--detach", str(output_dir), "HEAD"]
+
+
+def _run_git(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(REPO_ROOT), *args],
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _overlay_path(source: Path, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if source.exists():
+        if source.is_dir():
+            if destination.exists():
+                shutil.rmtree(destination)
+            shutil.copytree(source, destination)
+        else:
+            shutil.copy2(source, destination)
+        return
+
+    if destination.is_dir():
+        shutil.rmtree(destination)
+    elif destination.exists():
+        destination.unlink()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_openclaw_package.sh
+++ b/scripts/smoke_openclaw_package.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Build the current checkout into a wheel, install it into a clean temp venv,
+# and verify that the packaged OpenClaw demo surface actually works.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+KEEP_TMP="${KEEP_OPENCLAW_PACKAGE_SMOKE:-0}"
+
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/assay-openclaw-package-smoke.XXXXXX")"
+cleanup() {
+  if [[ "${KEEP_TMP}" == "1" ]]; then
+    echo "Keeping temp directory: ${WORK_DIR}"
+    return
+  fi
+  rm -rf "${WORK_DIR}"
+}
+trap cleanup EXIT
+
+DIST_DIR="${WORK_DIR}/dist"
+VENV_DIR="${WORK_DIR}/venv"
+RUN_DIR="${WORK_DIR}/run"
+mkdir -p "${DIST_DIR}" "${RUN_DIR}"
+
+echo "=== Assay OpenClaw Package Smoke ==="
+echo "Repo: ${ROOT_DIR}"
+echo "Work dir: ${WORK_DIR}"
+
+echo ""
+echo "--- release-slice gate ---"
+if ! "${PYTHON_BIN}" "${ROOT_DIR}/scripts/check_openclaw_release_slice.py"; then
+  echo ""
+  echo "ERROR: OpenClaw release slice is not isolated."
+  echo "Export an isolated slice with python3 scripts/export_openclaw_release_slice.py --output <dir> --run-smoke or remove out-of-scope changes before retrying package smoke." >&2
+  exit 1
+fi
+
+if command -v git >/dev/null 2>&1; then
+  DIRTY="$(git -C "${ROOT_DIR}" status --short)"
+  if [[ -n "${DIRTY}" ]]; then
+    echo ""
+    echo "--- git status (warning: dirty tree) ---"
+    echo "${DIRTY}"
+  fi
+fi
+
+echo ""
+echo "--- build wheel ---"
+(
+  cd "${ROOT_DIR}"
+  "${PYTHON_BIN}" -m pip wheel . --no-deps -w "${DIST_DIR}"
+)
+WHEEL_PATH="$(find "${DIST_DIR}" -maxdepth 1 -name 'assay_ai-*.whl' | head -n 1)"
+if [[ -z "${WHEEL_PATH}" ]]; then
+  echo "ERROR: wheel build succeeded but no assay wheel was found" >&2
+  exit 1
+fi
+echo "Wheel: ${WHEEL_PATH}"
+
+echo ""
+echo "--- create clean venv ---"
+"${PYTHON_BIN}" -m venv "${VENV_DIR}"
+"${VENV_DIR}/bin/python" -m pip install --upgrade pip >/dev/null
+"${VENV_DIR}/bin/python" -m pip install "${WHEEL_PATH}" >/dev/null
+
+echo ""
+echo "--- packaged help surface ---"
+HELP_OUTPUT="$("${VENV_DIR}/bin/assay" --help)"
+echo "${HELP_OUTPUT}" | sed -n '1,40p'
+if ! echo "${HELP_OUTPUT}" | grep -q "try-openclaw"; then
+  echo "ERROR: packaged CLI does not expose try-openclaw" >&2
+  exit 1
+fi
+
+echo ""
+echo "--- packaged try-openclaw ---"
+(
+  cd "${RUN_DIR}"
+  "${VENV_DIR}/bin/assay" try-openclaw --json > openclaw.json
+)
+cat "${RUN_DIR}/openclaw.json"
+
+echo ""
+echo "--- validate demo JSON ---"
+"${VENV_DIR}/bin/python" - <<'PY' "${RUN_DIR}/openclaw.json"
+import json
+import pathlib
+import sys
+
+json_path = pathlib.Path(sys.argv[1]).resolve()
+run_dir = json_path.parent
+payload = json.loads(json_path.read_text(encoding="utf-8"))
+assert payload["command"] == "try-openclaw", payload
+assert payload["status"] == "ok", payload
+assert payload["verification"] == "PASS", payload
+assert payload["import_status"] in {"clean", "partial"}, payload
+assert payload["projected_receipts"] >= 4, payload
+pack_dir = (run_dir / payload["pack_dir"]).resolve()
+assert pack_dir.exists(), payload
+print(json.dumps({
+    "verification": payload["verification"],
+    "import_status": payload["import_status"],
+    "projected_receipts": payload["projected_receipts"],
+    "pack_dir": str(pack_dir),
+}, indent=2))
+PY
+
+PACK_DIR="$("${VENV_DIR}/bin/python" - <<'PY' "${RUN_DIR}/openclaw.json"
+import json
+import pathlib
+import sys
+
+json_path = pathlib.Path(sys.argv[1]).resolve()
+run_dir = json_path.parent
+payload = json.loads(json_path.read_text(encoding="utf-8"))
+print((run_dir / payload["pack_dir"]).resolve())
+PY
+)"
+
+echo ""
+echo "--- packaged verify-pack ---"
+(
+  cd "${RUN_DIR}"
+  "${VENV_DIR}/bin/assay" verify-pack "${PACK_DIR}"
+)
+
+echo ""
+echo "--- metadata-floor check ---"
+"${PYTHON_BIN}" "${ROOT_DIR}/scripts/check_openclaw_metadata_floor.py" --openclaw-json "${RUN_DIR}/openclaw.json"
+
+echo ""
+echo "=== OpenClaw package smoke complete ==="

--- a/src/assay/_openclaw_release_slice.py
+++ b/src/assay/_openclaw_release_slice.py
@@ -1,0 +1,217 @@
+"""Helpers for checking whether the working tree is isolated to the OpenClaw slice."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Iterable, Sequence
+
+OPENCLAW_RELEASE_PATTERNS: tuple[str, ...] = (
+    ".gitignore",
+    "README.md",
+    "docs/START_HERE.md",
+    "docs/openclaw-v1-claim-sheet.md",
+    "docs/openclaw-support.md",
+    "docs/security/RELEASE_SECURITY_CHECKLIST.md",
+    "docs/specs/OPENCLAW_*",
+    "scripts/check_openclaw_release_branch_gate.py",
+    "scripts/check_openclaw_metadata_floor.py",
+    "scripts/check_openclaw_release_slice.py",
+    "scripts/export_openclaw_release_slice.py",
+    "scripts/smoke_openclaw_package.sh",
+    "src/assay/_openclaw_release_slice.py",
+    "src/assay/bridge.py",
+    "src/assay/commands.py",
+    "src/assay/openclaw_*",
+    "tests/assay/test_bridge.py",
+    "tests/assay/test_openclaw_*",
+)
+
+
+@dataclass(frozen=True)
+class OpenClawReleaseSliceReport:
+    """Classification of repository changes against the OpenClaw release slice."""
+
+    repository: str
+    allowed_patterns: list[str]
+    staged_in_scope: list[str]
+    staged_out_of_scope: list[str]
+    unstaged_in_scope: list[str]
+    unstaged_out_of_scope: list[str]
+    untracked_in_scope: list[str]
+    untracked_out_of_scope: list[str]
+
+    @property
+    def has_changes(self) -> bool:
+        return any(
+            (
+                self.staged_in_scope,
+                self.staged_out_of_scope,
+                self.unstaged_in_scope,
+                self.unstaged_out_of_scope,
+                self.untracked_in_scope,
+                self.untracked_out_of_scope,
+            )
+        )
+
+    @property
+    def is_isolated(self) -> bool:
+        return not any(
+            (
+                self.staged_out_of_scope,
+                self.unstaged_out_of_scope,
+                self.untracked_out_of_scope,
+            )
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "repository": self.repository,
+            "allowed_patterns": self.allowed_patterns,
+            "has_changes": self.has_changes,
+            "is_isolated": self.is_isolated,
+            "staged": {
+                "in_scope": self.staged_in_scope,
+                "out_of_scope": self.staged_out_of_scope,
+            },
+            "unstaged": {
+                "in_scope": self.unstaged_in_scope,
+                "out_of_scope": self.unstaged_out_of_scope,
+            },
+            "untracked": {
+                "in_scope": self.untracked_in_scope,
+                "out_of_scope": self.untracked_out_of_scope,
+            },
+        }
+
+
+def normalize_repo_path(path: str) -> str:
+    """Normalize git-reported paths to a stable relative POSIX form."""
+
+    normalized = path.strip().replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized.lstrip("/")
+
+
+def is_openclaw_release_path(
+    path: str,
+    *,
+    allowed_patterns: Sequence[str] = OPENCLAW_RELEASE_PATTERNS,
+) -> bool:
+    """Return whether a path is part of the intended OpenClaw review slice."""
+
+    candidate = normalize_repo_path(path)
+    pure_path = PurePosixPath(candidate)
+    return any(pure_path.match(pattern) for pattern in allowed_patterns)
+
+
+def classify_openclaw_release_paths(
+    paths: Iterable[str],
+    *,
+    allowed_patterns: Sequence[str] = OPENCLAW_RELEASE_PATTERNS,
+) -> tuple[list[str], list[str]]:
+    """Split paths into in-scope and out-of-scope buckets."""
+
+    in_scope: list[str] = []
+    out_of_scope: list[str] = []
+    seen: set[str] = set()
+
+    for raw_path in paths:
+        path = normalize_repo_path(raw_path)
+        if not path or path in seen:
+            continue
+        seen.add(path)
+        if is_openclaw_release_path(path, allowed_patterns=allowed_patterns):
+            in_scope.append(path)
+        else:
+            out_of_scope.append(path)
+
+    return sorted(in_scope), sorted(out_of_scope)
+
+
+def build_openclaw_release_slice_report_from_paths(
+    *,
+    repository: str,
+    staged_paths: Iterable[str] = (),
+    unstaged_paths: Iterable[str] = (),
+    untracked_paths: Iterable[str] = (),
+    allowed_patterns: Sequence[str] = OPENCLAW_RELEASE_PATTERNS,
+) -> OpenClawReleaseSliceReport:
+    """Build a release-slice report from explicit path lists."""
+
+    staged_in_scope, staged_out_of_scope = classify_openclaw_release_paths(
+        staged_paths,
+        allowed_patterns=allowed_patterns,
+    )
+    unstaged_in_scope, unstaged_out_of_scope = classify_openclaw_release_paths(
+        unstaged_paths,
+        allowed_patterns=allowed_patterns,
+    )
+    untracked_in_scope, untracked_out_of_scope = classify_openclaw_release_paths(
+        untracked_paths,
+        allowed_patterns=allowed_patterns,
+    )
+
+    return OpenClawReleaseSliceReport(
+        repository=repository,
+        allowed_patterns=list(allowed_patterns),
+        staged_in_scope=staged_in_scope,
+        staged_out_of_scope=staged_out_of_scope,
+        unstaged_in_scope=unstaged_in_scope,
+        unstaged_out_of_scope=unstaged_out_of_scope,
+        untracked_in_scope=untracked_in_scope,
+        untracked_out_of_scope=untracked_out_of_scope,
+    )
+
+
+def build_openclaw_release_slice_report(repo_root: Path) -> OpenClawReleaseSliceReport:
+    """Inspect git state and classify current changes against the slice allowlist."""
+
+    repo_root = repo_root.resolve()
+    return build_openclaw_release_slice_report_from_paths(
+        repository=str(repo_root),
+        staged_paths=_git_name_list(repo_root, "diff", "--name-only", "--cached"),
+        unstaged_paths=_git_name_list(repo_root, "diff", "--name-only"),
+        untracked_paths=_git_name_list(
+            repo_root,
+            "ls-files",
+            "--others",
+            "--exclude-standard",
+        ),
+    )
+
+
+def collect_openclaw_release_slice_paths(
+    report: OpenClawReleaseSliceReport,
+) -> list[str]:
+    """Return the deduplicated in-scope paths represented by a slice report."""
+
+    buckets = (
+        report.staged_in_scope,
+        report.unstaged_in_scope,
+        report.untracked_in_scope,
+    )
+    merged: list[str] = []
+    seen: set[str] = set()
+    for bucket in buckets:
+        for path in bucket:
+            normalized = normalize_repo_path(path)
+            if not normalized or normalized in seen:
+                continue
+            seen.add(normalized)
+            merged.append(normalized)
+    return sorted(merged)
+
+
+def _git_name_list(repo_root: Path, *args: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [
+        normalize_repo_path(line) for line in result.stdout.splitlines() if line.strip()
+    ]

--- a/src/assay/commands.py
+++ b/src/assay/commands.py
@@ -3,6 +3,7 @@ Assay CLI commands: AI evidence that's harder to fake and easier to verify.
 
 Commands:
   assay try           - See what Assay does in 15 seconds (start here)
+    assay try-openclaw  - OpenClaw membrane demo with proof-pack verification
   assay reviewer verify - Verify a Reviewer Packet and explain the settlement
   assay run           - Run a command and build a Proof Pack from receipts
   assay verify-pack   - Verify a Proof Pack's integrity
@@ -2288,6 +2289,111 @@ def try_mcp_cmd(
     )
 
 
+@assay_app.command("try-openclaw", rich_help_panel=_TRY_PANEL)
+def try_openclaw_cmd(
+    output_dir: str = typer.Option(
+        "./assay_openclaw_demo",
+        "-o",
+        "--output",
+        help="Output directory for the demo artifacts and proof pack",
+    ),
+    output_json: bool = typer.Option(False, "--json", help="Structured output"),
+):
+    """See the OpenClaw membrane posture with a deterministic proof path.
+
+    Produces:
+    - one allowed public web fetch through the subprocess membrane
+    - one denied localhost fetch blocked by policy
+    - one imported OpenClaw session-log event
+    - one blocked sensitive browser action via the receipt adapter
+    - one signed proof pack built from the projected evidence
+
+    The demo uses deterministic synthetic OpenClaw responses so it survives on a
+    clean machine without a live OpenClaw install.
+    """
+    from pathlib import Path
+
+    from assay.openclaw_demo import run_openclaw_demo
+
+    out_path = Path(output_dir)
+
+    if not output_json:
+        console.print()
+        console.print(
+            "[bold]assay try-openclaw[/] — OpenClaw membrane demo with offline verification"
+        )
+        console.print()
+        console.print(
+            "  [dim]Uses deterministic synthetic OpenClaw responses; no live OpenClaw process required.[/]"
+        )
+        console.print("  [bold]1.[/] Allowed public web fetch [green]→ receipted[/]")
+        console.print("  [bold]2.[/] Blocked localhost fetch [yellow]→ denied[/]")
+        console.print(
+            "  [bold]3.[/] Imported session-log browser event [green]→ receipted[/]"
+        )
+        console.print(
+            "  [bold]4.[/] Blocked sensitive browser action [yellow]→ blocked[/]"
+        )
+
+    result = run_openclaw_demo(out_path)
+
+    if output_json:
+        _output_json(
+            {
+                "command": "try-openclaw",
+                "status": "ok" if result.verification_passed else "error",
+                "pack_dir": str(result.pack_dir),
+                "session_log": str(result.session_log_path),
+                "summary": str(result.summary_path),
+                "projected_receipts": len(result.projected_entries),
+                "imported_events": result.import_report.imported_count,
+                "skipped_import_entries": result.import_report.skipped_count,
+                "import_status": result.import_report.completeness,
+                "import_total_lines": result.import_report.total_lines,
+                "import_blank_lines": result.import_report.blank_lines,
+                "verification": "PASS" if result.verification_passed else "FAIL",
+                "errors": result.verification_errors,
+            }
+        )
+        return
+
+    console.print()
+    if result.verification_passed:
+        console.print(
+            Panel(
+                f"[bold]Integrity:[/]  [bold green]PASS[/]\n"
+                f"[bold]Receipts:[/]   {len(result.projected_entries)} projected evidence entries\n"
+                f"[bold]Imported:[/]   {result.import_report.imported_count} session-log entries ({result.import_report.skipped_count} skipped, {result.import_report.completeness})\n"
+                f"[bold]Pack:[/]       {result.pack_dir}\n"
+                f"[bold]Session log:[/] {result.session_log_path}\n"
+                f"[bold]Summary:[/]    {result.summary_path}",
+                title="[bold green]OpenClaw Demo Pack Built & Verified[/]",
+                border_style="green",
+            )
+        )
+    else:
+        console.print(
+            Panel(
+                f"Pack built but verification failed.\nPack: {result.pack_dir}",
+                title="[bold red]OpenClaw Demo Verification Failed[/]",
+                border_style="red",
+            )
+        )
+        for error in result.verification_errors:
+            console.print(f"  [red]-[/] {error.get('message', error)}")
+
+    console.print()
+    console.print("[bold]Verify it yourself:[/]")
+    console.print(f"  [green]$ assay verify-pack {result.pack_dir}[/]")
+    console.print()
+    console.print(
+        "[bold]Proof boundary:[/] The proof pack covers the projected evidence entries."
+    )
+    console.print(
+        "[bold]Raw artifacts:[/] The bridge JSON artifacts and exported session log stay beside the pack for inspection."
+    )
+
+
 # --- End of early Start Here registration ---
 
 
@@ -3106,7 +3212,7 @@ def verify_pack_cmd(
     require_witness: bool = typer.Option(
         False,
         "--require-witness",
-        help="Fail if pack has no valid witness bundle (T2 trust).",
+        help="Fail if pack has no valid external witness bundle.",
     ),
     check_expiry: bool = typer.Option(
         False,

--- a/src/assay/openclaw_bridge.py
+++ b/src/assay/openclaw_bridge.py
@@ -24,6 +24,7 @@ Usage:
         latency_ms=450,
     )
 """
+
 from __future__ import annotations
 
 import fnmatch
@@ -35,19 +36,66 @@ from urllib.parse import urlparse
 
 from assay._receipts.domains.web_tool import (
     WebToolReceipt,
-    create_web_search_receipt,
-    create_web_fetch_receipt,
     create_browser_receipt,
+    create_web_fetch_receipt,
+    create_web_search_receipt,
 )
 
 
 @dataclass
 class BrowserVerdict:
     """Result of browser access policy check."""
+
     allowed: bool
     domain: str
     matched_pattern: Optional[str] = None
     reason: str = ""
+
+
+@dataclass(frozen=True)
+class SessionLogSkippedEntry:
+    """One session-log row that was ignored during import."""
+
+    line_number: int
+    reason: Literal["invalid_json", "unsupported_tool", "invalid_entry"]
+    message: str
+    tool: Optional[str] = None
+    raw_preview: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class SessionLogImportedEntry:
+    """One supported session-log row imported into an Assay receipt."""
+
+    line_number: int
+    tool: str
+    receipt: WebToolReceipt
+
+
+@dataclass(frozen=True)
+class SessionLogImportReport:
+    """Structured import result for an OpenClaw exported session log."""
+
+    imported_entries: List[SessionLogImportedEntry]
+    skipped_entries: List[SessionLogSkippedEntry]
+    total_lines: int
+    blank_lines: int
+
+    @property
+    def receipts(self) -> List[WebToolReceipt]:
+        return [entry.receipt for entry in self.imported_entries]
+
+    @property
+    def imported_count(self) -> int:
+        return len(self.imported_entries)
+
+    @property
+    def skipped_count(self) -> int:
+        return len(self.skipped_entries)
+
+    @property
+    def completeness(self) -> Literal["clean", "partial"]:
+        return "clean" if not self.skipped_entries else "partial"
 
 
 @dataclass
@@ -164,7 +212,9 @@ class OpenClawBridge:
         latency_ms: Optional[int] = None,
         outcome: Optional[str] = None,
         sensitive_action_attempted: bool = False,
-        sensitive_action_type: Optional[Literal["credential_entry", "form_submit", "file_upload", "payment"]] = None,
+        sensitive_action_type: Optional[
+            Literal["credential_entry", "form_submit", "file_upload", "payment"]
+        ] = None,
         sensitive_action_approved: Optional[bool] = None,
     ) -> WebToolReceipt:
         """
@@ -232,55 +282,130 @@ def parse_openclaw_session_log(
 
     Returns list of WebToolReceipts for each operation found.
     """
+    return import_openclaw_session_log(
+        log_path=log_path,
+        agent_id=agent_id,
+        allowlist=allowlist,
+    ).receipts
+
+
+def import_openclaw_session_log(
+    log_path: Path,
+    agent_id: str,
+    allowlist: Optional[List[str]] = None,
+) -> SessionLogImportReport:
+    """Parse a session log and surface imported vs skipped rows explicitly."""
+
     bridge = OpenClawBridge(
         agent_id=agent_id,
         allowlist=allowlist or [],
     )
 
-    receipts = []
+    imported_entries: List[SessionLogImportedEntry] = []
+    skipped_entries: List[SessionLogSkippedEntry] = []
+    total_lines = 0
+    blank_lines = 0
 
-    with open(log_path) as f:
-        for line in f:
-            if not line.strip():
+    with open(log_path, encoding="utf-8") as f:
+        for line_number, raw_line in enumerate(f, start=1):
+            total_lines += 1
+            line = raw_line.strip()
+            if not line:
+                blank_lines += 1
                 continue
 
             try:
                 entry = json.loads(line)
-            except json.JSONDecodeError:
+            except json.JSONDecodeError as exc:
+                skipped_entries.append(
+                    SessionLogSkippedEntry(
+                        line_number=line_number,
+                        reason="invalid_json",
+                        message=str(exc),
+                        raw_preview=_preview_line(raw_line),
+                    )
+                )
                 continue
 
             tool = entry.get("tool")
-
-            if tool == "web_search":
-                receipt = bridge.record_web_search(
-                    query=entry.get("query", ""),
-                    result_items=len(entry.get("results", [])),
+            try:
+                if tool == "web_search":
+                    receipt = bridge.record_web_search(
+                        query=entry.get("query", ""),
+                        result_items=len(entry.get("results", [])),
+                    )
+                elif tool == "web_fetch":
+                    receipt = bridge.record_web_fetch(
+                        url=entry.get("url", ""),
+                        result_size=entry.get("content_length"),
+                        cached=entry.get("cached", False),
+                    )
+                elif tool == "browser":
+                    receipt = bridge.record_browser(
+                        url=entry.get("url", ""),
+                        result_size=entry.get("content_length"),
+                        sensitive_action_attempted=entry.get(
+                            "sensitive_action_attempted", False
+                        ),
+                        sensitive_action_type=entry.get("sensitive_action_type"),
+                        sensitive_action_approved=entry.get(
+                            "sensitive_action_approved"
+                        ),
+                    )
+                else:
+                    skipped_entries.append(
+                        SessionLogSkippedEntry(
+                            line_number=line_number,
+                            reason="unsupported_tool",
+                            tool=str(tool) if tool is not None else None,
+                            message="Unsupported or missing tool field",
+                            raw_preview=_preview_line(raw_line),
+                        )
+                    )
+                    continue
+            except (TypeError, ValueError) as exc:
+                skipped_entries.append(
+                    SessionLogSkippedEntry(
+                        line_number=line_number,
+                        reason="invalid_entry",
+                        tool=str(tool) if tool is not None else None,
+                        message=str(exc),
+                        raw_preview=_preview_line(raw_line),
+                    )
                 )
-                receipts.append(receipt)
+                continue
 
-            elif tool == "web_fetch":
-                receipt = bridge.record_web_fetch(
-                    url=entry.get("url", ""),
-                    result_size=entry.get("content_length"),
-                    cached=entry.get("cached", False),
+            imported_entries.append(
+                SessionLogImportedEntry(
+                    line_number=line_number,
+                    tool=str(tool),
+                    receipt=receipt,
                 )
-                receipts.append(receipt)
+            )
 
-            elif tool == "browser":
-                receipt = bridge.record_browser(
-                    url=entry.get("url", ""),
-                    result_size=entry.get("content_length"),
-                    sensitive_action_attempted=entry.get("sensitive_action_attempted", False),
-                    sensitive_action_type=entry.get("sensitive_action_type"),
-                    sensitive_action_approved=entry.get("sensitive_action_approved"),
-                )
-                receipts.append(receipt)
+    return SessionLogImportReport(
+        imported_entries=imported_entries,
+        skipped_entries=skipped_entries,
+        total_lines=total_lines,
+        blank_lines=blank_lines,
+    )
 
-    return receipts
+
+def _preview_line(raw_line: str, max_chars: int = 160) -> str:
+    """Compact raw session-log content for skipped-entry diagnostics."""
+
+    preview = raw_line.strip().replace("\n", "\\n")
+    if len(preview) <= max_chars:
+        return preview
+    return preview[:max_chars] + "...[truncated]"
 
 
 __all__ = [
     "OpenClawBridge",
+    "SessionLogImportedEntry",
     "BrowserVerdict",
+    "SessionLogImportReport",
+    "SessionLogSkippedEntry",
+    "import_openclaw_session_log",
     "parse_openclaw_session_log",
 ]

--- a/src/assay/openclaw_demo.py
+++ b/src/assay/openclaw_demo.py
@@ -1,0 +1,481 @@
+"""Deterministic OpenClaw demo with proof-pack projection.
+
+This module wires the currently supported OpenClaw posture into one surviving
+demo path:
+
+- enforcement membrane via ReceiptBridge
+- receipt adapter via OpenClawBridge and session-log parsing
+- proof-pack projection into proof-pack-admissible namespaced tokens
+- offline verification of the resulting proof pack
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+from collections import Counter
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Sequence
+
+import assay.store as store_mod
+from assay.bridge import BridgeConfig, InvokeResult, ReceiptBridge, ToolInvoker
+from assay.keystore import AssayKeyStore
+from assay.openclaw_bridge import (
+    OpenClawBridge,
+    SessionLogImportReport,
+    import_openclaw_session_log,
+)
+from assay.proof_pack import ProofPack, verify_proof_pack
+
+DEMO_TRACE_ID = "openclaw_demo_v1"
+DEMO_SESSION_ID = "sess_openclaw_demo_v1"
+DEMO_TIMESTAMP = "2026-04-08T00:00:00+00:00"
+DEMO_PACK_ID = "pack_openclaw_demo_v1"
+DEMO_SIGNER_ID = "openclaw-demo-signer"
+DEMO_AGENT_ID = "agent:openclaw-demo"
+
+
+@dataclass(frozen=True)
+class OpenClawDemoResult:
+    """Structured result for the deterministic OpenClaw demo."""
+
+    output_dir: Path
+    pack_dir: Path
+    session_log_path: Path
+    summary_path: Path
+    projected_entries: List[Dict[str, Any]]
+    import_report: SessionLogImportReport
+    verification_passed: bool
+    verification_errors: List[Dict[str, Any]]
+
+
+class DeterministicOpenClawInvoker(ToolInvoker):
+    """Static invoker used by the demo to avoid a real OpenClaw dependency."""
+
+    def invoke(self, tool_name: str, arguments: Dict[str, Any]) -> InvokeResult:
+        if tool_name != "web_fetch":
+            raise ValueError(f"Unsupported demo tool: {tool_name}")
+
+        url = str(arguments.get("url") or "")
+        payload = {
+            "url": url,
+            "status": 200,
+            "title": "Async I/O in Python",
+            "provider": "openclaw-demo",
+        }
+        return InvokeResult(
+            exit_code=0,
+            stdout=json.dumps(payload, separators=(",", ":"), sort_keys=True),
+            stderr="",
+            duration_ms=42.0,
+            timed_out=False,
+        )
+
+
+@contextmanager
+def isolated_demo_store(base_dir: Path, trace_id: str) -> Iterator[None]:
+    """Route bridge trace writes into a temporary store for the demo lifetime."""
+
+    previous_store = store_mod._default_store
+    previous_seq_counter = store_mod._seq_counter
+    previous_seq_trace_id = store_mod._seq_trace_id
+    previous_trace_id = os.environ.get("ASSAY_TRACE_ID")
+
+    store_mod._default_store = store_mod.AssayStore(base_dir=base_dir)
+    store_mod._seq_counter = 0
+    store_mod._seq_trace_id = None
+    os.environ["ASSAY_TRACE_ID"] = trace_id
+    try:
+        yield
+    finally:
+        if previous_trace_id is None:
+            os.environ.pop("ASSAY_TRACE_ID", None)
+        else:
+            os.environ["ASSAY_TRACE_ID"] = previous_trace_id
+        store_mod._default_store = previous_store
+        store_mod._seq_counter = previous_seq_counter
+        store_mod._seq_trace_id = previous_seq_trace_id
+
+
+def _json_ready_receipt(receipt: Any) -> Dict[str, Any]:
+    if hasattr(receipt, "model_dump"):
+        return receipt.model_dump(mode="json", exclude_none=True)
+    return dict(receipt)
+
+
+def project_bridge_receipt_for_proof_pack(
+    receipt: Dict[str, Any],
+    *,
+    run_id: str,
+    seq: int,
+    evidence_source: str = "membrane_execution",
+) -> Dict[str, Any]:
+    """Project an internal bridge receipt into a proof-pack-admissible token."""
+
+    source_type = str(receipt.get("receipt_type") or receipt.get("type") or "")
+    projected_type = {
+        "BridgeExecution": "openclaw.bridge_execution/v1",
+        "BridgeDenial": "openclaw.bridge_denial/v1",
+    }.get(source_type)
+    if projected_type is None:
+        raise ValueError(f"Unsupported bridge receipt type: {source_type}")
+
+    allowed = bool(receipt.get("allowed", False))
+    outcome = str(receipt.get("outcome") or ("blocked" if not allowed else "ok"))
+
+    projected: Dict[str, Any] = {
+        "receipt_id": str(receipt["receipt_id"]),
+        "type": projected_type,
+        "timestamp": str(receipt.get("timestamp") or DEMO_TIMESTAMP),
+        "schema_version": str(receipt.get("schema_version") or "3.0"),
+        "seq": seq,
+        "run_id": run_id,
+        "provider": "openclaw",
+        "integration_source": "assay.bridge",
+        "source_receipt_type": source_type,
+        "source_receipt_id": str(receipt["receipt_id"]),
+        "evidence_source": evidence_source,
+        "agent_id": str(receipt.get("agent_id") or DEMO_AGENT_ID),
+        "session_id": str(receipt.get("session_id") or DEMO_SESSION_ID),
+        "tool_name": str(receipt.get("tool_name") or "unknown"),
+        "allowed": allowed,
+        "outcome": outcome,
+        "policy_hash": receipt.get("policy_hash"),
+        "policy_ref": receipt.get("policy_ref"),
+        "arguments_sha256": receipt.get("arguments_sha256"),
+    }
+
+    optional_fields = (
+        "cwd",
+        "denial_reason",
+        "duration_ms",
+        "exit_code",
+        "stderr_preview",
+        "stderr_sha256",
+        "stdout_preview",
+        "stdout_sha256",
+    )
+    for field in optional_fields:
+        value = receipt.get(field)
+        if value is not None:
+            projected[field] = value
+    return projected
+
+
+def project_web_tool_receipt_for_proof_pack(
+    receipt: Any,
+    *,
+    run_id: str,
+    seq: int,
+    evidence_source: str = "live_receipt_adapter",
+    source_line_number: int | None = None,
+) -> Dict[str, Any]:
+    """Project an OpenClaw web-tool receipt into a proof-pack-admissible token."""
+
+    payload = _json_ready_receipt(receipt)
+    tool = str(payload.get("tool") or "unknown")
+    projected_type = {
+        "web_search": "openclaw.web_search/v1",
+        "web_fetch": "openclaw.web_fetch/v1",
+        "browser": "openclaw.browser/v1",
+    }.get(tool)
+    if projected_type is None:
+        raise ValueError(f"Unsupported web tool type: {tool}")
+
+    timestamp = payload.get("ts") or payload.get("timestamp") or DEMO_TIMESTAMP
+    projected: Dict[str, Any] = {
+        "receipt_id": str(payload["receipt_id"]),
+        "type": projected_type,
+        "timestamp": str(timestamp),
+        "schema_version": str(payload.get("schema_version") or "3.0"),
+        "seq": seq,
+        "run_id": run_id,
+        "provider": str(payload.get("provider") or "openclaw"),
+        "integration_source": "assay.openclaw_bridge",
+        "source_receipt_type": str(payload.get("receipt_type") or "WebToolReceipt"),
+        "source_receipt_id": str(payload["receipt_id"]),
+        "evidence_source": evidence_source,
+        "agent_id": str(payload.get("agent_id") or DEMO_AGENT_ID),
+        "session_id": payload.get("session_id"),
+        "tool": tool,
+        "allowed": bool(payload.get("allowed", False)),
+        "outcome": str(payload.get("outcome") or "blocked"),
+        "policy_rule": payload.get("policy_rule"),
+        "target_domain": payload.get("target_domain"),
+    }
+
+    optional_fields = (
+        "cached",
+        "content_hash",
+        "content_type",
+        "crossed_domain_boundary",
+        "domain_allowlist_match",
+        "latency_ms",
+        "outcome_details",
+        "query",
+        "redirect_chain",
+        "result_items",
+        "result_size_chars",
+        "sensitive_action_approved",
+        "sensitive_action_attempted",
+        "sensitive_action_type",
+        "url",
+    )
+    for field in optional_fields:
+        value = payload.get(field)
+        if value is not None:
+            projected[field] = value
+    if source_line_number is not None:
+        projected["source_line_number"] = source_line_number
+    return projected
+
+
+def _write_demo_session_log(
+    path: Path,
+    *,
+    entries: Sequence[Dict[str, Any] | str] | None = None,
+) -> None:
+    """Write a deterministic exported OpenClaw session log for the demo."""
+
+    log_entries = (
+        list(entries)
+        if entries is not None
+        else [
+            {
+                "tool": "browser",
+                "url": "https://github.com/anthropics/claude-code",
+                "content_length": 1024,
+            }
+        ]
+    )
+    rendered_lines: List[str] = []
+    for entry in log_entries:
+        if isinstance(entry, str):
+            rendered_lines.append(entry.rstrip("\n"))
+        elif isinstance(entry, dict):
+            rendered_lines.append(
+                json.dumps(entry, separators=(",", ":"), sort_keys=True)
+            )
+        else:
+            raise TypeError(f"Unsupported demo session-log entry: {type(entry)!r}")
+
+    body = "\n".join(rendered_lines)
+    if rendered_lines:
+        body += "\n"
+    path.write_text(body, encoding="utf-8")
+
+
+def _reset_demo_outputs(output_dir: Path) -> None:
+    for path in (
+        output_dir / "artifacts",
+        output_dir / "proof_pack",
+    ):
+        if path.exists():
+            shutil.rmtree(path)
+    for path in (
+        output_dir / "DEMO_SUMMARY.json",
+        output_dir / "openclaw_session.jsonl",
+    ):
+        if path.exists():
+            path.unlink()
+
+
+def run_openclaw_demo(
+    output_dir: Path,
+    *,
+    keystore: AssayKeyStore | None = None,
+    session_log_lines: Sequence[Dict[str, Any] | str] | None = None,
+) -> OpenClawDemoResult:
+    """Run the deterministic OpenClaw demo and build a verifiable proof pack."""
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _reset_demo_outputs(output_dir)
+
+    artifacts_dir = output_dir / "artifacts"
+    session_log_path = output_dir / "openclaw_session.jsonl"
+    summary_path = output_dir / "DEMO_SUMMARY.json"
+    pack_dir = output_dir / "proof_pack"
+
+    with tempfile.TemporaryDirectory(prefix="assay_openclaw_demo_") as tmpdir:
+        temp_root = Path(tmpdir)
+        demo_store_dir = temp_root / "assay_store"
+        demo_keystore = keystore or AssayKeyStore(keys_dir=temp_root / "keys")
+        demo_keystore.generate_key(DEMO_SIGNER_ID)
+
+        with isolated_demo_store(demo_store_dir, DEMO_TRACE_ID):
+            membrane = ReceiptBridge(
+                cfg=BridgeConfig(artifacts_dir=artifacts_dir, cwd=str(output_dir)),
+                invoker=DeterministicOpenClawInvoker(),
+                agent_id=DEMO_AGENT_ID,
+            )
+            allowed_bridge = membrane.run_tool(
+                DEMO_SESSION_ID,
+                "web_fetch",
+                {"url": "https://docs.python.org/3/library/asyncio.html"},
+            )
+            denied_bridge = membrane.run_tool(
+                DEMO_SESSION_ID,
+                "web_fetch",
+                {"url": "http://127.0.0.1:8080/admin"},
+            )
+
+        _write_demo_session_log(session_log_path, entries=session_log_lines)
+        import_report = import_openclaw_session_log(
+            session_log_path,
+            agent_id=DEMO_AGENT_ID,
+            allowlist=["*.github.com"],
+        )
+        imported_receipts = import_report.receipts
+
+        adapter = OpenClawBridge(
+            allowlist=["*.github.com"],
+            agent_id=DEMO_AGENT_ID,
+            session_id=DEMO_SESSION_ID,
+        )
+        blocked_sensitive = adapter.record_browser(
+            url="https://github.com/login",
+            sensitive_action_attempted=True,
+            sensitive_action_type="credential_entry",
+            sensitive_action_approved=False,
+        )
+
+        projected_entries: List[Dict[str, Any]] = []
+        seq = 0
+        for receipt in (allowed_bridge, denied_bridge):
+            projected_entries.append(
+                project_bridge_receipt_for_proof_pack(
+                    receipt,
+                    run_id=DEMO_TRACE_ID,
+                    seq=seq,
+                    evidence_source="membrane_execution",
+                )
+            )
+            seq += 1
+        for imported in import_report.imported_entries:
+            projected_entries.append(
+                project_web_tool_receipt_for_proof_pack(
+                    imported.receipt,
+                    run_id=DEMO_TRACE_ID,
+                    seq=seq,
+                    evidence_source="imported_session_log",
+                    source_line_number=imported.line_number,
+                )
+            )
+            seq += 1
+        projected_entries.append(
+            project_web_tool_receipt_for_proof_pack(
+                blocked_sensitive,
+                run_id=DEMO_TRACE_ID,
+                seq=seq,
+                evidence_source="live_receipt_adapter",
+            )
+        )
+
+        pack = ProofPack(
+            run_id=DEMO_TRACE_ID,
+            entries=projected_entries,
+            signer_id=DEMO_SIGNER_ID,
+            suite_id="openclaw_demo",
+            claim_set_id="openclaw_demo_contract_v1",
+            mode="shadow",
+        )
+        pack.build(
+            pack_dir,
+            keystore=demo_keystore,
+            pack_id=DEMO_PACK_ID,
+            deterministic_ts=DEMO_TIMESTAMP,
+        )
+
+        manifest = json.loads(
+            (pack_dir / "pack_manifest.json").read_text(encoding="utf-8")
+        )
+        verify_result = verify_proof_pack(manifest, pack_dir, demo_keystore)
+
+    summary = {
+        "demo": "openclaw",
+        "trace_id": DEMO_TRACE_ID,
+        "pack_id": DEMO_PACK_ID,
+        "verification": "PASS" if verify_result.passed else "FAIL",
+        "projected_receipt_count": len(projected_entries),
+        "projected_receipt_types": [entry["type"] for entry in projected_entries],
+        "projected_evidence_sources": dict(
+            Counter(entry["evidence_source"] for entry in projected_entries)
+        ),
+        "cases": {
+            "membrane_allowed": {
+                "tool": allowed_bridge["tool_name"],
+                "url": "https://docs.python.org/3/library/asyncio.html",
+                "outcome": allowed_bridge["outcome"],
+            },
+            "membrane_denied": {
+                "tool": denied_bridge["tool_name"],
+                "url": "http://127.0.0.1:8080/admin",
+                "policy_ref": denied_bridge["policy_ref"],
+                "reason": denied_bridge["denial_reason"],
+            },
+            "session_log_import": {
+                "path": str(session_log_path),
+                "status": import_report.completeness,
+                "receipt_count": len(imported_receipts),
+                "imported_count": import_report.imported_count,
+                "total_lines": import_report.total_lines,
+                "blank_lines": import_report.blank_lines,
+                "skipped_count": import_report.skipped_count,
+            },
+            "sensitive_action_blocked": {
+                "url": blocked_sensitive.url,
+                "outcome": blocked_sensitive.outcome,
+                "approved": blocked_sensitive.sensitive_action_approved,
+            },
+        },
+        "import_report": {
+            "status": import_report.completeness,
+            "total_lines": import_report.total_lines,
+            "blank_lines": import_report.blank_lines,
+            "imported_count": import_report.imported_count,
+            "skipped_count": import_report.skipped_count,
+            "skipped_entries": [
+                {
+                    "line_number": skipped.line_number,
+                    "reason": skipped.reason,
+                    "message": skipped.message,
+                    "tool": skipped.tool,
+                    "raw_preview": skipped.raw_preview,
+                }
+                for skipped in import_report.skipped_entries
+            ],
+        },
+    }
+    summary_path.write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    return OpenClawDemoResult(
+        output_dir=output_dir,
+        pack_dir=pack_dir,
+        session_log_path=session_log_path,
+        summary_path=summary_path,
+        projected_entries=projected_entries,
+        import_report=import_report,
+        verification_passed=verify_result.passed,
+        verification_errors=[error.to_dict() for error in verify_result.errors],
+    )
+
+
+__all__ = [
+    "DEMO_AGENT_ID",
+    "DEMO_PACK_ID",
+    "DEMO_SESSION_ID",
+    "DEMO_TIMESTAMP",
+    "DEMO_TRACE_ID",
+    "OpenClawDemoResult",
+    "DeterministicOpenClawInvoker",
+    "project_bridge_receipt_for_proof_pack",
+    "project_web_tool_receipt_for_proof_pack",
+    "run_openclaw_demo",
+]

--- a/tests/assay/test_openclaw_bridge.py
+++ b/tests/assay/test_openclaw_bridge.py
@@ -1,9 +1,11 @@
 """
 Tests for OpenClaw bridge and WebToolReceipt.
 """
-import pytest
+
 import tempfile
 from pathlib import Path
+
+import pytest
 
 
 class TestWebToolReceipt:
@@ -107,7 +109,10 @@ class TestWebToolReceipt:
 
     def test_content_hash_computed(self):
         """Content hash is computed from response bytes."""
-        from assay._receipts.domains.web_tool import create_web_fetch_receipt, compute_content_hash
+        from assay._receipts.domains.web_tool import (
+            compute_content_hash,
+            create_web_fetch_receipt,
+        )
 
         content = b"Hello, world!"
         expected_hash = compute_content_hash(content)
@@ -132,7 +137,10 @@ class TestWebToolReceipt:
             agent_id="agent:test",
             redirect_chain=["https://docs.python.org/", "https://docs.python.org/3/"],
         )
-        assert receipt1.redirect_chain == ["https://docs.python.org/", "https://docs.python.org/3/"]
+        assert receipt1.redirect_chain == [
+            "https://docs.python.org/",
+            "https://docs.python.org/3/",
+        ]
         assert receipt1.crossed_domain_boundary is False
 
         # Cross-domain redirect
@@ -165,7 +173,9 @@ class TestWebToolReceipt:
         """Unapproved sensitive actions cannot have success outcome."""
         from assay._receipts.domains.web_tool import WebToolReceipt
 
-        with pytest.raises(ValueError, match="Unapproved sensitive actions must be blocked"):
+        with pytest.raises(
+            ValueError, match="Unapproved sensitive actions must be blocked"
+        ):
             WebToolReceipt(
                 receipt_id="wtr_test",
                 tool="browser",
@@ -272,7 +282,9 @@ class TestOpenClawBridge:
             allowlist=["*.github.com", "*.python.org"],
         )
 
-        verdict = bridge.check_browser_access("https://github.com/anthropics/claude-code")
+        verdict = bridge.check_browser_access(
+            "https://github.com/anthropics/claude-code"
+        )
 
         assert verdict.allowed is True
         assert verdict.domain == "github.com"
@@ -366,6 +378,80 @@ class TestParseOpenClawSessionLog:
             assert receipts[1].result_size_chars == 5000
             assert receipts[2].tool == "browser"
             assert receipts[2].allowed is True  # github.com in allowlist
+
+        finally:
+            log_path.unlink()
+
+    def test_import_report_tracks_skipped_rows(self):
+        """Malformed, unsupported, and invalid rows are surfaced explicitly."""
+        from assay.openclaw_bridge import import_openclaw_session_log
+
+        log_content = """
+{"tool": "web_search", "query": "python async", "results": [{"title": "a"}]}
+not-json
+{"tool": "shell_exec", "command": "whoami"}
+{"tool": "browser", "url": "https://github.com/login", "sensitive_action_attempted": true}
+{"tool": "web_fetch", "url": "https://docs.python.org/", "content_length": 5000}
+
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            f.write(log_content)
+            log_path = Path(f.name)
+
+        try:
+            report = import_openclaw_session_log(
+                log_path=log_path,
+                agent_id="agent:test",
+                allowlist=["*.github.com"],
+            )
+
+            assert report.total_lines == 7
+            assert report.blank_lines == 2
+            assert report.imported_count == 2
+            assert report.skipped_count == 3
+            assert report.completeness == "partial"
+            assert [receipt.tool for receipt in report.receipts] == [
+                "web_search",
+                "web_fetch",
+            ]
+            assert [entry.line_number for entry in report.imported_entries] == [2, 6]
+            assert [entry.reason for entry in report.skipped_entries] == [
+                "invalid_json",
+                "unsupported_tool",
+                "invalid_entry",
+            ]
+            assert report.skipped_entries[1].tool == "shell_exec"
+            assert "explicit approval status" in report.skipped_entries[2].message
+
+        finally:
+            log_path.unlink()
+
+    def test_imported_browser_row_still_receipts_allowlist_denial(self):
+        """Imported browser rows can become blocked receipts without being skipped."""
+        from assay.openclaw_bridge import import_openclaw_session_log
+
+        log_content = '{"tool": "browser", "url": "https://evil.com/login"}\n'
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            f.write(log_content)
+            log_path = Path(f.name)
+
+        try:
+            report = import_openclaw_session_log(
+                log_path=log_path,
+                agent_id="agent:test",
+                allowlist=["*.github.com"],
+            )
+
+            assert report.imported_count == 1
+            assert report.skipped_count == 0
+            assert report.completeness == "clean"
+            assert report.imported_entries[0].line_number == 1
+            receipt = report.receipts[0]
+            assert receipt.tool == "browser"
+            assert receipt.allowed is False
+            assert receipt.outcome == "blocked"
+            assert receipt.domain_allowlist_match is False
+            assert receipt.policy_rule == "domain_not_in_allowlist"
 
         finally:
             log_path.unlink()

--- a/tests/assay/test_openclaw_demo.py
+++ b/tests/assay/test_openclaw_demo.py
@@ -1,0 +1,137 @@
+"""Tests for the deterministic OpenClaw demo and proof-pack projection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from assay.commands import assay_app
+from assay.openclaw_demo import (
+    project_bridge_receipt_for_proof_pack,
+    run_openclaw_demo,
+)
+from assay.proof_pack import verify_proof_pack
+
+runner = CliRunner()
+
+
+def test_project_bridge_receipt_uses_namespaced_type() -> None:
+    projected = project_bridge_receipt_for_proof_pack(
+        {
+            "receipt_type": "BridgeExecution",
+            "receipt_id": "be_test",
+            "timestamp": "2026-04-08T00:00:00Z",
+            "schema_version": "3.0",
+            "agent_id": "agent:test",
+            "session_id": "sess",
+            "tool_name": "web_fetch",
+            "allowed": True,
+            "outcome": "ok",
+            "policy_hash": "abc",
+            "arguments_sha256": "def",
+        },
+        run_id="openclaw_demo_v1",
+        seq=0,
+    )
+
+    assert projected["type"] == "openclaw.bridge_execution/v1"
+    assert projected["evidence_source"] == "membrane_execution"
+    assert projected["source_receipt_type"] == "BridgeExecution"
+    assert projected["run_id"] == "openclaw_demo_v1"
+
+
+def test_run_openclaw_demo_builds_verifiable_pack(tmp_path: Path) -> None:
+    result = run_openclaw_demo(tmp_path / "demo")
+
+    assert result.verification_passed is True
+    assert result.pack_dir.exists()
+    assert result.session_log_path.exists()
+    assert result.summary_path.exists()
+    assert result.import_report.imported_count == 1
+    assert result.import_report.skipped_count == 0
+
+    manifest = json.loads(
+        (result.pack_dir / "pack_manifest.json").read_text(encoding="utf-8")
+    )
+    verify_result = verify_proof_pack(manifest, result.pack_dir)
+    assert verify_result.passed, [error.to_dict() for error in verify_result.errors]
+
+    summary = json.loads(result.summary_path.read_text(encoding="utf-8"))
+    assert summary["verification"] == "PASS"
+    assert summary["cases"]["membrane_denied"]["policy_ref"] == "POLICY_URL_002"
+    assert summary["import_report"]["status"] == "clean"
+    assert summary["import_report"]["imported_count"] == 1
+    assert summary["import_report"]["skipped_count"] == 0
+    assert summary["projected_evidence_sources"]["membrane_execution"] == 2
+    assert summary["projected_evidence_sources"]["imported_session_log"] == 1
+    assert summary["projected_evidence_sources"]["live_receipt_adapter"] == 1
+
+
+def test_run_openclaw_demo_surfaces_partial_import_report(tmp_path: Path) -> None:
+    result = run_openclaw_demo(
+        tmp_path / "demo_partial",
+        session_log_lines=[
+            {
+                "tool": "browser",
+                "url": "https://github.com/anthropics/claude-code",
+                "content_length": 1024,
+            },
+            {"tool": "shell_exec", "command": "whoami"},
+            {"tool": "browser", "url": "https://evil.com/login"},
+            {
+                "tool": "browser",
+                "url": "https://github.com/login",
+                "sensitive_action_attempted": True,
+            },
+            "not-json",
+            "",
+        ],
+    )
+
+    assert result.verification_passed is True
+    assert result.import_report.imported_count == 2
+    assert result.import_report.skipped_count == 3
+    assert result.import_report.blank_lines == 1
+    assert result.import_report.completeness == "partial"
+
+    imported_entries = {
+        entry["source_line_number"]: entry
+        for entry in result.projected_entries
+        if entry["evidence_source"] == "imported_session_log"
+    }
+    assert imported_entries[1]["allowed"] is True
+    assert imported_entries[3]["allowed"] is False
+    assert imported_entries[3]["outcome"] == "blocked"
+
+    summary = json.loads(result.summary_path.read_text(encoding="utf-8"))
+    assert summary["cases"]["session_log_import"]["status"] == "partial"
+    assert summary["import_report"]["status"] == "partial"
+    assert summary["import_report"]["skipped_count"] == 3
+    assert summary["projected_evidence_sources"]["imported_session_log"] == 2
+    assert [
+        entry["reason"] for entry in summary["import_report"]["skipped_entries"]
+    ] == [
+        "unsupported_tool",
+        "invalid_entry",
+        "invalid_json",
+    ]
+
+
+def test_try_openclaw_cli_json(tmp_path: Path) -> None:
+    output_dir = tmp_path / "demo_cli"
+    result = runner.invoke(
+        assay_app, ["try-openclaw", "--output", str(output_dir), "--json"]
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["status"] == "ok"
+    assert payload["verification"] == "PASS"
+    assert payload["imported_events"] == 1
+    assert payload["skipped_import_entries"] == 0
+    assert payload["import_status"] == "clean"
+    assert payload["import_total_lines"] == 1
+    assert payload["import_blank_lines"] == 0
+    assert Path(payload["pack_dir"]).exists()

--- a/tests/assay/test_openclaw_metadata_floor.py
+++ b/tests/assay/test_openclaw_metadata_floor.py
@@ -1,0 +1,113 @@
+"""Tests for the executable OpenClaw metadata-floor checker."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+from assay.openclaw_demo import run_openclaw_demo
+
+
+def _load_metadata_module():
+    script_path = (
+        Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "check_openclaw_metadata_floor.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "test_openclaw_metadata_floor",
+        script_path,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_metadata_floor_passes_for_clean_demo_artifacts(tmp_path: Path) -> None:
+    module = _load_metadata_module()
+    result = run_openclaw_demo(tmp_path / "demo")
+    openclaw_json_path = tmp_path / "openclaw.json"
+    openclaw_json_path.write_text(
+        json.dumps(
+            {
+                "pack_dir": str(result.pack_dir),
+                "summary": str(result.summary_path),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = module.check_openclaw_metadata_floor_from_openclaw_json(openclaw_json_path)
+
+    assert report.passed is True, report.to_dict()
+    assert report.import_status == "clean"
+    assert report.entry_count == 4
+
+
+def test_metadata_floor_passes_for_partial_import_when_reasons_survive(
+    tmp_path: Path,
+) -> None:
+    module = _load_metadata_module()
+    result = run_openclaw_demo(
+        tmp_path / "demo_partial",
+        session_log_lines=[
+            {
+                "tool": "browser",
+                "url": "https://github.com/anthropics/claude-code",
+                "content_length": 1024,
+            },
+            {"tool": "shell_exec", "command": "whoami"},
+            {"tool": "browser", "url": "https://evil.com/login"},
+            {
+                "tool": "browser",
+                "url": "https://github.com/login",
+                "sensitive_action_attempted": True,
+            },
+            "not-json",
+            "",
+        ],
+    )
+
+    report = module.check_openclaw_metadata_floor(
+        pack_dir=result.pack_dir,
+        summary_path=result.summary_path,
+    )
+
+    assert report.passed is True, report.to_dict()
+    assert report.import_status == "partial"
+
+
+def test_metadata_floor_holds_when_evidence_source_disappears(tmp_path: Path) -> None:
+    module = _load_metadata_module()
+    result = run_openclaw_demo(tmp_path / "demo_mutated")
+    receipt_pack_path = result.pack_dir / "receipt_pack.jsonl"
+
+    entries = [
+        json.loads(line)
+        for line in receipt_pack_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    entries[0].pop("evidence_source", None)
+    receipt_pack_path.write_text(
+        "\n".join(
+            json.dumps(entry, separators=(",", ":"), sort_keys=True)
+            for entry in entries
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = module.check_openclaw_metadata_floor(
+        pack_dir=result.pack_dir,
+        summary_path=result.summary_path,
+    )
+
+    assert report.passed is False
+    assert any(issue.field == "evidence_source" for issue in report.issues)

--- a/tests/assay/test_openclaw_release_branch_gate.py
+++ b/tests/assay/test_openclaw_release_branch_gate.py
@@ -1,0 +1,74 @@
+"""Tests for the OpenClaw release-branch gate script."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_gate_module():
+    script_path = (
+        Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "check_openclaw_release_branch_gate.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "test_openclaw_release_branch_gate",
+        script_path,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_is_branch_backed_distinguishes_detached_head() -> None:
+    module = _load_gate_module()
+
+    assert module.is_branch_backed("HEAD") is False
+    assert module.is_branch_backed("openclaw/release-slice") is True
+
+
+def test_has_pyproject_changes_detects_any_prebump_touch() -> None:
+    module = _load_gate_module()
+
+    assert module.has_pyproject_changes(["./pyproject.toml"], []) is True
+    assert module.has_pyproject_changes([], ["pyproject.toml"]) is True
+    assert (
+        module.has_pyproject_changes(["README.md"], ["docs/openclaw-support.md"])
+        is False
+    )
+
+
+def test_release_branch_gate_result_requires_all_green_conditions() -> None:
+    module = _load_gate_module()
+
+    result = module.OpenClawReleaseBranchGateResult(
+        repository="/tmp/assay",
+        branch_name="openclaw/release-slice",
+        branch_backed=True,
+        staged_pyproject_paths=[],
+        unstaged_pyproject_paths=[],
+        slice_report={"is_isolated": True},
+        slice_isolated=True,
+        smoke_ran=True,
+        smoke_passed=True,
+        smoke_exit_code=0,
+    )
+    assert result.passed is True
+
+    touched = module.OpenClawReleaseBranchGateResult(
+        repository="/tmp/assay",
+        branch_name="openclaw/release-slice",
+        branch_backed=True,
+        staged_pyproject_paths=["pyproject.toml"],
+        unstaged_pyproject_paths=[],
+        slice_report={"is_isolated": True},
+        slice_isolated=True,
+        smoke_ran=False,
+        smoke_passed=False,
+        smoke_exit_code=None,
+    )
+    assert touched.passed is False

--- a/tests/assay/test_openclaw_release_export.py
+++ b/tests/assay/test_openclaw_release_export.py
@@ -1,0 +1,59 @@
+"""Tests for the OpenClaw release-slice exporter script."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_export_module():
+    script_path = (
+        Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "export_openclaw_release_slice.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "test_openclaw_release_export",
+        script_path,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_worktree_add_args_detached_mode() -> None:
+    module = _load_export_module()
+
+    args = module._build_worktree_add_args(
+        Path("/tmp/openclaw-slice"),
+        branch_name=None,
+    )
+
+    assert args == [
+        "worktree",
+        "add",
+        "--detach",
+        "/tmp/openclaw-slice",
+        "HEAD",
+    ]
+
+
+def test_build_worktree_add_args_branch_mode() -> None:
+    module = _load_export_module()
+
+    args = module._build_worktree_add_args(
+        Path("/tmp/openclaw-slice"),
+        branch_name="openclaw/release-slice",
+    )
+
+    assert args == [
+        "worktree",
+        "add",
+        "-b",
+        "openclaw/release-slice",
+        "/tmp/openclaw-slice",
+        "HEAD",
+    ]

--- a/tests/assay/test_openclaw_release_slice.py
+++ b/tests/assay/test_openclaw_release_slice.py
@@ -1,0 +1,133 @@
+"""Tests for the OpenClaw release-slice classifier."""
+
+from __future__ import annotations
+
+from assay._openclaw_release_slice import (
+    OPENCLAW_RELEASE_PATTERNS,
+    build_openclaw_release_slice_report_from_paths,
+    classify_openclaw_release_paths,
+    collect_openclaw_release_slice_paths,
+    is_openclaw_release_path,
+    normalize_repo_path,
+)
+
+
+def test_normalize_repo_path_stabilizes_git_output() -> None:
+    assert (
+        normalize_repo_path("./src/assay/openclaw_demo.py")
+        == "src/assay/openclaw_demo.py"
+    )
+    assert (
+        normalize_repo_path("src\\assay\\openclaw_demo.py")
+        == "src/assay/openclaw_demo.py"
+    )
+
+
+def test_openclaw_release_allowlist_matches_expected_paths() -> None:
+    assert is_openclaw_release_path("src/assay/openclaw_demo.py") is True
+    assert is_openclaw_release_path("tests/assay/test_openclaw_bridge.py") is True
+    assert is_openclaw_release_path("docs/openclaw-v1-claim-sheet.md") is True
+    assert (
+        is_openclaw_release_path("docs/specs/OPENCLAW_BRIDGE_GAP_ANALYSIS_V1.md")
+        is True
+    )
+    assert (
+        is_openclaw_release_path("docs/security/RELEASE_SECURITY_CHECKLIST.md") is True
+    )
+    assert (
+        is_openclaw_release_path("scripts/check_openclaw_release_branch_gate.py")
+        is True
+    )
+    assert is_openclaw_release_path("scripts/check_openclaw_metadata_floor.py") is True
+    assert is_openclaw_release_path("scripts/export_openclaw_release_slice.py") is True
+    assert is_openclaw_release_path("src/assay/explain.py") is False
+    assert (
+        is_openclaw_release_path(
+            "docs/specs/PROOF_PACK_SCOPE_AND_RECEIPT_MAPPING_V1.md"
+        )
+        is False
+    )
+    assert is_openclaw_release_path("pyproject.toml") is False
+
+
+def test_classify_openclaw_release_paths_splits_scope_cleanly() -> None:
+    in_scope, out_of_scope = classify_openclaw_release_paths(
+        [
+            "README.md",
+            "src/assay/commands.py",
+            "src/assay/explain.py",
+            "assay_openclaw_demo/DEMO_SUMMARY.json",
+        ],
+        allowed_patterns=OPENCLAW_RELEASE_PATTERNS,
+    )
+
+    assert in_scope == ["README.md", "src/assay/commands.py"]
+    assert out_of_scope == [
+        "assay_openclaw_demo/DEMO_SUMMARY.json",
+        "src/assay/explain.py",
+    ]
+
+
+def test_release_slice_report_marks_mixed_tree_as_hold() -> None:
+    report = build_openclaw_release_slice_report_from_paths(
+        repository="/tmp/assay",
+        staged_paths=["src/assay/openclaw_bridge.py"],
+        unstaged_paths=["docs/openclaw-support.md", "src/assay/proof_pack.py"],
+        untracked_paths=["scripts/check_openclaw_release_slice.py"],
+    )
+
+    assert report.has_changes is True
+    assert report.is_isolated is False
+    assert report.staged_in_scope == ["src/assay/openclaw_bridge.py"]
+    assert report.unstaged_in_scope == ["docs/openclaw-support.md"]
+    assert report.unstaged_out_of_scope == ["src/assay/proof_pack.py"]
+    assert report.untracked_in_scope == ["scripts/check_openclaw_release_slice.py"]
+
+
+def test_release_slice_report_passes_when_only_openclaw_paths_change() -> None:
+    report = build_openclaw_release_slice_report_from_paths(
+        repository="/tmp/assay",
+        staged_paths=["src/assay/openclaw_demo.py"],
+        unstaged_paths=["README.md", "docs/openclaw-v1-claim-sheet.md"],
+        untracked_paths=["tests/assay/test_openclaw_release_slice.py"],
+    )
+
+    assert report.has_changes is True
+    assert report.is_isolated is True
+    assert report.staged_out_of_scope == []
+    assert report.unstaged_out_of_scope == []
+    assert report.untracked_out_of_scope == []
+
+
+def test_release_slice_report_blocks_version_bump_surface() -> None:
+    report = build_openclaw_release_slice_report_from_paths(
+        repository="/tmp/assay",
+        staged_paths=["pyproject.toml"],
+    )
+
+    assert report.is_isolated is False
+    assert report.staged_out_of_scope == ["pyproject.toml"]
+
+
+def test_collect_release_slice_paths_dedups_all_in_scope_buckets() -> None:
+    report = build_openclaw_release_slice_report_from_paths(
+        repository="/tmp/assay",
+        staged_paths=["src/assay/openclaw_demo.py"],
+        unstaged_paths=["README.md", "docs/openclaw-v1-claim-sheet.md"],
+        untracked_paths=[
+            "scripts/check_openclaw_release_branch_gate.py",
+            "scripts/check_openclaw_metadata_floor.py",
+            "scripts/check_openclaw_release_slice.py",
+            "scripts/export_openclaw_release_slice.py",
+        ],
+    )
+
+    assert collect_openclaw_release_slice_paths(report) == [
+        "README.md",
+        "docs/openclaw-v1-claim-sheet.md",
+        "scripts/check_openclaw_metadata_floor.py",
+        "scripts/check_openclaw_release_branch_gate.py",
+        "scripts/check_openclaw_release_slice.py",
+        "scripts/export_openclaw_release_slice.py",
+        "src/assay/openclaw_demo.py",
+    ]


### PR DESCRIPTION
## Summary

- add the OpenClaw release-review slice, branch gate, metadata-floor checker, and packaged smoke enforcement
- document the bounded OpenClaw v1 support and claim surface
- bump `assay-ai` from `1.21.0` to `1.22.0` in the clean review candidate only

## Review focus

- confirm the release wording stays intentionally narrow
- confirm artifact expectations match the packaged behavior
- confirm the explicit non-proof remains intact: OpenClaw v1 does not yet emit stable trust-boundary identity

## Release posture

- mechanically release-ready
- publish still requires explicit human go/no-go
- pre-bump evidence branch: `codex/openclaw-release-slice-2026-04-09-metadata-floor`
- review/publish candidate: `codex/openclaw-release-slice-2026-04-09-version-review-clean-025507`
- reviewed commit: `b5b564300c84e1e4af7144ad176dfdc9418092c2`

## Notes

- this PR is for review ceremony only
- no PyPI upload is included in this step
- stable trust-boundary identity remains post-release hardening work, not a v1 claim
