### PR TITLE
intake: wire Evidence Preview private form URL via contact_links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Evidence Preview (async, written-only)
+    url: https://tally.so/r/KYJ2VK
+    about: "Submit one workflow or eval pair and one assurance goal. 48-hour written response, no meeting required. Private intake — your submission is not public."


### PR DESCRIPTION
## Summary
- Adds `.github/ISSUE_TEMPLATE/config.yml` with a `contact_links` entry pointing the repo UI New Issue doorway at the private Tally intake form `https://tally.so/r/KYJ2VK`.
- Sets `blank_issues_enabled: false` to close the public bypass so the privacy promise on the form can be honored end-to-end.

## Why
Earlier design routed intake through a public GitHub issue form, but public issues cannot honor a private-handling promise for sensitive buyer context. The intake now lives on a private Tally form; this PR makes the repo UI point at it as a one-line doorway rather than collect data publicly.

## Test plan
- [ ] Preview the repo's "New issue" page and confirm the contact link "Evidence Preview (async, written-only)" appears, pointing at the Tally URL.
- [ ] Confirm the blank issue option is not visible to non-maintainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)