### PR TITLE
feat(reviewer-packet): buyer-packet evidence sprint — generator, validator, e2e tests

### DIFF
--- a/src/assay/reviewer_packet.py
+++ b/src/assay/reviewer_packet.py
@@ -1,0 +1,222 @@
+"""Reviewer Packet v0.1 -- buyer-facing evidence packet projection layer.
+
+Minimal dataclasses for the reviewer-ready evidence packet.
+This is the shape a skeptical buyer reads.
+
+Architecture law: This is a projection layer for commercial reviewability,
+not an independent source of truth. Canonical evidence remains the proof
+pack and the settlement-based reviewer-packet path in
+reviewer_packet_compile.py / reviewer_packet_verify.py. This module
+defines a lightweight buyer-facing *view* of that evidence for demo,
+outbound, and first-contact scenarios.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+AUTHORITY_CLASSES = frozenset({
+    "machine_evidenced",
+    "human_attested",
+    "mixed",
+    "insufficient",
+})
+
+ANSWER_STATUSES = frozenset({
+    "ANSWERED",
+    "INSUFFICIENT_EVIDENCE",
+    "NOT_APPLICABLE",
+})
+
+
+@dataclass
+class EvidenceRef:
+    """Pointer to a specific piece of evidence in the proof pack."""
+
+    receipt_id: str
+    receipt_type: str
+    authority_class: str  # machine_evidenced | human_attested
+    description: str
+    artifact_path: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {
+            "receipt_id": self.receipt_id,
+            "receipt_type": self.receipt_type,
+            "authority_class": self.authority_class,
+            "description": self.description,
+        }
+        if self.artifact_path is not None:
+            d["artifact_path"] = self.artifact_path
+        return d
+
+
+@dataclass
+class QuestionAnswer:
+    """One question-answer pair in the reviewer questionnaire."""
+
+    question_id: str
+    question_text: str
+    status: str  # ANSWERED | INSUFFICIENT_EVIDENCE | NOT_APPLICABLE
+    authority_class: str  # machine_evidenced | human_attested | mixed | insufficient
+    evidence_refs: List[EvidenceRef] = field(default_factory=list)
+    answer_text: Optional[str] = None
+    notes: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {
+            "question_id": self.question_id,
+            "question_text": self.question_text,
+            "status": self.status,
+            "authority_class": self.authority_class,
+            "evidence_refs": [r.to_dict() for r in self.evidence_refs],
+        }
+        if self.answer_text is not None:
+            d["answer_text"] = self.answer_text
+        if self.notes is not None:
+            d["notes"] = self.notes
+        return d
+
+
+@dataclass
+class ReviewerPacket:
+    """The top-level reviewer-facing evidence packet."""
+
+    packet_id: str
+    workflow_name: str
+    workflow_description: str
+    questions: List[QuestionAnswer]
+    proof_pack_path: str
+    proof_pack_id: str
+    proof_pack_verified: bool
+    signer_id: str
+    signer_fingerprint: str
+    generated_at: str
+
+    @property
+    def answered_count(self) -> int:
+        return sum(1 for q in self.questions if q.status == "ANSWERED")
+
+    @property
+    def unresolved_count(self) -> int:
+        return sum(1 for q in self.questions if q.status == "INSUFFICIENT_EVIDENCE")
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "packet_id": self.packet_id,
+            "schema_version": "0.1.0",
+            "workflow_name": self.workflow_name,
+            "workflow_description": self.workflow_description,
+            "questions": [q.to_dict() for q in self.questions],
+            "proof_pack_path": self.proof_pack_path,
+            "proof_pack_id": self.proof_pack_id,
+            "proof_pack_verified": self.proof_pack_verified,
+            "signer_id": self.signer_id,
+            "signer_fingerprint": self.signer_fingerprint,
+            "generated_at": self.generated_at,
+            "summary": {
+                "total_questions": len(self.questions),
+                "answered": self.answered_count,
+                "unresolved": self.unresolved_count,
+                "authority_breakdown": self._authority_breakdown(),
+            },
+        }
+
+    def _authority_breakdown(self) -> Dict[str, int]:
+        breakdown: Dict[str, int] = {}
+        for q in self.questions:
+            breakdown[q.authority_class] = breakdown.get(q.authority_class, 0) + 1
+        return breakdown
+
+    def write(self, out_dir: Path) -> Path:
+        """Write packet artifacts to out_dir. Returns out_dir."""
+        out_dir = Path(out_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        packet_dict = self.to_dict()
+
+        # packet.json — the canonical packet
+        (out_dir / "packet.json").write_text(
+            json.dumps(packet_dict, indent=2), encoding="utf-8"
+        )
+
+        # questionnaire_answers.json — just the Q&A pairs
+        (out_dir / "questionnaire_answers.json").write_text(
+            json.dumps(packet_dict["questions"], indent=2), encoding="utf-8"
+        )
+
+        # evidence_index.json — receipt_id -> evidence ref mapping
+        # A receipt can be referenced by multiple questions, so
+        # referenced_by is a list to avoid key-collision data loss.
+        index: Dict[str, Any] = {}
+        for q in self.questions:
+            for ref in q.evidence_refs:
+                if ref.receipt_id in index:
+                    existing = index[ref.receipt_id]
+                    if q.question_id not in existing["referenced_by"]:
+                        existing["referenced_by"].append(q.question_id)
+                else:
+                    index[ref.receipt_id] = {
+                        "receipt_type": ref.receipt_type,
+                        "authority_class": ref.authority_class,
+                        "referenced_by": [q.question_id],
+                        "description": ref.description,
+                    }
+        (out_dir / "evidence_index.json").write_text(
+            json.dumps(index, indent=2), encoding="utf-8"
+        )
+
+        # reviewer_summary.md — human-readable summary
+        lines = [
+            f"# Reviewer Packet: {self.workflow_name}",
+            "",
+            f"**Packet ID:** `{self.packet_id}`",
+            f"**Generated:** {self.generated_at}",
+            f"**Proof Pack:** `{self.proof_pack_id}` (verified: {self.proof_pack_verified})",
+            f"**Signer:** `{self.signer_id}` (`{self.signer_fingerprint[:16]}...`)",
+            "",
+            f"## Summary",
+            "",
+            f"- **{self.answered_count}** of **{len(self.questions)}** questions answered",
+            f"- **{self.unresolved_count}** honestly unresolved",
+            "",
+            "## Questions",
+            "",
+        ]
+        for q in self.questions:
+            status_marker = {
+                "ANSWERED": "PASS",
+                "INSUFFICIENT_EVIDENCE": "GAP",
+                "NOT_APPLICABLE": "N/A",
+            }.get(q.status, q.status)
+            lines.append(f"### {q.question_id}: {q.question_text}")
+            lines.append("")
+            lines.append(f"- **Status:** {status_marker}")
+            lines.append(f"- **Authority:** {q.authority_class}")
+            if q.answer_text:
+                lines.append(f"- **Answer:** {q.answer_text}")
+            if q.evidence_refs:
+                lines.append(f"- **Evidence:** {len(q.evidence_refs)} ref(s)")
+                for ref in q.evidence_refs:
+                    lines.append(f"  - `{ref.receipt_id}` ({ref.receipt_type}, {ref.authority_class})")
+            if q.notes:
+                lines.append(f"- **Notes:** {q.notes}")
+            lines.append("")
+
+        (out_dir / "reviewer_summary.md").write_text(
+            "\n".join(lines), encoding="utf-8"
+        )
+
+        return out_dir
+
+
+__all__ = [
+    "ANSWER_STATUSES",
+    "AUTHORITY_CLASSES",
+    "EvidenceRef",
+    "QuestionAnswer",
+    "ReviewerPacket",
+]

--- a/src/assay/reviewer_packet_validator.py
+++ b/src/assay/reviewer_packet_validator.py
@@ -1,0 +1,347 @@
+"""Reviewer Packet validator -- catches inflation, missing evidence, and inconsistency.
+
+Five failure modes (the commercial differentiator):
+  E_MISSING_EVIDENCE        ANSWERED question has no evidence refs
+  E_AUTHORITY_INFLATED      machine_evidenced but no machine-generated receipt
+  E_UNRESOLVED_RELABELED    was INSUFFICIENT_EVIDENCE, inflated to ANSWERED without evidence
+  E_MACHINE_CLAIM_NO_RECEIPT  machine_evidenced but only human attestation refs
+  E_VERIFICATION_MISMATCH   packet says proof_pack_verified=true but re-verification fails
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+
+from assay.reviewer_packet import (
+    ANSWER_STATUSES,
+    AUTHORITY_CLASSES,
+    ReviewerPacket,
+)
+
+# Error codes
+E_MISSING_EVIDENCE = "E_MISSING_EVIDENCE"
+E_AUTHORITY_INFLATED = "E_AUTHORITY_INFLATED"
+E_UNRESOLVED_RELABELED = "E_UNRESOLVED_RELABELED"
+E_MACHINE_CLAIM_NO_RECEIPT = "E_MACHINE_CLAIM_NO_RECEIPT"
+E_VERIFICATION_MISMATCH = "E_VERIFICATION_MISMATCH"
+E_INVALID_STATUS = "E_INVALID_STATUS"
+E_INVALID_AUTHORITY = "E_INVALID_AUTHORITY"
+E_NO_QUESTIONS = "E_NO_QUESTIONS"
+E_EVIDENCE_REF_ORPHANED = "E_EVIDENCE_REF_ORPHANED"
+E_ARTIFACT_PATH_MISSING = "E_ARTIFACT_PATH_MISSING"
+E_ARTIFACT_PATH_ESCAPE = "E_ARTIFACT_PATH_ESCAPE"
+
+# Receipt types that constitute machine-generated evidence
+MACHINE_RECEIPT_TYPES = frozenset({
+    "model_call",
+    "guardian_verdict",
+    "guardian_decision",
+    "claim_verification",
+    "claim_extraction",
+    "packet_compiled",
+    "verification_result",
+})
+
+
+@dataclass
+class PacketValidationError:
+    code: str
+    message: str
+    question_id: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {"code": self.code, "message": self.message}
+        if self.question_id is not None:
+            d["question_id"] = self.question_id
+        return d
+
+
+@dataclass
+class PacketValidationResult:
+    passed: bool
+    errors: List[PacketValidationError] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "passed": self.passed,
+            "errors": [e.to_dict() for e in self.errors],
+            "warnings": self.warnings,
+        }
+
+
+def validate_packet(
+    packet: ReviewerPacket,
+    *,
+    receipt_ids_on_disk: Optional[Set[str]] = None,
+    require_unresolved: bool = True,
+    proof_pack_dir: Optional[Path] = None,
+) -> PacketValidationResult:
+    """Validate a ReviewerPacket for evidence completeness and honesty.
+
+    Args:
+        packet: The packet to validate.
+        receipt_ids_on_disk: Set of receipt_ids present in the proof pack.
+            When provided, evidence refs are checked for orphaned references.
+        require_unresolved: When True (default), at least one question must
+            be INSUFFICIENT_EVIDENCE. This is the anti-inflation guardrail.
+        proof_pack_dir: When provided, re-verify the proof pack and check
+            consistency with packet.proof_pack_verified.
+    """
+    errors: List[PacketValidationError] = []
+    warnings: List[str] = []
+
+    # Structural: must have questions
+    if not packet.questions:
+        errors.append(PacketValidationError(
+            code=E_NO_QUESTIONS,
+            message="Packet has no questions",
+        ))
+        return PacketValidationResult(passed=False, errors=errors, warnings=warnings)
+
+    has_unresolved = False
+
+    for q in packet.questions:
+        # Valid status
+        if q.status not in ANSWER_STATUSES:
+            errors.append(PacketValidationError(
+                code=E_INVALID_STATUS,
+                message=f"Invalid status '{q.status}' (must be one of {sorted(ANSWER_STATUSES)})",
+                question_id=q.question_id,
+            ))
+
+        # Valid authority class
+        if q.authority_class not in AUTHORITY_CLASSES:
+            errors.append(PacketValidationError(
+                code=E_INVALID_AUTHORITY,
+                message=f"Invalid authority_class '{q.authority_class}' (must be one of {sorted(AUTHORITY_CLASSES)})",
+                question_id=q.question_id,
+            ))
+
+        if q.status == "INSUFFICIENT_EVIDENCE":
+            has_unresolved = True
+
+        # --- Core anti-inflation checks ---
+
+        if q.status == "ANSWERED":
+            # Check 1: ANSWERED must have evidence
+            if not q.evidence_refs:
+                errors.append(PacketValidationError(
+                    code=E_MISSING_EVIDENCE,
+                    message=f"Question is ANSWERED but has no evidence refs",
+                    question_id=q.question_id,
+                ))
+
+            # Check 2: machine_evidenced must have at least one machine receipt
+            if q.authority_class == "machine_evidenced" and q.evidence_refs:
+                has_machine = any(
+                    ref.receipt_type in MACHINE_RECEIPT_TYPES
+                    for ref in q.evidence_refs
+                )
+                if not has_machine:
+                    errors.append(PacketValidationError(
+                        code=E_MACHINE_CLAIM_NO_RECEIPT,
+                        message=f"Claims machine_evidenced but no machine-generated receipt type found",
+                        question_id=q.question_id,
+                    ))
+
+            # Check 3: mixed must have both machine and human evidence
+            if q.authority_class == "mixed" and q.evidence_refs:
+                has_machine = any(
+                    ref.authority_class == "machine_evidenced"
+                    for ref in q.evidence_refs
+                )
+                has_human = any(
+                    ref.authority_class == "human_attested"
+                    for ref in q.evidence_refs
+                )
+                if not (has_machine and has_human):
+                    warnings.append(
+                        f"{q.question_id}: mixed authority but evidence refs "
+                        f"don't include both machine and human sources"
+                    )
+
+        # Check 4: authority inflation — insufficient authority with ANSWERED status
+        if q.status == "ANSWERED" and q.authority_class == "insufficient":
+            errors.append(PacketValidationError(
+                code=E_AUTHORITY_INFLATED,
+                message=f"ANSWERED with 'insufficient' authority class is contradictory",
+                question_id=q.question_id,
+            ))
+
+        # Check 5: unresolved relabeled — ANSWERED with machine_evidenced but
+        # evidence refs are empty (the tamper-B scenario)
+        if (
+            q.status == "ANSWERED"
+            and q.authority_class == "machine_evidenced"
+            and not q.evidence_refs
+        ):
+            errors.append(PacketValidationError(
+                code=E_UNRESOLVED_RELABELED,
+                message=f"Appears to be an inflated unresolved question: "
+                        f"ANSWERED + machine_evidenced but no evidence",
+                question_id=q.question_id,
+            ))
+
+        # Check 6: orphaned evidence refs
+        if receipt_ids_on_disk is not None:
+            for ref in q.evidence_refs:
+                if ref.receipt_id not in receipt_ids_on_disk:
+                    errors.append(PacketValidationError(
+                        code=E_EVIDENCE_REF_ORPHANED,
+                        message=f"Evidence ref '{ref.receipt_id}' not found in proof pack",
+                        question_id=q.question_id,
+                    ))
+
+        # Check 7: artifact_path existence and containment
+        if proof_pack_dir is not None:
+            packet_root = proof_pack_dir.parent
+            root_resolved = packet_root.resolve()
+            for ref in q.evidence_refs:
+                if ref.artifact_path is not None:
+                    target = (packet_root / ref.artifact_path).resolve()
+                    # Semantic path containment (not string prefix).
+                    # relative_to raises ValueError if target is not
+                    # under root_resolved, catching both traversal
+                    # and sibling-prefix attacks.
+                    try:
+                        target.relative_to(root_resolved)
+                    except ValueError:
+                        errors.append(PacketValidationError(
+                            code=E_ARTIFACT_PATH_ESCAPE,
+                            message=f"artifact_path '{ref.artifact_path}' escapes packet root",
+                            question_id=q.question_id,
+                        ))
+                        continue
+                    if not target.exists():
+                        errors.append(PacketValidationError(
+                            code=E_ARTIFACT_PATH_MISSING,
+                            message=f"artifact_path '{ref.artifact_path}' does not exist on disk",
+                            question_id=q.question_id,
+                        ))
+
+    # Anti-inflation guardrail: require at least one honest gap
+    if require_unresolved and not has_unresolved:
+        warnings.append(
+            "No INSUFFICIENT_EVIDENCE questions. A packet claiming 100% "
+            "coverage may indicate inflation."
+        )
+
+    # Proof pack re-verification
+    if proof_pack_dir is not None:
+        _check_proof_pack_consistency(packet, proof_pack_dir, errors)
+
+    return PacketValidationResult(
+        passed=len(errors) == 0,
+        errors=errors,
+        warnings=warnings,
+    )
+
+
+def _check_proof_pack_consistency(
+    packet: ReviewerPacket,
+    proof_pack_dir: Path,
+    errors: List[PacketValidationError],
+) -> None:
+    """Re-verify the nested proof pack and check consistency."""
+    manifest_path = proof_pack_dir / "pack_manifest.json"
+    if not manifest_path.exists():
+        errors.append(PacketValidationError(
+            code=E_VERIFICATION_MISMATCH,
+            message="Proof pack manifest not found at expected path",
+        ))
+        return
+
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        errors.append(PacketValidationError(
+            code=E_VERIFICATION_MISMATCH,
+            message=f"Cannot read proof pack manifest: {exc}",
+        ))
+        return
+
+    from assay.integrity import verify_pack_manifest
+    from assay.keystore import AssayKeyStore
+
+    result = verify_pack_manifest(manifest, proof_pack_dir, None)
+
+    if packet.proof_pack_verified and not result.passed:
+        errors.append(PacketValidationError(
+            code=E_VERIFICATION_MISMATCH,
+            message="Packet claims proof_pack_verified=true but re-verification failed: "
+                    + (result.errors[0].message if result.errors else "unknown error"),
+        ))
+    elif not packet.proof_pack_verified and result.passed:
+        # Not an error, but worth noting
+        pass
+
+
+def validate_packet_dict(
+    packet_dict: Dict[str, Any],
+    **kwargs: Any,
+) -> PacketValidationResult:
+    """Validate a packet from its dict representation.
+
+    Convenience for validating packet.json loaded from disk.
+    """
+    from assay.reviewer_packet import EvidenceRef, QuestionAnswer, ReviewerPacket
+
+    questions = []
+    for qd in packet_dict.get("questions", []):
+        refs = [
+            EvidenceRef(
+                receipt_id=r["receipt_id"],
+                receipt_type=r["receipt_type"],
+                authority_class=r["authority_class"],
+                description=r["description"],
+                artifact_path=r.get("artifact_path"),
+            )
+            for r in qd.get("evidence_refs", [])
+        ]
+        questions.append(QuestionAnswer(
+            question_id=qd["question_id"],
+            question_text=qd["question_text"],
+            status=qd["status"],
+            authority_class=qd["authority_class"],
+            evidence_refs=refs,
+            answer_text=qd.get("answer_text"),
+            notes=qd.get("notes"),
+        ))
+
+    packet = ReviewerPacket(
+        packet_id=packet_dict["packet_id"],
+        workflow_name=packet_dict["workflow_name"],
+        workflow_description=packet_dict["workflow_description"],
+        questions=questions,
+        proof_pack_path=packet_dict["proof_pack_path"],
+        proof_pack_id=packet_dict["proof_pack_id"],
+        proof_pack_verified=packet_dict["proof_pack_verified"],
+        signer_id=packet_dict["signer_id"],
+        signer_fingerprint=packet_dict["signer_fingerprint"],
+        generated_at=packet_dict["generated_at"],
+    )
+
+    return validate_packet(packet, **kwargs)
+
+
+__all__ = [
+    "E_ARTIFACT_PATH_ESCAPE",
+    "E_ARTIFACT_PATH_MISSING",
+    "E_AUTHORITY_INFLATED",
+    "E_EVIDENCE_REF_ORPHANED",
+    "E_INVALID_AUTHORITY",
+    "E_INVALID_STATUS",
+    "E_MACHINE_CLAIM_NO_RECEIPT",
+    "E_MISSING_EVIDENCE",
+    "E_NO_QUESTIONS",
+    "E_UNRESOLVED_RELABELED",
+    "E_VERIFICATION_MISMATCH",
+    "MACHINE_RECEIPT_TYPES",
+    "PacketValidationError",
+    "PacketValidationResult",
+    "validate_packet",
+    "validate_packet_dict",
+]

--- a/tests/BUYER_SIMULATION_TEST_CONTRACT.md
+++ b/tests/BUYER_SIMULATION_TEST_CONTRACT.md
@@ -1,0 +1,62 @@
+# Buyer Simulation Test Contract
+
+**Status:** IMPLEMENTED. 29 tests passing (0.4s). All pass bar items covered.
+
+**Goal:** Prove Assay can produce a reviewer-ready evidence packet for a
+realistic synthetic buyer-review simulation: one scenario, one
+questionnaire, one signed proof pack, one reviewer packet, one explicit
+evidence gap, one successful verification, one failed tamper attempt.
+
+**What this is:** CI-stable buyer-packet simulation using realistic
+synthetic receipts that mirror the shape of real OpenAI integration output.
+**What this is not:** A live integration test, or a substitute for the
+production reviewer-packet compile/verify path in `reviewer_packet_compile.py`.
+
+**Test name:** `tests/e2e/test_reviewer_packet_evidence_sprint.py`
+
+**Scenario:** Mid-market SaaS company uses an LLM in a customer-support
+workflow. A prospect reviewer asks 6 governance/security questions.
+
+## Questionnaire
+
+Q1: Which model/provider executed the workflow? → ANSWERED (machine_evidenced)
+Q2: Is there evidence the workflow was actually executed? → ANSWERED (machine_evidenced)
+Q3: Was a policy/safety gate evaluated before model execution? → ANSWERED (mixed)
+Q4: Can the result be independently verified and tamper-checked? → ANSWERED (machine_evidenced)
+Q5: Which claims rely on machine evidence vs human attestation? → ANSWERED (mixed)
+Q6: Is prompt-injection resilience proven? → INSUFFICIENT_EVIDENCE (honest gap)
+
+## Required artifacts
+- Multiple receipts (model_call, guardian_verdict, guardian_decision, verification_result, packet_compiled)
+- Signed proof pack
+- Reviewer packet with authority classes and evidence index
+- Tamper test A: proof-pack mutation → verify fails
+- Tamper test B: answer inflation (Q6 → ANSWERED) → packet consistency fails
+
+## Pass criteria
+- At least one question is honestly unresolved
+- No unsupported question marked ANSWERED with machine_evidenced
+- All cited evidence receipt_ids exist in proof pack; artifact_path refs resolve to existing files
+- Packet visibly separates authority classes
+
+## Implementation (2026-03-17)
+
+**New modules:**
+- `src/assay/reviewer_packet.py` — `EvidenceRef`, `QuestionAnswer`, `ReviewerPacket` dataclasses
+- `src/assay/reviewer_packet_validator.py` — 11 error codes, 5 anti-inflation checks + 2 artifact-path checks
+
+**Fixtures:**
+- `tests/fixtures/evidence_sprint_minirepo/questionnaire.json` — 6 questions
+- `tests/fixtures/evidence_sprint_minirepo/human_attestation.json` — human attestation
+
+**Test:** `tests/e2e/test_reviewer_packet_evidence_sprint.py` — 29 tests across 8 test classes:
+- `TestProofPackIntegrity` (4) — files, receipts, signing, claims
+- `TestReviewerPacket` (9) — structure, questions, authority, roundtrip, evidence index
+- `TestPacketValidation` (2) — clean pass, proof pack re-verification
+- `TestTamperA` (2) — proof-pack mutation, validator catch
+- `TestTamperB` (3) — answer inflation (in-memory, authority, disk roundtrip)
+- `TestArtifactPathIntegrity` (4) — valid paths pass, missing caught, escape caught, sibling-prefix caught
+- `TestFixtureConsistency` (4) — fixture/scenario alignment, Q6 status, human attestation
+- `TestOutputStructure` (1) — full output tree
+
+**Test ladder:** live_receipt_smoke → constitutional_episode_runtime → reviewer_packet_evidence_sprint.

--- a/tests/e2e/test_reviewer_packet_evidence_sprint.py
+++ b/tests/e2e/test_reviewer_packet_evidence_sprint.py
@@ -1,0 +1,741 @@
+"""Buyer simulation: reviewer-ready evidence packet (synthetic, CI-stable).
+
+Realistic synthetic buyer-review simulation. Receipt shapes mirror real
+OpenAI integration output but no live API call is made. This is a
+buyer-facing projection layer test, not the production reviewer-packet
+compile/verify path (see reviewer_packet_compile.py for that).
+
+Scenario: Mid-market SaaS uses LLM in customer-support. Reviewer asks
+6 governance questions. One is honestly unresolved (prompt-injection
+resilience). The rest are answered with machine evidence and one human
+attestation.
+
+Pass bar (from BUYER_SIMULATION_TEST_CONTRACT.md):
+  - realistic synthetic receipts emitted (mirror OpenAI integration shape)
+  - multiple receipts exist (5 types)
+  - signed pack verifies (Ed25519)
+  - reviewer packet generated (4 artifact files)
+  - all 6 questions present
+  - at least 1 question unresolved (Q6)
+  - authority classes visible (machine_evidenced, mixed, insufficient)
+  - proof tamper fails (tamper A: receipt mutation)
+  - answer inflation tamper fails (tamper B: Q6 status inflation)
+"""
+from __future__ import annotations
+
+import copy
+import json
+import shutil
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from assay.claim_verifier import ClaimSpec
+from assay.integrity import verify_pack_manifest
+from assay.keystore import AssayKeyStore
+from assay.proof_pack import ProofPack
+from assay.reviewer_packet import (
+    ANSWER_STATUSES,
+    AUTHORITY_CLASSES,
+    EvidenceRef,
+    QuestionAnswer,
+    ReviewerPacket,
+)
+from assay.reviewer_packet_validator import (
+    E_ARTIFACT_PATH_ESCAPE,
+    E_ARTIFACT_PATH_MISSING,
+    E_AUTHORITY_INFLATED,
+    E_MACHINE_CLAIM_NO_RECEIPT,
+    E_MISSING_EVIDENCE,
+    E_UNRESOLVED_RELABELED,
+    E_VERIFICATION_MISMATCH,
+    validate_packet,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+FIXTURES_DIR = Path(__file__).parent.parent / "fixtures" / "evidence_sprint_minirepo"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _build_receipts(run_id: str) -> list[dict]:
+    """Build realistic receipts matching what the OpenAI integration emits."""
+    ts_base = _now_iso()
+    return [
+        {
+            "receipt_id": f"r_{run_id}_001",
+            "type": "model_call",
+            "timestamp": ts_base,
+            "schema_version": "3.0",
+            "seq": 0,
+            "provider": "openai",
+            "model_id": "gpt-4o",
+            "input_tokens": 1850,
+            "output_tokens": 620,
+            "total_tokens": 2470,
+            "latency_ms": 1120,
+            "finish_reason": "stop",
+            "input_hash": "a1b2c3d4e5f6a7b8",
+            "output_hash": "f8e7d6c5b4a39281",
+            "message_count": 3,
+            "integration_source": "assay.integrations.openai",
+        },
+        {
+            "receipt_id": f"r_{run_id}_002",
+            "type": "guardian_verdict",
+            "timestamp": ts_base,
+            "schema_version": "3.0",
+            "seq": 1,
+            "parent_receipt_id": f"r_{run_id}_001",
+            "verdict": "allow",
+            "action": "customer_support_response",
+            "reason": "Content within policy bounds; no PII detected",
+            "guardian_id": "content-policy-v2",
+        },
+        {
+            "receipt_id": f"r_{run_id}_003",
+            "type": "guardian_decision",
+            "timestamp": ts_base,
+            "schema_version": "3.0",
+            "seq": 2,
+            "parent_receipt_id": f"r_{run_id}_002",
+            "decision": "approved",
+            "authority_class": "BINDING",
+            "policy_version": "content-policy-v2.1",
+            "controls_evaluated": ["pii_filter", "content_safety", "output_length"],
+        },
+        {
+            "receipt_id": f"r_{run_id}_004",
+            "type": "verification_result",
+            "timestamp": ts_base,
+            "schema_version": "3.0",
+            "seq": 3,
+            "verified": True,
+            "receipt_count": 3,
+            "integrity": "PASS",
+            "method": "jcs-ed25519",
+        },
+        {
+            "receipt_id": f"r_{run_id}_005",
+            "type": "packet_compiled",
+            "timestamp": ts_base,
+            "schema_version": "3.0",
+            "seq": 4,
+            "packet_type": "reviewer_packet",
+            "questions_total": 6,
+            "questions_answered": 5,
+            "questions_unresolved": 1,
+            "authority_classes_present": [
+                "machine_evidenced",
+                "mixed",
+                "insufficient",
+            ],
+        },
+    ]
+
+
+def _build_claims() -> list[ClaimSpec]:
+    """Claims that the proof pack should satisfy."""
+    return [
+        ClaimSpec(
+            claim_id="model_called",
+            description="At least one model_call receipt",
+            check="receipt_type_present",
+            params={"receipt_type": "model_call"},
+        ),
+        ClaimSpec(
+            claim_id="guardian_ran",
+            description="Guardian verdict was issued",
+            check="receipt_type_present",
+            params={"receipt_type": "guardian_verdict"},
+        ),
+        ClaimSpec(
+            claim_id="guardian_decision_issued",
+            description="Guardian decision receipt exists",
+            check="receipt_type_present",
+            params={"receipt_type": "guardian_decision"},
+        ),
+        ClaimSpec(
+            claim_id="verification_completed",
+            description="Verification result receipt exists",
+            check="receipt_type_present",
+            params={"receipt_type": "verification_result"},
+        ),
+    ]
+
+
+def _build_reviewer_packet(
+    run_id: str,
+    receipts: list[dict],
+    proof_pack_id: str,
+    proof_pack_verified: bool,
+    signer_id: str,
+    signer_fingerprint: str,
+) -> ReviewerPacket:
+    """Compile the 6-question reviewer packet from receipts."""
+    human_attestation = json.loads(
+        (FIXTURES_DIR / "human_attestation.json").read_text()
+    )
+
+    # Q1: Which model/provider? → machine_evidenced from model_call
+    q1 = QuestionAnswer(
+        question_id="Q1",
+        question_text="Which model/provider executed the workflow?",
+        status="ANSWERED",
+        authority_class="machine_evidenced",
+        answer_text="gpt-4o via OpenAI (2,470 tokens, 1,120ms latency)",
+        evidence_refs=[
+            EvidenceRef(
+                receipt_id=receipts[0]["receipt_id"],
+                receipt_type="model_call",
+                authority_class="machine_evidenced",
+                description="OpenAI model_call receipt with provider, model_id, token counts",
+                artifact_path="proof_pack/receipt_pack.jsonl",
+            ),
+        ],
+    )
+
+    # Q2: Was it actually executed? → machine_evidenced from model_call
+    q2 = QuestionAnswer(
+        question_id="Q2",
+        question_text="Is there evidence the workflow was actually executed?",
+        status="ANSWERED",
+        authority_class="machine_evidenced",
+        answer_text="Yes. Model call receipt shows finish_reason=stop with measurable latency.",
+        evidence_refs=[
+            EvidenceRef(
+                receipt_id=receipts[0]["receipt_id"],
+                receipt_type="model_call",
+                authority_class="machine_evidenced",
+                description="Execution evidence: latency_ms=1120, finish_reason=stop",
+                artifact_path="proof_pack/receipt_pack.jsonl",
+            ),
+        ],
+    )
+
+    # Q3: Safety gate? → mixed (machine guardian_verdict + human attestation)
+    q3 = QuestionAnswer(
+        question_id="Q3",
+        question_text="Was a policy/safety gate evaluated before model execution?",
+        status="ANSWERED",
+        authority_class="mixed",
+        answer_text="Yes. Guardian verdict=allow (content-policy-v2). Human review confirms gate configuration.",
+        evidence_refs=[
+            EvidenceRef(
+                receipt_id=receipts[1]["receipt_id"],
+                receipt_type="guardian_verdict",
+                authority_class="machine_evidenced",
+                description="Guardian verdict: allow, action=customer_support_response",
+                artifact_path="proof_pack/receipt_pack.jsonl",
+            ),
+            EvidenceRef(
+                receipt_id=human_attestation["attestation_id"],
+                receipt_type="human_attestation",
+                authority_class="human_attested",
+                description=human_attestation["statement"],
+            ),
+        ],
+    )
+
+    # Q4: Independently verifiable? → machine_evidenced from verification_result
+    q4 = QuestionAnswer(
+        question_id="Q4",
+        question_text="Can the result be independently verified and tamper-checked?",
+        status="ANSWERED",
+        authority_class="machine_evidenced",
+        answer_text="Yes. Signed proof pack passes Ed25519 verification. Run `assay verify-pack` to confirm.",
+        evidence_refs=[
+            EvidenceRef(
+                receipt_id=receipts[3]["receipt_id"],
+                receipt_type="verification_result",
+                authority_class="machine_evidenced",
+                description="Verification result: PASS, method=jcs-ed25519",
+                artifact_path="proof_pack/receipt_pack.jsonl",
+            ),
+        ],
+    )
+
+    # Q5: Machine vs human separation? → mixed from packet_compiled + human attestation
+    q5 = QuestionAnswer(
+        question_id="Q5",
+        question_text="Which claims rely on machine evidence vs human attestation?",
+        status="ANSWERED",
+        authority_class="mixed",
+        answer_text="Q1,Q2,Q4 are machine_evidenced. Q3,Q5 are mixed. Q6 is honestly unresolved.",
+        evidence_refs=[
+            EvidenceRef(
+                receipt_id=receipts[4]["receipt_id"],
+                receipt_type="packet_compiled",
+                authority_class="machine_evidenced",
+                description="Packet compilation receipt showing authority class breakdown",
+                artifact_path="proof_pack/receipt_pack.jsonl",
+            ),
+            EvidenceRef(
+                receipt_id=human_attestation["attestation_id"],
+                receipt_type="human_attestation",
+                authority_class="human_attested",
+                description="Human attestation confirming policy review scope",
+            ),
+        ],
+    )
+
+    # Q6: Prompt injection resilience? → INSUFFICIENT_EVIDENCE (honest gap)
+    q6 = QuestionAnswer(
+        question_id="Q6",
+        question_text="Is prompt-injection resilience proven?",
+        status="INSUFFICIENT_EVIDENCE",
+        authority_class="insufficient",
+        answer_text=None,
+        notes="Honest gap: no adversarial testing evidence exists for this workflow. "
+              "This is a known limitation, not a hidden one.",
+    )
+
+    return ReviewerPacket(
+        packet_id=f"rp_{run_id}",
+        workflow_name="Customer Support LLM Workflow",
+        workflow_description="Mid-market SaaS customer-support workflow using GPT-4o "
+                            "with content-policy guardian gate.",
+        questions=[q1, q2, q3, q4, q5, q6],
+        proof_pack_path="./proof_pack",
+        proof_pack_id=proof_pack_id,
+        proof_pack_verified=proof_pack_verified,
+        signer_id=signer_id,
+        signer_fingerprint=signer_fingerprint,
+        generated_at=_now_iso(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def run_dir(tmp_path: Path):
+    """Create the full run directory with proof pack and reviewer packet."""
+    run_id = f"esprint_{uuid.uuid4().hex[:8]}"
+    run_root = tmp_path / run_id
+
+    # --- 1. Build and sign proof pack ---
+    ks = AssayKeyStore(keys_dir=tmp_path / "keys")
+    ks.generate_key("evidence-sprint")
+    signer_fingerprint = ks.signer_fingerprint("evidence-sprint")
+
+    receipts = _build_receipts(run_id)
+    claims = _build_claims()
+
+    pack = ProofPack(
+        run_id=run_id,
+        entries=receipts,
+        signer_id="evidence-sprint",
+        claims=claims,
+        mode="shadow",
+    )
+    pack_dir = pack.build(run_root / "proof_pack", keystore=ks)
+
+    # --- 2. Verify proof pack ---
+    manifest = json.loads((pack_dir / "pack_manifest.json").read_text())
+    verify_result = verify_pack_manifest(manifest, pack_dir, ks)
+    pack_id = manifest.get("pack_id", run_id)
+
+    # --- 3. Build reviewer packet ---
+    reviewer_packet = _build_reviewer_packet(
+        run_id=run_id,
+        receipts=receipts,
+        proof_pack_id=pack_id,
+        proof_pack_verified=verify_result.passed,
+        signer_id="evidence-sprint",
+        signer_fingerprint=signer_fingerprint,
+    )
+    packet_dir = reviewer_packet.write(run_root / "reviewer_packet")
+
+    return {
+        "run_id": run_id,
+        "run_root": run_root,
+        "pack_dir": pack_dir,
+        "packet_dir": packet_dir,
+        "receipts": receipts,
+        "claims": claims,
+        "keystore": ks,
+        "manifest": manifest,
+        "verify_result": verify_result,
+        "reviewer_packet": reviewer_packet,
+        "signer_fingerprint": signer_fingerprint,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestProofPackIntegrity:
+    """Proof pack is built, signed, and verifiable."""
+
+    def test_pack_files_exist(self, run_dir):
+        pack_dir = run_dir["pack_dir"]
+        for name in [
+            "receipt_pack.jsonl",
+            "pack_manifest.json",
+            "pack_signature.sig",
+            "verify_report.json",
+            "verify_transcript.md",
+        ]:
+            assert (pack_dir / name).exists(), f"Missing: {name}"
+
+    def test_multiple_receipts(self, run_dir):
+        pack_dir = run_dir["pack_dir"]
+        lines = [
+            ln for ln in (pack_dir / "receipt_pack.jsonl").read_text().splitlines()
+            if ln.strip()
+        ]
+        assert len(lines) >= 4, f"Expected >= 4 receipts, got {len(lines)}"
+
+    def test_signed_pack_verifies(self, run_dir):
+        assert run_dir["verify_result"].passed, (
+            f"Proof pack verification failed: "
+            f"{[e.message for e in run_dir['verify_result'].errors]}"
+        )
+
+    def test_claims_pass(self, run_dir):
+        report = json.loads(
+            (run_dir["pack_dir"] / "verify_report.json").read_text()
+        )
+        claim_v = report.get("claim_verification", {})
+        assert claim_v.get("passed", False), f"Claims failed: {claim_v}"
+
+
+class TestReviewerPacket:
+    """Reviewer packet is generated with correct structure."""
+
+    def test_packet_files_exist(self, run_dir):
+        packet_dir = run_dir["packet_dir"]
+        for name in [
+            "packet.json",
+            "questionnaire_answers.json",
+            "evidence_index.json",
+            "reviewer_summary.md",
+        ]:
+            assert (packet_dir / name).exists(), f"Missing: {name}"
+
+    def test_six_questions_present(self, run_dir):
+        packet = run_dir["reviewer_packet"]
+        assert len(packet.questions) == 6
+
+    def test_at_least_one_unresolved(self, run_dir):
+        packet = run_dir["reviewer_packet"]
+        assert packet.unresolved_count >= 1, "No honestly unresolved questions"
+
+    def test_q6_is_unresolved(self, run_dir):
+        packet = run_dir["reviewer_packet"]
+        q6 = next(q for q in packet.questions if q.question_id == "Q6")
+        assert q6.status == "INSUFFICIENT_EVIDENCE"
+        assert q6.authority_class == "insufficient"
+
+    def test_authority_classes_visible(self, run_dir):
+        packet = run_dir["reviewer_packet"]
+        classes = {q.authority_class for q in packet.questions}
+        assert "machine_evidenced" in classes
+        assert "mixed" in classes
+        assert "insufficient" in classes
+
+    def test_answered_questions_have_evidence(self, run_dir):
+        packet = run_dir["reviewer_packet"]
+        for q in packet.questions:
+            if q.status == "ANSWERED":
+                assert len(q.evidence_refs) > 0, (
+                    f"{q.question_id} is ANSWERED but has no evidence refs"
+                )
+
+    def test_packet_json_roundtrip(self, run_dir):
+        packet_dir = run_dir["packet_dir"]
+        packet_dict = json.loads((packet_dir / "packet.json").read_text())
+        assert packet_dict["schema_version"] == "0.1.0"
+        assert packet_dict["proof_pack_verified"] is True
+        assert len(packet_dict["questions"]) == 6
+        assert packet_dict["summary"]["answered"] == 5
+        assert packet_dict["summary"]["unresolved"] == 1
+
+    def test_evidence_index_has_all_refs(self, run_dir):
+        packet_dir = run_dir["packet_dir"]
+        index = json.loads((packet_dir / "evidence_index.json").read_text())
+        packet = run_dir["reviewer_packet"]
+        for q in packet.questions:
+            for ref in q.evidence_refs:
+                assert ref.receipt_id in index, (
+                    f"Evidence ref {ref.receipt_id} missing from evidence_index.json"
+                )
+
+    def test_reviewer_summary_mentions_gap(self, run_dir):
+        packet_dir = run_dir["packet_dir"]
+        summary = (packet_dir / "reviewer_summary.md").read_text()
+        assert "GAP" in summary or "INSUFFICIENT_EVIDENCE" in summary or "unresolved" in summary.lower()
+
+
+class TestPacketValidation:
+    """Packet validator catches real issues and passes clean packets."""
+
+    def test_clean_packet_passes(self, run_dir):
+        packet = run_dir["reviewer_packet"]
+        receipts = run_dir["receipts"]
+        human_att = json.loads(
+            (FIXTURES_DIR / "human_attestation.json").read_text()
+        )
+        receipt_ids = {r["receipt_id"] for r in receipts}
+        receipt_ids.add(human_att["attestation_id"])
+
+        result = validate_packet(
+            packet,
+            receipt_ids_on_disk=receipt_ids,
+            require_unresolved=True,
+        )
+        assert result.passed, (
+            f"Clean packet should pass: {[e.to_dict() for e in result.errors]}"
+        )
+
+    def test_validator_with_proof_pack_reverification(self, run_dir):
+        packet = run_dir["reviewer_packet"]
+        result = validate_packet(
+            packet,
+            proof_pack_dir=run_dir["pack_dir"],
+        )
+        assert result.passed
+
+
+class TestTamperA:
+    """Tamper A: mutate proof pack → verification fails."""
+
+    def test_proof_pack_tamper_detected(self, run_dir):
+        pack_dir = run_dir["pack_dir"]
+        ks = run_dir["keystore"]
+
+        # Copy the pack and tamper the receipt file
+        tampered_dir = run_dir["run_root"] / "tampered_pack"
+        shutil.copytree(pack_dir, tampered_dir)
+
+        receipt_file = tampered_dir / "receipt_pack.jsonl"
+        data = bytearray(receipt_file.read_bytes())
+        # Change model name: gpt-4o → gpt-5x
+        target = b'"gpt-4o"'
+        idx = data.find(target)
+        assert idx >= 0, "Could not find gpt-4o in receipt pack"
+        data[idx + 1 : idx + 6] = b"gpt-5x"
+        receipt_file.write_bytes(bytes(data))
+
+        # Re-verify: must fail
+        manifest = json.loads(
+            (tampered_dir / "pack_manifest.json").read_text()
+        )
+        result = verify_pack_manifest(manifest, tampered_dir, ks)
+        assert not result.passed, "Tampered pack should fail verification"
+        assert any(
+            "mismatch" in e.message.lower() or "tamper" in e.message.lower()
+            for e in result.errors
+        ), f"Expected tamper/mismatch error, got: {[e.message for e in result.errors]}"
+
+    def test_tampered_pack_fails_packet_validation(self, run_dir):
+        """Packet validation with tampered proof pack fails E_VERIFICATION_MISMATCH."""
+        pack_dir = run_dir["pack_dir"]
+        packet = run_dir["reviewer_packet"]
+
+        tampered_dir = run_dir["run_root"] / "tampered_pack_for_validator"
+        shutil.copytree(pack_dir, tampered_dir)
+
+        receipt_file = tampered_dir / "receipt_pack.jsonl"
+        data = bytearray(receipt_file.read_bytes())
+        target = b'"gpt-4o"'
+        idx = data.find(target)
+        assert idx >= 0
+        data[idx + 1 : idx + 6] = b"gpt-5x"
+        receipt_file.write_bytes(bytes(data))
+
+        result = validate_packet(
+            packet,
+            proof_pack_dir=tampered_dir,
+        )
+        assert not result.passed
+        error_codes = {e.code for e in result.errors}
+        assert E_VERIFICATION_MISMATCH in error_codes, (
+            f"Expected E_VERIFICATION_MISMATCH, got: {error_codes}"
+        )
+
+
+class TestTamperB:
+    """Tamper B: inflate Q6 from INSUFFICIENT_EVIDENCE to ANSWERED → validator fails."""
+
+    def test_answer_inflation_detected(self, run_dir):
+        """Mutate Q6 to claim ANSWERED + machine_evidenced with no evidence."""
+        packet = run_dir["reviewer_packet"]
+
+        # Deep copy and inflate Q6
+        inflated = copy.deepcopy(packet)
+        q6 = next(q for q in inflated.questions if q.question_id == "Q6")
+        q6.status = "ANSWERED"
+        q6.authority_class = "machine_evidenced"
+        # Crucially: no evidence_refs added
+
+        result = validate_packet(inflated, require_unresolved=True)
+        assert not result.passed, "Inflated packet should fail validation"
+
+        error_codes = {e.code for e in result.errors}
+        # Must catch at least one of these inflation signals
+        inflation_codes = {
+            E_MISSING_EVIDENCE,
+            E_UNRESOLVED_RELABELED,
+            E_MACHINE_CLAIM_NO_RECEIPT,
+        }
+        assert error_codes & inflation_codes, (
+            f"Expected inflation error codes {inflation_codes}, got: {error_codes}"
+        )
+
+    def test_answer_inflation_with_authority_inflated(self, run_dir):
+        """Mutate Q6 to ANSWERED + insufficient → E_AUTHORITY_INFLATED."""
+        packet = run_dir["reviewer_packet"]
+
+        inflated = copy.deepcopy(packet)
+        q6 = next(q for q in inflated.questions if q.question_id == "Q6")
+        q6.status = "ANSWERED"
+        # Leave authority_class as 'insufficient' — contradicts ANSWERED
+        q6.authority_class = "insufficient"
+
+        result = validate_packet(inflated)
+        assert not result.passed
+        error_codes = {e.code for e in result.errors}
+        assert E_AUTHORITY_INFLATED in error_codes, (
+            f"Expected E_AUTHORITY_INFLATED, got: {error_codes}"
+        )
+
+    def test_inflation_from_disk_roundtrip(self, run_dir):
+        """Write packet to disk, tamper the JSON, re-validate — must fail."""
+        packet = run_dir["reviewer_packet"]
+        packet_dir = run_dir["packet_dir"]
+
+        # Load from disk
+        packet_dict = json.loads((packet_dir / "packet.json").read_text())
+
+        # Find Q6 and inflate it
+        for q in packet_dict["questions"]:
+            if q["question_id"] == "Q6":
+                q["status"] = "ANSWERED"
+                q["authority_class"] = "machine_evidenced"
+                # No evidence_refs added
+                break
+
+        # Write tampered packet back
+        tampered_path = run_dir["run_root"] / "tampered_packet.json"
+        tampered_path.write_text(json.dumps(packet_dict, indent=2))
+
+        # Validate from dict
+        from assay.reviewer_packet_validator import validate_packet_dict
+        result = validate_packet_dict(packet_dict)
+        assert not result.passed, "Tampered packet.json should fail validation"
+
+
+class TestArtifactPathIntegrity:
+    """Validator checks that artifact_path refs resolve to real files."""
+
+    def test_valid_artifact_paths_pass(self, run_dir):
+        """All artifact_path refs in the clean packet point to existing files."""
+        packet = run_dir["reviewer_packet"]
+        result = validate_packet(packet, proof_pack_dir=run_dir["pack_dir"])
+        assert result.passed
+        # No artifact-path errors
+        path_errors = {e.code for e in result.errors} & {
+            E_ARTIFACT_PATH_MISSING, E_ARTIFACT_PATH_ESCAPE
+        }
+        assert not path_errors
+
+    def test_missing_artifact_path_caught(self, run_dir):
+        """Fabricated artifact_path that doesn't exist is caught."""
+        packet = copy.deepcopy(run_dir["reviewer_packet"])
+        packet.questions[0].evidence_refs[0].artifact_path = "proof_pack/nonexistent.jsonl"
+        result = validate_packet(packet, proof_pack_dir=run_dir["pack_dir"])
+        assert not result.passed
+        error_codes = {e.code for e in result.errors}
+        assert E_ARTIFACT_PATH_MISSING in error_codes
+
+    def test_path_escape_caught(self, run_dir):
+        """artifact_path that escapes the packet root is caught."""
+        packet = copy.deepcopy(run_dir["reviewer_packet"])
+        packet.questions[0].evidence_refs[0].artifact_path = "../../etc/passwd"
+        result = validate_packet(packet, proof_pack_dir=run_dir["pack_dir"])
+        assert not result.passed
+        error_codes = {e.code for e in result.errors}
+        assert E_ARTIFACT_PATH_ESCAPE in error_codes
+
+    def test_sibling_prefix_escape_caught(self, run_dir):
+        """Sibling directory with shared prefix stem is caught.
+
+        e.g. root=/tmp/proof_pack, target=/tmp/proof_pack_evil/file.json
+        String prefix check would pass this; semantic relative_to does not.
+        """
+        packet = copy.deepcopy(run_dir["reviewer_packet"])
+        # proof_pack_dir.parent is the run_root. A sibling with the same
+        # prefix stem but different suffix escapes the real root.
+        run_root = run_dir["run_root"]
+        evil_dir = run_root.parent / (run_root.name + "_evil")
+        evil_dir.mkdir(exist_ok=True)
+        (evil_dir / "fake.jsonl").write_text("{}")
+        # Build a relative path that resolves to the evil sibling
+        # from the packet root (run_root):  ../<run_root_name>_evil/fake.jsonl
+        relative_escape = f"../{run_root.name}_evil/fake.jsonl"
+        packet.questions[0].evidence_refs[0].artifact_path = relative_escape
+        result = validate_packet(packet, proof_pack_dir=run_dir["pack_dir"])
+        assert not result.passed
+        error_codes = {e.code for e in result.errors}
+        assert E_ARTIFACT_PATH_ESCAPE in error_codes
+
+
+class TestFixtureConsistency:
+    """Questionnaire fixture stays consistent with the hardcoded scenario."""
+
+    def test_fixture_question_count_matches(self):
+        """questionnaire.json has exactly 6 questions."""
+        q = json.loads((FIXTURES_DIR / "questionnaire.json").read_text())
+        assert len(q["questions"]) == 6
+
+    def test_fixture_question_ids_match_scenario(self, run_dir):
+        """Fixture question_ids match the test scenario Q1-Q6."""
+        q = json.loads((FIXTURES_DIR / "questionnaire.json").read_text())
+        fixture_ids = {qn["question_id"] for qn in q["questions"]}
+        scenario_ids = {qa.question_id for qa in run_dir["reviewer_packet"].questions}
+        assert fixture_ids == scenario_ids
+
+    def test_fixture_q6_expects_insufficient(self):
+        """Fixture declares Q6 as INSUFFICIENT_EVIDENCE."""
+        q = json.loads((FIXTURES_DIR / "questionnaire.json").read_text())
+        q6 = next(qn for qn in q["questions"] if qn["question_id"] == "Q6")
+        assert q6["expected_status"] == "INSUFFICIENT_EVIDENCE"
+        assert q6["expected_authority"] == "insufficient"
+
+    def test_human_attestation_fixture_loads(self):
+        """human_attestation.json is valid and has required fields."""
+        ha = json.loads((FIXTURES_DIR / "human_attestation.json").read_text())
+        assert "attestation_id" in ha
+        assert "type" in ha
+        assert ha["type"] == "human_attestation"
+
+
+class TestOutputStructure:
+    """The test produces the exact output folder structure from the pass bar."""
+
+    def test_full_output_tree(self, run_dir):
+        run_root = run_dir["run_root"]
+
+        # Proof pack kernel
+        assert (run_root / "proof_pack" / "receipt_pack.jsonl").exists()
+        assert (run_root / "proof_pack" / "pack_manifest.json").exists()
+        assert (run_root / "proof_pack" / "pack_signature.sig").exists()
+
+        # Reviewer packet
+        assert (run_root / "reviewer_packet" / "packet.json").exists()
+        assert (run_root / "reviewer_packet" / "reviewer_summary.md").exists()
+        assert (run_root / "reviewer_packet" / "questionnaire_answers.json").exists()
+        assert (run_root / "reviewer_packet" / "evidence_index.json").exists()

--- a/tests/fixtures/evidence_sprint_minirepo/human_attestation.json
+++ b/tests/fixtures/evidence_sprint_minirepo/human_attestation.json
@@ -1,0 +1,9 @@
+{
+  "attestation_id": "ha_policy_review_001",
+  "type": "human_attestation",
+  "attester": "security-reviewer@example.com",
+  "scope": "Policy gate review for customer-support workflow",
+  "statement": "I reviewed the guardian configuration and confirm the safety gate is configured to evaluate content policy before model execution.",
+  "attested_at": "2026-03-17T10:00:00Z",
+  "authority_class": "human_attested"
+}

--- a/tests/fixtures/evidence_sprint_minirepo/questionnaire.json
+++ b/tests/fixtures/evidence_sprint_minirepo/questionnaire.json
@@ -1,0 +1,50 @@
+{
+  "questionnaire_id": "evidence_sprint_v1",
+  "scenario": "Mid-market SaaS company uses an LLM in a customer-support workflow. A prospect reviewer asks 6 governance/security questions.",
+  "questions": [
+    {
+      "question_id": "Q1",
+      "question_text": "Which model/provider executed the workflow?",
+      "expected_status": "ANSWERED",
+      "expected_authority": "machine_evidenced",
+      "evidence_receipt_types": ["model_call"]
+    },
+    {
+      "question_id": "Q2",
+      "question_text": "Is there evidence the workflow was actually executed?",
+      "expected_status": "ANSWERED",
+      "expected_authority": "machine_evidenced",
+      "evidence_receipt_types": ["model_call"]
+    },
+    {
+      "question_id": "Q3",
+      "question_text": "Was a policy/safety gate evaluated before model execution?",
+      "expected_status": "ANSWERED",
+      "expected_authority": "mixed",
+      "evidence_receipt_types": ["guardian_verdict"]
+    },
+    {
+      "question_id": "Q4",
+      "question_text": "Can the result be independently verified and tamper-checked?",
+      "expected_status": "ANSWERED",
+      "expected_authority": "machine_evidenced",
+      "evidence_receipt_types": ["verification_result"]
+    },
+    {
+      "question_id": "Q5",
+      "question_text": "Which claims rely on machine evidence vs human attestation?",
+      "expected_status": "ANSWERED",
+      "expected_authority": "mixed",
+      "evidence_receipt_types": ["packet_compiled"],
+      "notes": "Mixed: machine evidence from receipts, human attestation for policy review completeness"
+    },
+    {
+      "question_id": "Q6",
+      "question_text": "Is prompt-injection resilience proven?",
+      "expected_status": "INSUFFICIENT_EVIDENCE",
+      "expected_authority": "insufficient",
+      "evidence_receipt_types": [],
+      "notes": "Honest gap: no adversarial testing evidence exists for this workflow"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds the reviewer-packet evidence sprint surface — a buyer-facing artifact that packages repo evidence into a structured, validatable reviewer packet.

- `src/assay/reviewer_packet.py` (222 lines): reviewer packet generator
- `src/assay/reviewer_packet_validator.py` (347 lines): packet validation
- `tests/e2e/test_reviewer_packet_evidence_sprint.py` (741 lines): 29 e2e tests
- `tests/e2e/evidence_sprint_minirepo/`: fixture repo with questionnaire + human attestation
- `tests/BUYER_SIMULATION_TEST_CONTRACT.md`: test contract documentation

## Merge evidence
- **Additive only**: 7 new files, 0 modifications to existing code
- **Rebased cleanly** onto current `origin/main` (030dce7) — no conflicts
- **Branch tests**: `tests/e2e/test_reviewer_packet_evidence_sprint.py` → 29 passed
- **Non-regression**: full suite unchanged vs main (3227 passed, 43 failed, 16 skipped — identical failure set on both branch and main)

## Test plan
- [x] `pytest tests/e2e/test_reviewer_packet_evidence_sprint.py -q` → 29 passed
- [x] `pytest tests/assay/ tests/contracts/ tests/e2e/ -q` → 0 regressions vs main
- [x] Rebase onto origin/main: clean, no conflicts