### PR TITLE
docs(readme): coherence pass — receipt line, pilot waitlist, VendorQ demote

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Microsoft enforces runtime policy. Assay proves what happened.
 
 One byte changed. Verification fails. No server call. Just math.
 
+Receipts are forwardable, offline-verifiable, and tamper-evident.
+
 ### Install
 
 ```bash
@@ -464,11 +466,15 @@ Full reference (key management, lockfile, pack management, incident forensics): 
 </details>
 
 <details>
-<summary><b>Advanced: VendorQ</b> (verifiable vendor questionnaires)</summary>
+<summary><b>Experimental: VendorQ</b> (verifiable vendor questionnaires — export format only)</summary>
 
 ## VendorQ: Verifiable Vendor Questionnaires
 
-Enterprise customers ask AI governance questions in security questionnaires.
+> **Posture:** VendorQ is currently an **export format** for evidence-backed
+> answers, not a production governance surface. Command examples are retained
+> for reproducibility; broader governance features are out of scope until the
+> product surface stabilizes.
+
 VendorQ compiles evidence-backed answer packets from Assay proof packs.
 Every answer traces to a signed receipt. Every modification is detectable.
 
@@ -759,9 +765,9 @@ Restart your shell after installing. Tab completion works for all commands and o
 - **Try it**: `python3 -m pip install assay-ai && assay try`
 - **Questions / feedback**: [GitHub Discussions](https://github.com/Haserjian/assay/discussions)
 - **Bug reports**: [Issues](https://github.com/Haserjian/assay/issues)
-- **Want this in your stack in 2 weeks?** [Pilot program](docs/PILOT_PROGRAM.md) --
-  we instrument your AI workflows, set up CI gates, and hand you a working
-  evidence pipeline. [Open a pilot inquiry](https://github.com/Haserjian/assay/issues/new?template=pilot-inquiry.md).
+- **Pilot program**: onboarding a bounded cohort while the product surface
+  stabilizes; new inquiries are queued as a waitlist rather than an immediate
+  start. Posture and scope: [Pilot program](docs/PILOT_PROGRAM.md).
 
 ## Related Repos
 


### PR DESCRIPTION
## Why now

`assay-ai 1.22.0` is already shipped and live on PyPI, but ecosystem version and discovery signals were inconsistent across repos (scorecard lagged at 1.19.0, AgentMesh CI pinned 1.18.0, pilot CTA language predated the current product posture). This is the `assay`-side of a bounded four-repo coherence pass aligning the public surface with already-shipped reality.

## Scope (only public coherence edits in this repo)

Three surgical edits to `README.md`:

1. **Bounded receipt-properties sentence** near the opening:
   > Receipts are forwardable, offline-verifiable, and tamper-evident.

2. **Pilot CTA replacement.** Dropped "Want this in your stack in 2 weeks?" + direct pilot-inquiry link. Replaced with bounded waitlist language that matches the current "product surface frozen / no outbound GTM" posture.

3. **VendorQ demote.** Summary label `Advanced` → `Experimental (— export format only)`; added a posture banner explicitly stating VendorQ is an export format, not a production governance surface. Dropped the `Enterprise customers ask…` buyer framing. Command examples retained for reproducibility.

Total diff: 1 file, +11 -5.

## Not included

- No product-surface widening
- No new feature claims
- No branch cleanup or archaeology
- No release work
- No `src/` or test changes
- No touching the in-flight post-1.22.0 working-tree work (base is `origin/main` @ the v1.22.0 merge, not local state)

## Sibling PRs

This PR is part of a coordinated four-repo coherence pass:

- Haserjian/assay#67 — this PR: bounded receipt line, pilot waitlist, VendorQ demote
- Haserjian/agentmesh#41 — `assay-ai` pin bump to `1.22.0` + OpenClaw discoverability
- Haserjian/assay-scorecard#1 — bump scan-version reference to `v1.22.0`
- Haserjian/assay-verify-action#12 — OpenClaw integration link in Links section