### PR TITLE
ci: temporary expiry-surface guard until #75 is decided

### DIFF
--- a/.github/workflows/expiry-decision-gate.yml
+++ b/.github/workflows/expiry-decision-gate.yml
@@ -1,0 +1,43 @@
+name: verify-pack expiry decision gate
+
+# TEMPORARY — remove once https://github.com/Haserjian/assay/issues/75 is decided and implemented.
+#
+# Fires only when commands.py changes. Within that, blocks any diff hunk
+# that touches the verify-pack expiry surface until #75 is resolved.
+
+on:
+  pull_request:
+    paths:
+      - 'src/assay/commands.py'
+
+jobs:
+  expiry-guard:
+    name: expiry-surface guard (#75)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fail if expiry surface is touched
+        run: |
+          EXPIRY_PATTERN='check.expiry|valid_until|parse_rfc3339|expiry_failed|expiry_message'
+
+          if git diff "origin/${{ github.base_ref }}...HEAD" -- src/assay/commands.py \
+               | grep -E "^\+" \
+               | grep -qE "$EXPIRY_PATTERN"; then
+            echo ""
+            echo "ERROR: verify-pack expiry behavior is under active decision."
+            echo ""
+            echo "  Issue:   https://github.com/Haserjian/assay/issues/75"
+            echo "  Surface: verify_pack_cmd --check-expiry / valid_until handling"
+            echo ""
+            echo "Do not change this surface until #75 is resolved and implemented."
+            echo "If your change is genuinely unrelated to expiry logic, update the guard in"
+            echo "  .github/workflows/expiry-decision-gate.yml"
+            echo "with an explanation."
+            echo ""
+            exit 1
+          fi
+
+          echo "No expiry surface changes detected. Guard passed."


### PR DESCRIPTION
## What

A narrow, temporary CI workflow that blocks any PR touching the `verify-pack` expiry surface in `commands.py` until [#75](https://github.com/Haserjian/assay/issues/75) is decided.

## How it works

- Triggers **only** when `src/assay/commands.py` is in the changeset (path filter)
- Within that, greps the added lines for expiry-related tokens: `check.expiry`, `valid_until`, `parse_rfc3339`, `expiry_failed`, `expiry_message`
- Fails with a plain message pointing to #75
- Passes silently for any commands.py change that doesn't touch the expiry surface

## What it does NOT block

- Any PR that doesn't touch `commands.py`
- Changes to `commands.py` unrelated to expiry logic

## Removal condition

Delete this workflow once #75 is resolved and the decided behavior is implemented. The file header says so explicitly.

## Why this instead of a comment

A comment is advisory. A CI gate is structural. The point is to prevent casual "just also fix this" edits before the decision is made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)