### PR TITLE
docs: add OpenClaw live-validation runbook link to START_HERE

### DIFF
--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -111,6 +111,7 @@ Open a PR and you'll see all three checks in your GitHub status checks.
 - [Reviewer Packets](reviewer-packets.md) -- compile and verify the buyer-facing reviewer-ready evidence packet
 - [OpenClaw v1 Claim Sheet](openclaw-v1-claim-sheet.md) -- short statement of current proofs, non-proofs, trust assumptions, and required artifacts
 - [OpenClaw Support](openclaw-support.md) -- current subprocess membrane posture, proof boundary, and non-goals
+- [OpenClaw Live Validation Runbook](openclaw-live-validation-runbook.md) -- internal operator path for generating the first real exported session log and rerunning the live-fit harness
 - `assay diff` -- compare packs for cost/latency regressions
 - [Integrity surface spec](specs/INTEGRITY_SURFACE_SPEC_V1.md) and [port compatibility checklist](specs/INTEGRITY_PORT_COMPATIBILITY_CHECKLIST.md) -- the normative contract for verifier ports
 - [CI integration](ci-integration.md) -- why CI matters and how to enforce evidence discipline


### PR DESCRIPTION
Companion to #72. The runbook (`docs/openclaw-live-validation-runbook.md`) landed in that PR but the `START_HERE.md` index wasn't updated in the same slice.

1 file, 1 line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)