### PR TITLE
fix(score): remove key_setup from composite, report as environment (#78)

### DIFF
--- a/src/assay/score.py
+++ b/src/assay/score.py
@@ -20,15 +20,16 @@ from assay.keystore import get_default_keystore
 from assay.lockfile import check_lockfile
 from assay.scanner import scan_directory
 
-SCORE_VERSION = "1.0.0"
+SCORE_VERSION = "2.0.0"
 
-# Weighted components (must sum to 100)
+# Weighted repo-scoped components (must sum to 100).
+# key_setup was removed in v2: it read the operator's ~/.assay/keys/
+# instead of the scanned repo, making scores non-reproducible (#78).
 WEIGHTS: Dict[str, int] = {
-    "coverage": 35,
-    "lockfile": 15,
-    "ci_gate": 20,
-    "receipts": 20,
-    "key_setup": 10,
+    "coverage": 39,
+    "lockfile": 17,
+    "ci_gate": 22,
+    "receipts": 22,
 }
 
 # Grade tier descriptions shown to users.
@@ -234,21 +235,21 @@ def compute_evidence_readiness_score(facts: Dict[str, Any]) -> Dict[str, Any]:
         },
     }
 
-    # 5) Key setup
+    # 5) Key setup — environment-scoped, NOT included in composite (#78).
+    # Reported for operator awareness but does not affect repo score.
     keys = facts.get("keys", {})
     signer_count = int(keys.get("signer_count", 0) or 0)
     if signer_count > 0:
-        key_points = float(WEIGHTS["key_setup"])
         key_status = "pass"
-        key_note = f"{signer_count} signer(s) configured."
+        key_note = f"{signer_count} signer(s) configured (operator environment)."
     else:
-        key_points = 0.0
-        key_status = "fail"
-        key_note = "No signing key configured."
+        key_status = "info"
+        key_note = "No signing key configured (operator environment — does not affect score)."
 
     breakdown["key_setup"] = {
-        "weight": WEIGHTS["key_setup"],
-        "points": key_points,
+        "scope": "environment",
+        "weight": 0,
+        "points": 0.0,
         "status": key_status,
         "note": key_note,
         "evidence": {
@@ -444,10 +445,10 @@ def _build_next_actions(
         })
     if int(keys.get("signer_count", 0) or 0) == 0:
         actions.append({
-            "action": "Initialize signer key",
+            "action": "Initialize signer key (operator environment — does not affect score)",
             "command": 'assay run --allow-empty -- python -c "pass"',
             "component": "key_setup",
-            "points_est": _gap("key_setup"),
+            "points_est": 0.0,
         })
 
     if not actions:

--- a/tests/assay/test_score.py
+++ b/tests/assay/test_score.py
@@ -8,7 +8,7 @@ from typing import Any, Dict
 from typer.testing import CliRunner
 
 from assay.commands import assay_app
-from assay.score import GRADE_TIERS, SCORE_VERSION, compute_evidence_readiness_score, gather_score_facts
+from assay.score import GRADE_TIERS, SCORE_VERSION, WEIGHTS, compute_evidence_readiness_score, gather_score_facts
 
 runner = CliRunner()
 
@@ -104,6 +104,23 @@ class TestComputeEvidenceReadiness:
         assert any("assay lock init" in step for step in result["next_actions"])
 
 
+    def test_key_setup_does_not_affect_composite_score(self) -> None:
+        """Regression test for #78: key_setup is environment-scoped and must
+        not contribute points to the repo-scoped composite score."""
+        with_signer = compute_evidence_readiness_score(_facts(signer_count=5))
+        without_signer = compute_evidence_readiness_score(_facts(signer_count=0))
+        assert with_signer["score"] == without_signer["score"]
+        assert with_signer["breakdown"]["key_setup"]["scope"] == "environment"
+        assert with_signer["breakdown"]["key_setup"]["points"] == 0.0
+        assert without_signer["breakdown"]["key_setup"]["points"] == 0.0
+
+    def test_weights_sum_to_100(self) -> None:
+        assert sum(WEIGHTS.values()) == 100
+
+    def test_key_setup_not_in_weights(self) -> None:
+        assert "key_setup" not in WEIGHTS
+
+
 class TestGatherFacts:
     def test_gather_score_facts_basic_shape(self, tmp_path: Path) -> None:
         (tmp_path / "app.py").write_text(
@@ -195,7 +212,7 @@ class TestGuidanceLayer:
             a for a in result["next_actions_detail"] if a["component"] == "lockfile"
         ]
         assert len(lock_actions) == 1
-        assert lock_actions[0]["points_est"] == 15.0
+        assert lock_actions[0]["points_est"] == float(WEIGHTS["lockfile"])
         assert "assay lock init" in lock_actions[0]["command"]
 
     def test_next_actions_backward_compat_strings(self) -> None:


### PR DESCRIPTION
## Summary
- `key_setup` read from `~/.assay/keys/` (operator env) not the scanned repo, making `assay score` non-reproducible across machines (#78)
- Removed from `WEIGHTS`, re-weighted remaining 4 components proportionally (39/17/22/22)
- Still reported in breakdown as `scope: "environment"` with `points: 0`
- `SCORE_VERSION` bumped `1.0.0` → `2.0.0` (methodology change)

## Test plan
- [x] `pytest tests/assay/test_score.py tests/assay/test_score_report.py -q` → 58 passed
- [x] key_setup does not affect composite (signer_count=5 == signer_count=0)
- [x] WEIGHTS sum to 100
- [x] key_setup not in WEIGHTS

Closes #78.