### PR TITLE
Slice 1: commitment fulfillment receipts and store-order hardening

### DIFF
--- a/src/assay/checkpoint_views.py
+++ b/src/assay/checkpoint_views.py
@@ -28,6 +28,7 @@ TRACE_ENVELOPE_FIELDS = {
     "schema_version",
     "_trace_id",
     "_stored_at",
+    "_store_seq",
     "parent_receipt_id",
     "seq",
     "canonical_hash",

--- a/src/assay/checkpoints.py
+++ b/src/assay/checkpoints.py
@@ -64,6 +64,7 @@ TRACE_ENVELOPE_FIELDS = {
     "schema_version",
     "_trace_id",
     "_stored_at",
+    "_store_seq",
     "parent_receipt_id",
     "seq",
     "canonical_hash",

--- a/src/assay/commands.py
+++ b/src/assay/commands.py
@@ -1109,7 +1109,7 @@ def verify_trace(
                         payload = {
                             k: v
                             for k, v in entry.items()
-                            if k not in ("proof", "_trace_id", "_stored_at")
+                            if k not in ("proof", "_trace_id", "_stored_at", "_store_seq")
                         }
                         # compute_payload_hash returns raw hex (OCD-1 resolved)
                         computed_hash = compute_payload_hash(
@@ -1144,7 +1144,7 @@ def verify_trace(
                             k: v
                             for k, v in entry.items()
                             if k
-                            not in ("proof", "_trace_id", "_stored_at", "receipt_hash")
+                            not in ("proof", "_trace_id", "_stored_at", "_store_seq", "receipt_hash")
                         }
                         computed_receipt_hash = compute_payload_hash(
                             payload, algorithm="sha256"

--- a/src/assay/commitment_closure_detector.py
+++ b/src/assay/commitment_closure_detector.py
@@ -1,0 +1,275 @@
+"""Commitment closure detector — DOCTOR_COMMITMENT_001.
+
+Pure-read scan of an AssayStore that flags ``commitment.registered`` receipts
+with a past ``due_at`` and no terminal fulfillment
+(``fulfillment.commitment_kept`` | ``fulfillment.commitment_broken``).
+
+Mirrors ``contradiction_detector.py`` structurally. No mutations.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Set
+
+from assay.commitment_fulfillment import (
+    COMMITMENT_REGISTRATION_RECEIPT_TYPE,
+    RESULT_OBSERVATION_RECEIPT_TYPE,
+    TERMINAL_FULFILLMENT_TYPES,
+    _iter_all_receipts,
+)
+from assay.store import AssayStore
+
+
+@dataclass(frozen=True)
+class OpenOverdueCommitment:
+    """A detected open, overdue commitment."""
+
+    commitment_id: str
+    trace_id: str
+    episode_id: str
+    actor_id: str
+    text: str
+    commitment_type: str
+    registered_at: str
+    due_at: str
+    trace_path: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "commitment_id": self.commitment_id,
+            "trace_id": self.trace_id,
+            "episode_id": self.episode_id,
+            "actor_id": self.actor_id,
+            "text": self.text,
+            "commitment_type": self.commitment_type,
+            "registered_at": self.registered_at,
+            "due_at": self.due_at,
+            "trace_path": self.trace_path,
+        }
+
+
+@dataclass(frozen=True)
+class CommitmentClosureResult:
+    """Result of scanning a store for open, overdue commitments."""
+
+    open_commitments: List[OpenOverdueCommitment] = field(default_factory=list)
+    total_traces_scanned: int = 0
+    total_registered_found: int = 0
+    total_closed_found: int = 0
+    total_open_found: int = 0
+    scanned_at: str = ""
+
+    @property
+    def clean(self) -> bool:
+        return self.total_open_found == 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "clean": self.clean,
+            "total_traces_scanned": self.total_traces_scanned,
+            "total_registered_found": self.total_registered_found,
+            "total_closed_found": self.total_closed_found,
+            "total_open_found": self.total_open_found,
+            "scanned_at": self.scanned_at,
+            "open_commitments": [c.to_dict() for c in self.open_commitments],
+        }
+
+
+def _extract_receipt_type(entry: Dict[str, Any]) -> str:
+    return str(entry.get("type") or entry.get("receipt_type") or "")
+
+
+def _extract_timestamp(entry: Dict[str, Any]) -> str:
+    return str(entry.get("timestamp") or entry.get("_stored_at") or "")
+
+
+def _parse_iso(value: str) -> Optional[datetime]:
+    """Parse ISO-8601; return None if unparseable."""
+    if not value:
+        return None
+    v = value.strip()
+    if v.endswith("Z"):
+        v = v[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(v)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def detect_open_overdue_commitments(
+    store: AssayStore,
+    *,
+    now: Optional[datetime] = None,
+) -> CommitmentClosureResult:
+    """Scan a store for open, overdue commitments.
+
+    Closure rule (order-aware):
+        A terminal fulfillment closes commitment C if, *at the point the
+        terminal is encountered in receipt order*:
+          - C was already registered (``commitment.registered``); AND
+          - result R was already observed (``result.observed`` with
+            ``result_id == terminal.result_id``); AND
+          - that observation's ``references`` list explicitly carried
+            ``{"kind": "commitment", "id": C}``.
+
+    Future observations cannot retroactively legitimize prior terminals.
+    Forged terminals written before any observation — or naming a result
+    that observed a different commitment — do not close anything.
+
+    A commitment is "open and overdue" when:
+        - It is registered.
+        - Its ``due_at`` is parseable and in the past relative to ``now``.
+        - No valid closure edge was observed for it.
+
+    Commitments without ``due_at`` are treated as perpetual in Slice 1
+    and never flagged. Commitments whose ``due_at`` is unparseable are
+    treated conservatively as perpetual.
+
+    Scan is full-store and fail-closed: corruption surfaces as
+    ``ReceiptStoreIntegrityError``, not as missing evidence.
+
+    Args:
+        store: The AssayStore to scan.
+        now: Reference time for overdue comparison. Defaults to
+            ``datetime.now(timezone.utc)``.
+
+    Returns:
+        CommitmentClosureResult with all findings.
+    """
+    reference = now or datetime.now(timezone.utc)
+    scanned_at = reference.isoformat()
+
+    registered: Dict[str, Dict[str, Any]] = {}
+    # result_id -> set of commitment_ids the observation explicitly referenced.
+    observed_result_anchors: Dict[str, Set[str]] = {}
+    closed_ids: Set[str] = set()
+    trace_ids_seen: Set[str] = set()
+
+    # Walk receipts in store order (path-sorted, then line order).
+    # _iter_all_receipts raises ReceiptStoreIntegrityError on corruption.
+    for entry in _iter_all_receipts(store):
+        rt = _extract_receipt_type(entry)
+        trace_id = str(entry.get("_trace_id") or "")
+        if trace_id:
+            trace_ids_seen.add(trace_id)
+
+        if rt == COMMITMENT_REGISTRATION_RECEIPT_TYPE:
+            cmt_id = entry.get("commitment_id")
+            if cmt_id and cmt_id not in registered:
+                registered[cmt_id] = {
+                    "trace_id": trace_id,
+                    "trace_path": None,
+                    "episode_id": str(entry.get("episode_id") or ""),
+                    "actor_id": str(entry.get("actor_id") or ""),
+                    "text": str(entry.get("text") or ""),
+                    "commitment_type": str(entry.get("commitment_type") or ""),
+                    "registered_at": _extract_timestamp(entry),
+                    "due_at": str(entry.get("due_at") or ""),
+                }
+            continue
+
+        if rt == RESULT_OBSERVATION_RECEIPT_TYPE:
+            result_id = entry.get("result_id")
+            if not result_id:
+                continue
+            anchors = observed_result_anchors.setdefault(str(result_id), set())
+            for ref in entry.get("references") or []:
+                if (
+                    isinstance(ref, dict)
+                    and ref.get("kind") == "commitment"
+                    and ref.get("id")
+                ):
+                    anchors.add(str(ref["id"]))
+            continue
+
+        if rt in TERMINAL_FULFILLMENT_TYPES:
+            cmt_id = entry.get("commitment_id")
+            result_id = entry.get("result_id")
+            if not cmt_id or not result_id:
+                continue
+            cmt_id_s = str(cmt_id)
+            result_id_s = str(result_id)
+            # At the temporal point of THIS terminal:
+            #   - commitment must already be registered
+            #   - result must already be observed with this commitment in refs
+            if cmt_id_s not in registered:
+                continue  # terminal precedes registration — invalid
+            if cmt_id_s not in observed_result_anchors.get(result_id_s, set()):
+                continue  # no valid (result_id, commitment_id) edge yet — invalid
+            closed_ids.add(cmt_id_s)
+            continue
+
+    open_commitments: List[OpenOverdueCommitment] = []
+    for cmt_id, info in registered.items():
+        if cmt_id in closed_ids:
+            continue
+        due_at_str = info["due_at"]
+        if not due_at_str:
+            continue  # perpetual
+        due_at_dt = _parse_iso(due_at_str)
+        if due_at_dt is None:
+            continue  # unparseable → perpetual (conservative)
+        if due_at_dt >= reference:
+            continue  # not yet overdue
+        open_commitments.append(OpenOverdueCommitment(
+            commitment_id=cmt_id,
+            trace_id=info["trace_id"],
+            episode_id=info["episode_id"],
+            actor_id=info["actor_id"],
+            text=info["text"],
+            commitment_type=info["commitment_type"],
+            registered_at=info["registered_at"],
+            due_at=info["due_at"],
+            trace_path=info["trace_path"],
+        ))
+
+    return CommitmentClosureResult(
+        open_commitments=open_commitments,
+        total_traces_scanned=len(trace_ids_seen),
+        total_registered_found=len(registered),
+        total_closed_found=len(closed_ids),
+        total_open_found=len(open_commitments),
+        scanned_at=scanned_at,
+    )
+
+
+def check_commitment_health(
+    store: AssayStore,
+    *,
+    loud: bool = True,
+) -> bool:
+    """Run overdue-commitment detection; optionally print to stderr.
+
+    Returns True if the store is clean (no overdue open commitments).
+    """
+    import sys
+
+    result = detect_open_overdue_commitments(store)
+    if loud and not result.clean:
+        print(
+            f"[CONSTITUTIONAL VIOLATION] {result.total_open_found} overdue commitment(s) "
+            "with no terminal fulfillment",
+            file=sys.stderr,
+        )
+        for c in result.open_commitments:
+            print(
+                f"  open: commitment_id={c.commitment_id} "
+                f"episode_id={c.episode_id} "
+                f"due_at={c.due_at} "
+                f"actor_id={c.actor_id} "
+                f"trace={c.trace_id}",
+                file=sys.stderr,
+            )
+    return result.clean
+
+
+__all__ = [
+    "OpenOverdueCommitment",
+    "CommitmentClosureResult",
+    "detect_open_overdue_commitments",
+    "check_commitment_health",
+]

--- a/src/assay/commitment_fulfillment.py
+++ b/src/assay/commitment_fulfillment.py
@@ -1,0 +1,611 @@
+"""Commitment → Result → Fulfillment wedge — Slice 1.
+
+Doctrine source: loom-staging docs/architecture/authority_nouns.md
+(commit 9c5921d5, frozen).
+
+Event lifecycle:
+    commitment.registered      — a declared forward-looking commitment.
+    result.observed            — a non-adjudicating observation referencing
+                                 zero or more commitments. Never closes.
+    fulfillment.commitment_kept    — terminal: commitment was kept.
+    fulfillment.commitment_broken  — terminal: commitment was broken.
+
+Invariants:
+    1. Every commitment.registered must have a resolvable policy_hash. The
+       embedded PolicyResolver must bind to a COMPILE_RECEIPT.json whose
+       policy_hash equals the receipt's policy_hash.
+    2. result.observed is non-adjudicating. It MUST NOT contain ``fulfills``
+       or ``closes`` fields. References are typed ({"kind": "commitment",
+       "id": ...}) and do not, by themselves, close anything.
+    3. A commitment has zero or one terminal fulfillment. Emission of a
+       second terminal for the same commitment_id raises
+       ``TerminalFulfillmentError``.
+
+This module does NOT adjudicate the obligation namespace collision with
+``src/assay/obligation.py`` (override-debt semantics). Slice 2 must resolve
+that before adding the obligation side of the wedge.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from importlib import resources
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+
+from jsonschema import Draft202012Validator
+
+from assay.episode import Episode
+from assay.policy_resolver import PolicyResolutionError, PolicyResolver, resolve_policy
+from assay.store import AssayStore, ReceiptStoreIntegrityError
+
+
+SCHEMA_VERSION = "0.1.0"
+
+
+# ---------------------------------------------------------------------------
+# Receipt-type constants — DOCTRINE-EXACT serialized form
+# ---------------------------------------------------------------------------
+
+COMMITMENT_REGISTRATION_RECEIPT_TYPE = "commitment.registered"
+RESULT_OBSERVATION_RECEIPT_TYPE = "result.observed"
+FULFILLMENT_COMMITMENT_KEPT_RECEIPT_TYPE = "fulfillment.commitment_kept"
+FULFILLMENT_COMMITMENT_BROKEN_RECEIPT_TYPE = "fulfillment.commitment_broken"
+
+TERMINAL_FULFILLMENT_TYPES = frozenset({
+    FULFILLMENT_COMMITMENT_KEPT_RECEIPT_TYPE,
+    FULFILLMENT_COMMITMENT_BROKEN_RECEIPT_TYPE,
+})
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class TerminalFulfillmentError(ValueError):
+    """Raised when emitting a terminal fulfillment for an already-closed commitment.
+
+    A commitment has zero or one terminal fulfillment (kept | broken).
+    Attempting to emit a second terminal for the same commitment_id is a
+    constitutional violation of the closure invariant.
+    """
+
+
+class UnanchoredFulfillmentError(ValueError):
+    """Raised when a terminal fulfillment cannot anchor to its referents.
+
+    A terminal fulfillment must anchor to:
+        1. A prior ``commitment.registered`` receipt with the same commitment_id.
+        2. A prior ``result.observed`` receipt whose ``result_id`` equals the
+           terminal's ``result_id`` **and** whose ``references`` list contains
+           an explicit commitment reference to the terminal's ``commitment_id``.
+
+    Existence alone is insufficient: a result that observed a different
+    commitment must not adjudicate this one. The anchor is the
+    ``(result_id, commitment_id)`` edge, not bare id existence.
+    """
+
+
+# ``ReceiptStoreIntegrityError`` is defined in ``assay.store`` (its home is
+# the storage substrate, not the commitment wedge). We re-export it here
+# for backwards-compat with tests/consumers that imported it from this
+# module in earlier iterations of the slice.
+
+
+# ---------------------------------------------------------------------------
+# Schema validator cache
+# ---------------------------------------------------------------------------
+
+_SCHEMA_VALIDATORS: Dict[str, Draft202012Validator] = {}
+
+
+def _get_validator(schema_name: str) -> Draft202012Validator:
+    validator = _SCHEMA_VALIDATORS.get(schema_name)
+    if validator is None:
+        schema_path = resources.files("assay").joinpath(f"schemas/{schema_name}")
+        schema = json.loads(schema_path.read_text())
+        validator = Draft202012Validator(schema)
+        _SCHEMA_VALIDATORS[schema_name] = validator
+    return validator
+
+
+# ---------------------------------------------------------------------------
+# Artifacts
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CommitmentRegistrationArtifact:
+    """A declared forward-looking commitment."""
+
+    commitment_id: str
+    timestamp: str
+    episode_id: str
+    actor_id: str
+    text: str
+    commitment_type: str
+    policy_hash: str
+    policy_resolver: Dict[str, Any]
+    due_at: Optional[str] = None
+    evidence_uri: Optional[str] = None
+    schema_version: str = SCHEMA_VERSION
+    artifact_type: str = "commitment_registration"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {k: v for k, v in asdict(self).items() if v is not None}
+
+    def validate(self) -> None:
+        _get_validator("commitment_registration.v0.1.schema.json").validate(
+            self.to_dict()
+        )
+
+
+@dataclass
+class ResultObservationArtifact:
+    """A non-adjudicating observation.
+
+    Results NEVER close commitments. The ``references`` list is typed but
+    carries no adjudicating meaning: only a terminal fulfillment can close
+    a commitment.
+    """
+
+    result_id: str
+    timestamp: str
+    episode_id: str
+    text: str
+    evidence_uri: str
+    policy_hash: str
+    policy_resolver: Dict[str, Any]
+    references: List[Dict[str, Any]] = field(default_factory=list)
+    schema_version: str = SCHEMA_VERSION
+    artifact_type: str = "result_observation"
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = asdict(self)
+        # result.observed MUST NOT carry fulfills/closes semantics. Strip
+        # defensively even though no field sources them.
+        d.pop("fulfills", None)
+        d.pop("closes", None)
+        return d
+
+    def validate(self) -> None:
+        _get_validator("result_observation.v0.1.schema.json").validate(self.to_dict())
+
+
+@dataclass
+class FulfillmentKeptArtifact:
+    """Terminal closure: a commitment was kept."""
+
+    fulfillment_id: str
+    timestamp: str
+    episode_id: str
+    commitment_id: str
+    result_id: str
+    evaluator: str
+    evaluator_version: str
+    policy_hash: str
+    policy_resolver: Dict[str, Any]
+    schema_version: str = SCHEMA_VERSION
+    artifact_type: str = "fulfillment_commitment_kept"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    def validate(self) -> None:
+        _get_validator("fulfillment_commitment_kept.v0.1.schema.json").validate(
+            self.to_dict()
+        )
+
+
+@dataclass
+class FulfillmentBrokenArtifact:
+    """Terminal closure: a commitment was broken."""
+
+    fulfillment_id: str
+    timestamp: str
+    episode_id: str
+    commitment_id: str
+    result_id: str
+    evaluator: str
+    evaluator_version: str
+    policy_hash: str
+    policy_resolver: Dict[str, Any]
+    violation_reason: str
+    schema_version: str = SCHEMA_VERSION
+    artifact_type: str = "fulfillment_commitment_broken"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    def validate(self) -> None:
+        _get_validator("fulfillment_commitment_broken.v0.1.schema.json").validate(
+            self.to_dict()
+        )
+
+
+# ---------------------------------------------------------------------------
+# Store scanning helpers (full-store, uncapped)
+# ---------------------------------------------------------------------------
+
+
+def _iter_all_receipts(store: AssayStore) -> Iterator[Dict[str, Any]]:
+    """Iterate all receipts in store-wide ``_store_seq`` order.
+
+    Slice 1's receipt-order primitive is the monotonic ``_store_seq``
+    envelope field assigned by ``AssayStore.append`` / ``append_dict``.
+    Lexicographic trace-path order is NOT a valid chronology because
+    ``AssayStore.start_trace(trace_id=...)`` accepts arbitrary trace IDs.
+
+    Fail-closed on every ambiguity: unreadable files, malformed JSON,
+    missing ``_store_seq``, non-integer ``_store_seq``, duplicated
+    ``_store_seq``, or a ``_store_seq`` that regresses within a single
+    file (tampering detection). Any of these raise
+    ``ReceiptStoreIntegrityError``. Receipt-backed invariants must never
+    treat corruption or ambiguity as absence.
+
+    Blank lines are tolerated (common append-only artifact).
+    """
+    base = store.base_dir
+    if not base.exists():
+        return
+
+    entries: List[Tuple[int, Dict[str, Any]]] = []
+    seen_seqs: Dict[int, str] = {}  # seq -> "file:line" witness of first occurrence
+
+    for trace_file in sorted(base.rglob("trace_*.jsonl")):
+        if not trace_file.is_file():
+            continue
+        try:
+            handle = open(trace_file)
+        except OSError as exc:
+            raise ReceiptStoreIntegrityError(
+                f"Cannot read trace file {trace_file}: {exc}"
+            ) from exc
+        last_seq_in_file = -1
+        with handle:
+            for line_number, line in enumerate(handle, start=1):
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    entry = json.loads(stripped)
+                except json.JSONDecodeError as exc:
+                    raise ReceiptStoreIntegrityError(
+                        f"Malformed JSON in {trace_file} line {line_number}: {exc}"
+                    ) from exc
+                seq = entry.get("_store_seq")
+                if not isinstance(seq, int) or isinstance(seq, bool):
+                    raise ReceiptStoreIntegrityError(
+                        f"Missing or non-integer _store_seq in {trace_file} "
+                        f"line {line_number}. Slice 1 requires every receipt "
+                        "to carry a monotonic _store_seq stamped at write time."
+                    )
+                if seq in seen_seqs:
+                    raise ReceiptStoreIntegrityError(
+                        f"Duplicate _store_seq={seq} at {trace_file} line "
+                        f"{line_number}; first seen at {seen_seqs[seq]}. "
+                        "Store-local sequence must be unique."
+                    )
+                if seq <= last_seq_in_file:
+                    raise ReceiptStoreIntegrityError(
+                        f"Non-monotonic _store_seq in {trace_file} line "
+                        f"{line_number}: {seq} <= previous {last_seq_in_file}. "
+                        "Within-file sequence must strictly increase."
+                    )
+                seen_seqs[seq] = f"{trace_file}:{line_number}"
+                last_seq_in_file = seq
+                entries.append((seq, entry))
+
+    entries.sort(key=lambda t: t[0])
+    for _, entry in entries:
+        yield entry
+
+
+def _extract_receipt_type(entry: Dict[str, Any]) -> str:
+    return str(entry.get("type") or entry.get("receipt_type") or "")
+
+
+def _find_receipt_by_field(
+    store: AssayStore,
+    receipt_type: str,
+    id_field: str,
+    id_value: str,
+) -> Optional[Dict[str, Any]]:
+    """Return the first receipt in ``store`` matching both type and id field.
+
+    Type-aware: a bare ``id_field`` match on some unrelated receipt type
+    does not count. The scan is full-store (no cap).
+    """
+    for entry in _iter_all_receipts(store):
+        if _extract_receipt_type(entry) != receipt_type:
+            continue
+        if entry.get(id_field) != id_value:
+            continue
+        return entry
+    return None
+
+
+def _assert_commitment_exists(store: AssayStore, commitment_id: str) -> None:
+    """Raise UnanchoredFulfillmentError if commitment_id has no registration."""
+    if _find_receipt_by_field(
+        store,
+        COMMITMENT_REGISTRATION_RECEIPT_TYPE,
+        "commitment_id",
+        commitment_id,
+    ) is None:
+        raise UnanchoredFulfillmentError(
+            f"Fulfillment references unknown commitment_id={commitment_id!r}. "
+            f"No commitment.registered receipt with that id exists in the store. "
+            "A terminal fulfillment must anchor to a prior registration."
+        )
+
+
+def _assert_result_anchors_commitment(
+    store: AssayStore,
+    *,
+    result_id: str,
+    commitment_id: str,
+) -> None:
+    """Raise UnanchoredFulfillmentError unless a result.observed edge exists.
+
+    The edge the wedge requires: some ``result.observed`` receipt with
+    ``result_id`` whose ``references`` list contains an explicit
+    ``{"kind": "commitment", "id": commitment_id}`` entry.
+
+    Bare ``result_id`` existence is not sufficient — a result observed for
+    a different commitment must not adjudicate this one.
+    """
+    found_result_receipt = False
+    for entry in _iter_all_receipts(store):
+        if _extract_receipt_type(entry) != RESULT_OBSERVATION_RECEIPT_TYPE:
+            continue
+        if entry.get("result_id") != result_id:
+            continue
+        found_result_receipt = True
+        for ref in entry.get("references") or []:
+            if (
+                isinstance(ref, dict)
+                and ref.get("kind") == "commitment"
+                and ref.get("id") == commitment_id
+            ):
+                return  # edge exists: (result_id, commitment_id)
+    if not found_result_receipt:
+        raise UnanchoredFulfillmentError(
+            f"Fulfillment references unknown result_id={result_id!r}. "
+            f"No result.observed receipt with that id exists in the store. "
+            "A terminal fulfillment must cite a prior observation that "
+            "references its commitment."
+        )
+    raise UnanchoredFulfillmentError(
+        f"result_id={result_id!r} exists but does not reference "
+        f"commitment_id={commitment_id!r}. "
+        "A terminal fulfillment must cite an observation whose "
+        "references list includes the commitment it closes."
+    )
+
+
+def _assert_no_existing_terminal(store: AssayStore, commitment_id: str) -> None:
+    """Scan the entire store for a prior terminal fulfillment of this commitment.
+
+    Full-store scan, no cap. Raises TerminalFulfillmentError if one is found.
+    """
+    for entry in _iter_all_receipts(store):
+        entry_type = _extract_receipt_type(entry)
+        if entry_type not in TERMINAL_FULFILLMENT_TYPES:
+            continue
+        if entry.get("commitment_id") != commitment_id:
+            continue
+        raise TerminalFulfillmentError(
+            f"Commitment {commitment_id!r} already has a terminal fulfillment: "
+            f"type={entry_type!r} "
+            f"fulfillment_id={entry.get('fulfillment_id')!r}. "
+            "A commitment has zero or one terminal fulfillment."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Policy-binding verification
+# ---------------------------------------------------------------------------
+
+
+def _verify_policy_binding(artifact: Any) -> None:
+    """Verify an artifact's policy_hash is backed by a resolvable policy.
+
+    Checks:
+        1. The artifact's embedded ``policy_resolver.policy_hash`` equals
+           the artifact's top-level ``policy_hash``.
+        2. Resolving the PolicyResolver yields a COMPILE_RECEIPT whose
+           own ``policy_hash`` equals the expected hash.
+
+    Applied uniformly to every Slice 1 receipt. Closure records (result +
+    fulfillment) must clear the same bar as registration.
+    """
+    resolver_dict = artifact.policy_resolver
+    if not isinstance(resolver_dict, dict):
+        raise PolicyResolutionError(
+            "Artifact.policy_resolver must be a dict with keys "
+            "{'kind','ref','policy_hash'}."
+        )
+    embedded_hash = resolver_dict.get("policy_hash")
+    if embedded_hash != artifact.policy_hash:
+        raise PolicyResolutionError(
+            f"Artifact policy_hash={artifact.policy_hash!r} does not match "
+            f"embedded policy_resolver.policy_hash={embedded_hash!r}. "
+            "Receipt refused."
+        )
+    try:
+        resolver = PolicyResolver(
+            kind=resolver_dict["kind"],
+            ref=resolver_dict["ref"],
+            policy_hash=resolver_dict["policy_hash"],
+        )
+    except KeyError as exc:
+        raise PolicyResolutionError(
+            f"Artifact.policy_resolver missing required key: {exc}"
+        ) from exc
+    resolve_policy(resolver)
+
+
+# ---------------------------------------------------------------------------
+# Emit functions
+# ---------------------------------------------------------------------------
+
+
+def emit_commitment_registration(
+    episode: Episode,
+    commitment: Union[CommitmentRegistrationArtifact, Dict[str, Any]],
+    *,
+    parent_receipt_id: Optional[str] = None,
+) -> CommitmentRegistrationArtifact:
+    """Emit a commitment.registered receipt after verifying the policy binding.
+
+    Raises:
+        PolicyResolutionError: If the embedded resolver cannot resolve, or
+            the artifact's top-level ``policy_hash`` does not match both
+            the embedded resolver hash and the resolved COMPILE_RECEIPT.
+    """
+    artifact = (
+        commitment
+        if isinstance(commitment, CommitmentRegistrationArtifact)
+        else CommitmentRegistrationArtifact(**commitment)
+    )
+    _verify_policy_binding(artifact)
+    artifact.validate()
+    episode.emit(
+        COMMITMENT_REGISTRATION_RECEIPT_TYPE,
+        artifact.to_dict(),
+        parent_receipt_id=parent_receipt_id,
+    )
+    return artifact
+
+
+def emit_result_observation(
+    episode: Episode,
+    result: Union[ResultObservationArtifact, Dict[str, Any]],
+    *,
+    parent_receipt_id: Optional[str] = None,
+) -> ResultObservationArtifact:
+    """Emit a result.observed receipt.
+
+    Non-adjudicating: never closes a commitment. Terminal closure is the
+    exclusive job of fulfillment.commitment_kept | commitment_broken.
+
+    Raises:
+        PolicyResolutionError: If the embedded resolver cannot resolve, or
+            policy_hash bindings are inconsistent.
+    """
+    artifact = (
+        result
+        if isinstance(result, ResultObservationArtifact)
+        else ResultObservationArtifact(**result)
+    )
+    _verify_policy_binding(artifact)
+    artifact.validate()
+    episode.emit(
+        RESULT_OBSERVATION_RECEIPT_TYPE,
+        artifact.to_dict(),
+        parent_receipt_id=parent_receipt_id,
+    )
+    return artifact
+
+
+def emit_fulfillment_kept(
+    episode: Episode,
+    fulfillment: Union[FulfillmentKeptArtifact, Dict[str, Any]],
+    *,
+    parent_receipt_id: Optional[str] = None,
+) -> FulfillmentKeptArtifact:
+    """Emit a fulfillment.commitment_kept receipt.
+
+    Guards four invariants before writing:
+        1. Policy binding is consistent and resolvable.
+        2. The referenced commitment exists as a commitment.registered receipt.
+        3. The referenced result exists as a result.observed receipt.
+        4. No prior terminal fulfillment names this commitment
+           (zero-or-one terminal invariant).
+
+    Raises:
+        PolicyResolutionError: On any policy-binding defect.
+        UnanchoredFulfillmentError: If commitment or result referents are
+            not present in the store.
+        TerminalFulfillmentError: If a prior terminal already closes this
+            commitment.
+    """
+    artifact = (
+        fulfillment
+        if isinstance(fulfillment, FulfillmentKeptArtifact)
+        else FulfillmentKeptArtifact(**fulfillment)
+    )
+    store = episode._store
+    _verify_policy_binding(artifact)
+    _assert_commitment_exists(store, artifact.commitment_id)
+    _assert_result_anchors_commitment(
+        store,
+        result_id=artifact.result_id,
+        commitment_id=artifact.commitment_id,
+    )
+    _assert_no_existing_terminal(store, artifact.commitment_id)
+    artifact.validate()
+    episode.emit(
+        FULFILLMENT_COMMITMENT_KEPT_RECEIPT_TYPE,
+        artifact.to_dict(),
+        parent_receipt_id=parent_receipt_id,
+    )
+    return artifact
+
+
+def emit_fulfillment_broken(
+    episode: Episode,
+    fulfillment: Union[FulfillmentBrokenArtifact, Dict[str, Any]],
+    *,
+    parent_receipt_id: Optional[str] = None,
+) -> FulfillmentBrokenArtifact:
+    """Emit a fulfillment.commitment_broken receipt.
+
+    Same four invariants as ``emit_fulfillment_kept``.
+
+    Raises:
+        PolicyResolutionError, UnanchoredFulfillmentError, TerminalFulfillmentError
+    """
+    artifact = (
+        fulfillment
+        if isinstance(fulfillment, FulfillmentBrokenArtifact)
+        else FulfillmentBrokenArtifact(**fulfillment)
+    )
+    store = episode._store
+    _verify_policy_binding(artifact)
+    _assert_commitment_exists(store, artifact.commitment_id)
+    _assert_result_anchors_commitment(
+        store,
+        result_id=artifact.result_id,
+        commitment_id=artifact.commitment_id,
+    )
+    _assert_no_existing_terminal(store, artifact.commitment_id)
+    artifact.validate()
+    episode.emit(
+        FULFILLMENT_COMMITMENT_BROKEN_RECEIPT_TYPE,
+        artifact.to_dict(),
+        parent_receipt_id=parent_receipt_id,
+    )
+    return artifact
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "COMMITMENT_REGISTRATION_RECEIPT_TYPE",
+    "RESULT_OBSERVATION_RECEIPT_TYPE",
+    "FULFILLMENT_COMMITMENT_KEPT_RECEIPT_TYPE",
+    "FULFILLMENT_COMMITMENT_BROKEN_RECEIPT_TYPE",
+    "TERMINAL_FULFILLMENT_TYPES",
+    "TerminalFulfillmentError",
+    "UnanchoredFulfillmentError",
+    "ReceiptStoreIntegrityError",
+    "CommitmentRegistrationArtifact",
+    "ResultObservationArtifact",
+    "FulfillmentKeptArtifact",
+    "FulfillmentBrokenArtifact",
+    "emit_commitment_registration",
+    "emit_result_observation",
+    "emit_fulfillment_kept",
+    "emit_fulfillment_broken",
+]

--- a/src/assay/doctor.py
+++ b/src/assay/doctor.py
@@ -908,6 +908,71 @@ def _check_contradiction_001(store: Any = None) -> DoctorCheckResult:
         )
 
 
+def _check_commitment_001(store: Any = None) -> DoctorCheckResult:
+    """Detect overdue open commitments (declared but unfulfilled past due_at).
+
+    Scope: Slice 1 of the Commitment-Fulfillment wedge. A commitment is open
+    when no terminal fulfillment (commitment_kept | commitment_broken) names
+    it; it is overdue when its declared due_at is in the past. Commitments
+    without due_at are treated as perpetual and not flagged.
+
+    Enabled via --check-orphans (not in default profiles).
+    """
+    try:
+        from assay.commitment_closure_detector import (
+            detect_open_overdue_commitments,
+        )
+        from assay.store import get_default_store
+
+        s = store if store is not None else get_default_store()
+        result = detect_open_overdue_commitments(s)
+        if result.clean:
+            return DoctorCheckResult(
+                id="DOCTOR_COMMITMENT_001",
+                status=CheckStatus.PASS,
+                severity=Severity.INFO,
+                message=(
+                    f"No overdue commitments ({result.total_traces_scanned} traces "
+                    f"scanned, {result.total_registered_found} registered, "
+                    f"{result.total_closed_found} closed)"
+                ),
+                evidence={
+                    "traces_scanned": result.total_traces_scanned,
+                    "registered_found": result.total_registered_found,
+                    "closed_found": result.total_closed_found,
+                },
+            )
+        return DoctorCheckResult(
+            id="DOCTOR_COMMITMENT_001",
+            status=CheckStatus.FAIL,
+            severity=Severity.HIGH,
+            message=(
+                f"{result.total_open_found} overdue commitment(s) detected "
+                "(no terminal fulfillment past due_at)"
+            ),
+            evidence={
+                "total_open": result.total_open_found,
+                "total_registered": result.total_registered_found,
+                "total_closed": result.total_closed_found,
+                "open_commitments": [
+                    c.to_dict() for c in result.open_commitments
+                ],
+            },
+            fix=(
+                "# Close each overdue commitment via emit_fulfillment_kept() "
+                "or emit_fulfillment_broken()"
+            ),
+        )
+    except Exception as e:
+        return DoctorCheckResult(
+            id="DOCTOR_COMMITMENT_001",
+            status=CheckStatus.FAIL,
+            severity=Severity.HIGH,
+            message=f"Commitment check error: {e}",
+            evidence={"error": str(e)},
+        )
+
+
 def _check_obligation_001(store: Any = None) -> DoctorCheckResult:
     """Detect open override obligations (unresolved governance debt).
 
@@ -1178,6 +1243,7 @@ _CHECK_FUNCTIONS = {
     "DOCTOR_ORPHAN_001": lambda **kw: _check_orphan_001(kw.get("store")),
     "DOCTOR_CONTRADICTION_001": lambda **kw: _check_contradiction_001(kw.get("store")),
     "DOCTOR_OBLIGATION_001": lambda **kw: _check_obligation_001(kw.get("store")),
+    "DOCTOR_COMMITMENT_001": lambda **kw: _check_commitment_001(kw.get("store")),
     "DOCTOR_ANCHOR_001": lambda **kw: _check_anchor_001(kw.get("pack_dir")),
 }
 
@@ -1244,6 +1310,8 @@ def run_doctor(
             check_ids.append("DOCTOR_CONTRADICTION_001")
         if "DOCTOR_OBLIGATION_001" not in check_ids:
             check_ids.append("DOCTOR_OBLIGATION_001")
+        if "DOCTOR_COMMITMENT_001" not in check_ids:
+            check_ids.append("DOCTOR_COMMITMENT_001")
         if "DOCTOR_ANCHOR_001" not in check_ids:
             check_ids.append("DOCTOR_ANCHOR_001")
 

--- a/src/assay/episode.py
+++ b/src/assay/episode.py
@@ -289,6 +289,7 @@ class Receipt:
                 "canonical_hash",
                 "_trace_id",
                 "_stored_at",
+                "_store_seq",
             }
         }
         canonical_hash = str(data.get("canonical_hash") or "")
@@ -532,7 +533,7 @@ def _strip_runtime_metadata(entry: Mapping[str, Any]) -> Dict[str, Any]:
     return {
         key: value
         for key, value in entry.items()
-        if key not in {"_trace_id", "_stored_at"}
+        if key not in {"_trace_id", "_stored_at", "_store_seq"}
     }
 
 

--- a/src/assay/epistemic_kernel.py
+++ b/src/assay/epistemic_kernel.py
@@ -42,6 +42,7 @@ TRACE_ENVELOPE_FIELDS = {
     "type",
     "_trace_id",
     "_stored_at",
+    "_store_seq",
     "parent_receipt_id",
     "seq",
     "canonical_hash",

--- a/src/assay/policy_resolver.py
+++ b/src/assay/policy_resolver.py
@@ -1,0 +1,140 @@
+"""Policy resolver — turn a PolicyResolver handle into a COMPILE_RECEIPT dict.
+
+This is a reusable primitive, not commitment-specific glue. Any receipt type
+that carries a ``policy_hash`` may use it to bind the hash to a concrete
+compiled-policy provenance record.
+
+Slice 1 scope:
+    - kind="uri": read a ``file://`` URI and parse as JSON; verify the
+      returned ``policy_hash`` matches the resolver's declared hash.
+    - kind="registry": declared but not implemented. Raises
+      ``NotImplementedError`` explicitly — callers must not silently fall
+      back to a different kind.
+
+Design:
+    - ``PolicyResolver`` is a plain dataclass with ``to_dict()``. Callers
+      embed ``to_dict()`` into their receipt payloads alongside the
+      ``policy_hash`` field.
+    - ``resolve_policy`` never mutates state; it returns the parsed dict.
+    - Mismatched hashes or missing files raise ``PolicyResolutionError``.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict
+from urllib.parse import urlparse
+
+
+VALID_KINDS = {"uri", "registry"}
+
+
+class PolicyResolutionError(ValueError):
+    """Raised when a PolicyResolver cannot bind to a matching COMPILE_RECEIPT."""
+
+
+@dataclass
+class PolicyResolver:
+    """Handle that names *where* a compiled policy lives and *what* it hashes to.
+
+    ``ref`` interpretation depends on ``kind``:
+        - ``"uri"``      → a ``file://`` URI to a COMPILE_RECEIPT.json document.
+        - ``"registry"`` → a registry identifier (reserved; not implemented
+          in Slice 1).
+
+    ``policy_hash`` is the expected hash of the compiled policy. The resolved
+    document's ``policy_hash`` field must equal this value, or resolution
+    fails.
+    """
+
+    kind: str
+    ref: str
+    policy_hash: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    def validate(self) -> None:
+        if self.kind not in VALID_KINDS:
+            raise PolicyResolutionError(
+                f"Unknown PolicyResolver kind: {self.kind!r}. "
+                f"Valid kinds: {sorted(VALID_KINDS)}"
+            )
+
+
+def resolve_policy(resolver: PolicyResolver) -> Dict[str, Any]:
+    """Resolve a PolicyResolver to its COMPILE_RECEIPT document.
+
+    Args:
+        resolver: The handle naming where the compiled policy lives and
+            what hash it must carry.
+
+    Returns:
+        The parsed COMPILE_RECEIPT.json as a dict.
+
+    Raises:
+        PolicyResolutionError: If the document is missing, malformed, or
+            carries a ``policy_hash`` that differs from ``resolver.policy_hash``.
+        NotImplementedError: If ``kind="registry"``. Registry-backed
+            resolution is reserved for a later slice.
+    """
+    resolver.validate()
+
+    if resolver.kind == "registry":
+        raise NotImplementedError(
+            "PolicyResolver kind='registry' is not implemented in Slice 1. "
+            "Use kind='uri' with a file:// reference. Do not fall back silently."
+        )
+
+    if resolver.kind == "uri":
+        return _resolve_uri(resolver)
+
+    raise PolicyResolutionError(f"Unhandled resolver kind: {resolver.kind!r}")
+
+
+def _resolve_uri(resolver: PolicyResolver) -> Dict[str, Any]:
+    parsed = urlparse(resolver.ref)
+    if parsed.scheme != "file":
+        raise PolicyResolutionError(
+            f"Slice 1 supports file:// URIs only (got scheme {parsed.scheme!r}). "
+            f"ref={resolver.ref!r}"
+        )
+
+    path = Path(parsed.path)
+    if not path.exists():
+        raise PolicyResolutionError(
+            f"COMPILE_RECEIPT not found at {path}. "
+            f"ref={resolver.ref!r} policy_hash={resolver.policy_hash!r}"
+        )
+
+    try:
+        raw = path.read_text()
+        document = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PolicyResolutionError(
+            f"COMPILE_RECEIPT at {path} is unreadable or malformed: {exc}"
+        ) from exc
+
+    if not isinstance(document, dict):
+        raise PolicyResolutionError(
+            f"COMPILE_RECEIPT at {path} must be a JSON object, got {type(document).__name__}"
+        )
+
+    declared_hash = document.get("policy_hash")
+    if declared_hash != resolver.policy_hash:
+        raise PolicyResolutionError(
+            f"COMPILE_RECEIPT policy_hash mismatch at {path}. "
+            f"Resolver expected {resolver.policy_hash!r}, "
+            f"document declares {declared_hash!r}."
+        )
+
+    return document
+
+
+__all__ = [
+    "VALID_KINDS",
+    "PolicyResolutionError",
+    "PolicyResolver",
+    "resolve_policy",
+]

--- a/src/assay/schema.py
+++ b/src/assay/schema.py
@@ -46,6 +46,7 @@ _VERSIONS: Dict[str, Dict[str, FrozenSet[str]]] = {
             # Trace metadata (added by store)
             "_trace_id",
             "_stored_at",
+            "_store_seq",
         }),
     },
 }

--- a/src/assay/schemas/commitment_registration.v0.1.schema.json
+++ b/src/assay/schemas/commitment_registration.v0.1.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://assay.ai/schemas/commitment_registration.v0.1.schema.json",
+  "title": "Commitment Registration (v0.1)",
+  "description": "A declared forward-looking commitment. Doctrine source: authority_nouns.md (9c5921d5, frozen).",
+  "type": "object",
+  "required": [
+    "commitment_id",
+    "timestamp",
+    "episode_id",
+    "actor_id",
+    "text",
+    "commitment_type",
+    "policy_hash",
+    "policy_resolver",
+    "schema_version",
+    "artifact_type"
+  ],
+  "properties": {
+    "commitment_id": {"type": "string", "minLength": 1},
+    "timestamp": {"type": "string", "format": "date-time"},
+    "episode_id": {"type": "string", "minLength": 1},
+    "actor_id": {"type": "string", "minLength": 1},
+    "text": {"type": "string", "minLength": 1},
+    "commitment_type": {"type": "string", "minLength": 1},
+    "due_at": {"type": "string", "format": "date-time"},
+    "evidence_uri": {"type": "string"},
+    "policy_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "policy_resolver": {
+      "type": "object",
+      "required": ["kind", "ref", "policy_hash"],
+      "properties": {
+        "kind": {"type": "string", "enum": ["uri", "registry"]},
+        "ref": {"type": "string", "minLength": 1},
+        "policy_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+      }
+    },
+    "schema_version": {"type": "string"},
+    "artifact_type": {"type": "string", "const": "commitment_registration"}
+  },
+  "additionalProperties": true
+}

--- a/src/assay/schemas/fulfillment_commitment_broken.v0.1.schema.json
+++ b/src/assay/schemas/fulfillment_commitment_broken.v0.1.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://assay.ai/schemas/fulfillment_commitment_broken.v0.1.schema.json",
+  "title": "Fulfillment — Commitment Broken (v0.1)",
+  "description": "Terminal: commitment was broken. Doctrine source: authority_nouns.md (9c5921d5, frozen).",
+  "type": "object",
+  "required": [
+    "fulfillment_id",
+    "timestamp",
+    "episode_id",
+    "commitment_id",
+    "result_id",
+    "evaluator",
+    "evaluator_version",
+    "policy_hash",
+    "policy_resolver",
+    "violation_reason",
+    "schema_version",
+    "artifact_type"
+  ],
+  "properties": {
+    "fulfillment_id": {"type": "string", "minLength": 1},
+    "timestamp": {"type": "string", "format": "date-time"},
+    "episode_id": {"type": "string", "minLength": 1},
+    "commitment_id": {"type": "string", "minLength": 1},
+    "result_id": {"type": "string", "minLength": 1},
+    "evaluator": {"type": "string", "minLength": 1},
+    "evaluator_version": {"type": "string", "minLength": 1},
+    "policy_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "policy_resolver": {
+      "type": "object",
+      "required": ["kind", "ref", "policy_hash"],
+      "properties": {
+        "kind": {"type": "string", "enum": ["uri", "registry"]},
+        "ref": {"type": "string", "minLength": 1},
+        "policy_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+      }
+    },
+    "violation_reason": {"type": "string", "minLength": 1},
+    "schema_version": {"type": "string"},
+    "artifact_type": {"type": "string", "const": "fulfillment_commitment_broken"}
+  },
+  "additionalProperties": true
+}

--- a/src/assay/schemas/fulfillment_commitment_kept.v0.1.schema.json
+++ b/src/assay/schemas/fulfillment_commitment_kept.v0.1.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://assay.ai/schemas/fulfillment_commitment_kept.v0.1.schema.json",
+  "title": "Fulfillment — Commitment Kept (v0.1)",
+  "description": "Terminal: commitment was kept. Doctrine source: authority_nouns.md (9c5921d5, frozen).",
+  "type": "object",
+  "required": [
+    "fulfillment_id",
+    "timestamp",
+    "episode_id",
+    "commitment_id",
+    "result_id",
+    "evaluator",
+    "evaluator_version",
+    "policy_hash",
+    "policy_resolver",
+    "schema_version",
+    "artifact_type"
+  ],
+  "properties": {
+    "fulfillment_id": {"type": "string", "minLength": 1},
+    "timestamp": {"type": "string", "format": "date-time"},
+    "episode_id": {"type": "string", "minLength": 1},
+    "commitment_id": {"type": "string", "minLength": 1},
+    "result_id": {"type": "string", "minLength": 1},
+    "evaluator": {"type": "string", "minLength": 1},
+    "evaluator_version": {"type": "string", "minLength": 1},
+    "policy_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "policy_resolver": {
+      "type": "object",
+      "required": ["kind", "ref", "policy_hash"],
+      "properties": {
+        "kind": {"type": "string", "enum": ["uri", "registry"]},
+        "ref": {"type": "string", "minLength": 1},
+        "policy_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+      }
+    },
+    "schema_version": {"type": "string"},
+    "artifact_type": {"type": "string", "const": "fulfillment_commitment_kept"}
+  },
+  "additionalProperties": true
+}

--- a/src/assay/schemas/result_observation.v0.1.schema.json
+++ b/src/assay/schemas/result_observation.v0.1.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://assay.ai/schemas/result_observation.v0.1.schema.json",
+  "title": "Result Observation (v0.1)",
+  "description": "A non-adjudicating observation. Never closes a commitment. Doctrine source: authority_nouns.md (9c5921d5, frozen).",
+  "type": "object",
+  "required": [
+    "result_id",
+    "timestamp",
+    "episode_id",
+    "text",
+    "evidence_uri",
+    "policy_hash",
+    "policy_resolver",
+    "schema_version",
+    "artifact_type"
+  ],
+  "properties": {
+    "result_id": {"type": "string", "minLength": 1},
+    "timestamp": {"type": "string", "format": "date-time"},
+    "episode_id": {"type": "string", "minLength": 1},
+    "text": {"type": "string", "minLength": 1},
+    "evidence_uri": {"type": "string", "minLength": 1},
+    "policy_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "policy_resolver": {
+      "type": "object",
+      "required": ["kind", "ref", "policy_hash"],
+      "properties": {
+        "kind": {"type": "string", "enum": ["uri", "registry"]},
+        "ref": {"type": "string", "minLength": 1},
+        "policy_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+      }
+    },
+    "references": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["kind", "id"],
+        "properties": {
+          "kind": {"type": "string"},
+          "id": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "schema_version": {"type": "string"},
+    "artifact_type": {"type": "string", "const": "result_observation"},
+    "fulfills": {"not": {}},
+    "closes": {"not": {}}
+  },
+  "additionalProperties": true
+}

--- a/src/assay/store.py
+++ b/src/assay/store.py
@@ -15,7 +15,7 @@ import threading
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from assay._receipts.compat.pyd import BaseModel
 
@@ -28,6 +28,41 @@ except ImportError:
 
 _LEGACY_HOME = ".loom/assay"
 _NEW_HOME = ".assay"
+
+
+class ReceiptStoreIntegrityError(RuntimeError):
+    """Raised when the store's trace corpus is unreadable, malformed, or
+    otherwise in a state where normal writes cannot proceed safely.
+
+    Covers:
+        - unreadable trace files
+        - malformed JSON lines
+        - mixed state (some receipts with ``_store_seq``, some without)
+        - within-file ``_store_seq`` regression or duplicates
+
+    Distinct from :class:`MigrationRequiredError`: that is an operator-
+    solvable state with a clear remediation path (run migration). An
+    integrity error signals the corpus itself has been tampered with or
+    damaged and requires explicit repair tooling — no silent recovery.
+    """
+
+
+class MigrationRequiredError(RuntimeError):
+    """Raised by the write path when a store carries legacy receipts without
+    ``_store_seq`` and has not been migrated.
+
+    A pure legacy store must be migrated explicitly before new writes, or
+    the next ordinary write would silently convert the store to mixed
+    state (which ``migrate_legacy_store_seq`` then correctly refuses to
+    touch, stranding the operator).
+
+    Resolution:
+        from assay.store_seq_migration import migrate_legacy_store_seq
+        migrate_legacy_store_seq(store)
+
+    Or via CLI:
+        python -m assay.store_seq_migration <base_dir>
+    """
 
 
 def assay_home() -> Path:
@@ -69,6 +104,16 @@ class AssayStore:
         self._current_trace_id: Optional[str] = None
         self._current_file: Optional[Path] = None
         self._lock = threading.RLock()
+        # Store-wide monotonic receipt sequence primitive. Its state lives
+        # ON DISK at ``<base_dir>/.store_seq`` and is mutated under
+        # ``fcntl.flock(LOCK_EX)`` so that multiple AssayStore instances
+        # (including across processes) cannot allocate the same seq.
+        # Allocation + receipt persistence run in a single critical section:
+        # no writer releases the seq-file lock between "take a seq" and
+        # "put the receipt bearing that seq on disk". Lexicographic trace-
+        # path order is NOT a valid chronology; ``_store_seq`` is the
+        # authority.
+        self._seq_file = self.base_dir / ".store_seq"
 
     def start_trace(self, trace_id: Optional[str] = None) -> str:
         """Start a new trace, returning the trace ID.
@@ -154,6 +199,245 @@ class AssayStore:
         finally:
             os.close(fd)
 
+    def _classify_store_for_write_strict(self) -> Tuple[int, int]:
+        """Full-corpus strict validation for the write path.
+
+        Walks every ``trace_*.jsonl`` file under ``base_dir``. Enforces the
+        same stamped-store integrity invariants as the detector's
+        ``_iter_all_receipts``: corrupt, duplicated, non-monotonic, or
+        non-integer ``_store_seq`` values all fail closed.
+
+        Classification buckets:
+            * ABSENT — receipt lacks ``_store_seq`` key entirely (legacy).
+            * VALID — ``_store_seq`` is a non-boolean integer ≥ 0, unique
+              store-wide, and strictly increasing within its trace file.
+            * CORRUPT — ``_store_seq`` is present but not a valid integer,
+              or violates uniqueness / within-file monotonicity. Always
+              an integrity error.
+
+        Returns:
+            ``(max_store_seq_seen, legacy_count)``
+
+            * ``max_store_seq_seen`` is the largest VALID ``_store_seq``,
+              or ``-1`` if no receipt carries one.
+            * ``legacy_count`` is the number of ABSENT-bucket receipts.
+              A positive value with zero stamped receipts signals
+              PURE_LEGACY; callers should raise
+              :class:`MigrationRequiredError`.
+
+        State decoding by caller (assuming this method returned cleanly):
+            ``(max=-1, legacy=0)``  → EMPTY (first-ever write allowed)
+            ``(max>=0, legacy=0)``  → CURRENT (next_seq = max+1 or counter)
+            ``(_,      legacy>0)``  → PURE_LEGACY (raise MigrationRequiredError)
+
+        Raises:
+            ReceiptStoreIntegrityError on:
+                - any unreadable trace file
+                - any malformed JSON line
+                - MIXED state (VALID AND ABSENT receipts both present)
+                - duplicate ``_store_seq`` anywhere in the corpus
+                - within-file regression or equality of ``_store_seq``
+                - ``_store_seq`` present but not an integer (or a bool),
+                  or a negative integer
+
+        The ``.store_seq`` counter file is intentionally NOT consulted
+        here: it is only authoritative for a corpus that has passed this
+        check.
+        """
+        max_seq = -1
+        stamped = 0
+        legacy = 0
+        if not self.base_dir.exists():
+            return max_seq, legacy
+
+        # seq -> "file:line" witness of first occurrence, for duplicate detection.
+        seen_seqs: Dict[int, str] = {}
+
+        for trace_file in sorted(self.base_dir.rglob("trace_*.jsonl")):
+            if not trace_file.is_file():
+                continue
+            try:
+                handle = open(trace_file)
+            except OSError as exc:
+                raise ReceiptStoreIntegrityError(
+                    f"Cannot read trace file {trace_file} during write "
+                    f"validation: {exc}. Write refused."
+                ) from exc
+            last_seq_in_file = -1
+            with handle:
+                for line_number, line in enumerate(handle, start=1):
+                    stripped = line.strip()
+                    if not stripped:
+                        continue
+                    try:
+                        entry = json.loads(stripped)
+                    except json.JSONDecodeError as exc:
+                        raise ReceiptStoreIntegrityError(
+                            f"Malformed JSON in {trace_file} line "
+                            f"{line_number}: {exc}. Write refused: the "
+                            "trace corpus must be readable before new "
+                            "receipts can be written."
+                        ) from exc
+
+                    # Classify this receipt's _store_seq.
+                    if "_store_seq" not in entry:
+                        legacy += 1
+                        continue
+                    seq = entry["_store_seq"]
+                    # bool is subclass of int in Python — reject explicitly.
+                    if not isinstance(seq, int) or isinstance(seq, bool):
+                        raise ReceiptStoreIntegrityError(
+                            f"Non-integer _store_seq at {trace_file} line "
+                            f"{line_number}: got {seq!r} "
+                            f"({type(seq).__name__}). Write refused; this "
+                            "is corpus corruption, not legacy data."
+                        )
+                    if seq < 0:
+                        raise ReceiptStoreIntegrityError(
+                            f"Negative _store_seq at {trace_file} line "
+                            f"{line_number}: {seq}. Write refused."
+                        )
+                    if seq in seen_seqs:
+                        raise ReceiptStoreIntegrityError(
+                            f"Duplicate _store_seq={seq} at {trace_file} "
+                            f"line {line_number}; first seen at "
+                            f"{seen_seqs[seq]}. Write refused: "
+                            "store-local sequence must be unique."
+                        )
+                    if seq <= last_seq_in_file:
+                        raise ReceiptStoreIntegrityError(
+                            f"Non-monotonic _store_seq in {trace_file} "
+                            f"line {line_number}: {seq} <= previous "
+                            f"{last_seq_in_file}. Write refused: "
+                            "within-file sequence must strictly increase."
+                        )
+                    seen_seqs[seq] = f"{trace_file}:{line_number}"
+                    last_seq_in_file = seq
+                    stamped += 1
+                    if seq > max_seq:
+                        max_seq = seq
+
+        if stamped > 0 and legacy > 0:
+            raise ReceiptStoreIntegrityError(
+                f"AssayStore at {self.base_dir} is in mixed state: "
+                f"{stamped} receipts stamped with _store_seq and "
+                f"{legacy} receipts without. Normal writes refused. "
+                "Mixed state cannot be healed by automatic migration; "
+                "explicit operator repair is required."
+            )
+
+        return max_seq, legacy
+
+    def _raise_migration_required(self) -> None:
+        raise MigrationRequiredError(
+            f"AssayStore at {self.base_dir} contains legacy "
+            "receipts without _store_seq. Appending now would "
+            "create unrecoverable mixed state (migration "
+            "refuses to repair a mixed store). Run migration "
+            "before writing: "
+            "`python -m assay.store_seq_migration "
+            f"{self.base_dir}` "
+            "(or `from assay.store_seq_migration import "
+            "migrate_legacy_store_seq; "
+            "migrate_legacy_store_seq(store)`)."
+        )
+
+    def _persist_entry_with_store_seq(self, data: Dict[str, Any]) -> None:
+        """Atomically allocate the next ``_store_seq`` and write ``data``.
+
+        Rollout contract (enforced on every write):
+
+            EMPTY          — allow; start at seq 0
+            CURRENT        — allow; allocate from ``.store_seq`` counter or
+                             ``max(_store_seq) + 1``, whichever is higher
+            PURE_LEGACY    — refuse with :class:`MigrationRequiredError`
+            MIXED          — refuse with :class:`ReceiptStoreIntegrityError`
+            CORRUPT        — refuse with :class:`ReceiptStoreIntegrityError`
+
+        ``.store_seq`` is NOT a health certificate. Its presence does not
+        bypass corpus validation; the counter is only authoritative for a
+        corpus that has just passed strict classification.
+
+        Cross-process-safe: the durable ``<base_dir>/.store_seq`` file is
+        opened under ``fcntl.flock(LOCK_EX)`` around allocation and
+        persistence. The strict classifier is also re-run under the lock
+        to close the narrow ToCTTOU window between the pre-check and
+        counter read.
+        """
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+        # Strict full-corpus validation BEFORE touching ``.store_seq``.
+        # Fails closed on corrupt / mixed state. On PURE_LEGACY we still
+        # get here (no raise from the classifier) and refuse with a
+        # migration-pointer error — leaving ``.store_seq`` uncreated.
+        _, legacy_count = self._classify_store_for_write_strict()
+        if legacy_count > 0:
+            self._raise_migration_required()
+
+        seq_fd = os.open(
+            str(self._seq_file),
+            os.O_RDWR | os.O_CREAT,
+            0o644,
+        )
+        try:
+            if _HAS_FCNTL:
+                fcntl.flock(seq_fd, fcntl.LOCK_EX)
+            try:
+                # Defensive re-classification under the lock: closes a
+                # narrow window where another writer could have changed
+                # corpus state between the pre-check and here.
+                max_seq_in_corpus, legacy_count = (
+                    self._classify_store_for_write_strict()
+                )
+                if legacy_count > 0:
+                    self._raise_migration_required()
+
+                # Corpus is EMPTY or CURRENT. Allocate from the counter
+                # file if it's valid; otherwise reconstruct defensively
+                # from the corpus. Never allocate a seq that would
+                # non-monotonically collide with an existing receipt.
+                os.lseek(seq_fd, 0, os.SEEK_SET)
+                raw = os.read(seq_fd, 64)
+                text = raw.decode("utf-8").strip() if raw else ""
+                if text:
+                    try:
+                        counter_seq = int(text)
+                    except ValueError as exc:
+                        raise RuntimeError(
+                            f"AssayStore sequence counter at "
+                            f"{self._seq_file} is corrupted: {text!r}"
+                        ) from exc
+                    if counter_seq < 0:
+                        raise RuntimeError(
+                            f"AssayStore sequence counter at "
+                            f"{self._seq_file} is negative: {counter_seq}"
+                        )
+                    # Defensive: if the counter has somehow fallen behind
+                    # the corpus (external reset, partial rollback), use
+                    # whichever is higher to preserve strict monotonicity.
+                    next_seq = max(counter_seq, max_seq_in_corpus + 1)
+                else:
+                    next_seq = max_seq_in_corpus + 1
+
+                # Stamp receipt with allocated seq and persist to trace file.
+                data["_store_seq"] = next_seq
+                line = json.dumps(data, default=str) + "\n"
+                self._write_line(line.encode("utf-8"))
+
+                # Persist incremented counter.
+                new_counter = str(next_seq + 1).encode("utf-8")
+                os.lseek(seq_fd, 0, os.SEEK_SET)
+                os.ftruncate(seq_fd, 0)
+                self._write_all(seq_fd, new_counter)
+            finally:
+                if _HAS_FCNTL:
+                    try:
+                        fcntl.flock(seq_fd, fcntl.LOCK_UN)
+                    except OSError:
+                        pass
+        finally:
+            os.close(seq_fd)
+
     def append(self, receipt: BaseModel) -> str:
         """
         Append a receipt to the current trace.
@@ -167,12 +451,12 @@ class AssayStore:
             # Serialize with Pydantic
             data = receipt.model_dump(mode="json", exclude_none=True)
 
-            # Add trace metadata
+            # Add trace metadata (trace_id + wall-clock). _store_seq is
+            # stamped inside the cross-process critical section below.
             data["_trace_id"] = self._current_trace_id
             data["_stored_at"] = datetime.now(timezone.utc).isoformat()
 
-            line = json.dumps(data, default=str) + "\n"
-            self._write_line(line.encode("utf-8"))
+            self._persist_entry_with_store_seq(data)
 
             return data.get("receipt_id", "unknown")
 
@@ -185,8 +469,7 @@ class AssayStore:
             data["_trace_id"] = self._current_trace_id
             data["_stored_at"] = datetime.now(timezone.utc).isoformat()
 
-            line = json.dumps(data, default=str) + "\n"
-            self._write_line(line.encode("utf-8"))
+            self._persist_entry_with_store_seq(data)
 
     def read_trace(self, trace_id: str) -> List[Dict[str, Any]]:
         """Read all entries from a trace file."""
@@ -329,6 +612,8 @@ __all__ = [
     "assay_home",
     "generate_trace_id",
     "AssayStore",
+    "MigrationRequiredError",
+    "ReceiptStoreIntegrityError",
     "get_default_store",
     "emit_receipt",
 ]

--- a/src/assay/store_seq_migration.py
+++ b/src/assay/store_seq_migration.py
@@ -1,0 +1,293 @@
+"""Legacy-store migration: backfill ``_store_seq`` on pre-Slice-1 receipts.
+
+The Slice 1 commitment-fulfillment wedge treats ``_store_seq`` as the
+authoritative receipt-order primitive and fails closed on any receipt
+lacking it. That is the correct posture for new-format stores, but an
+unannounced upgrade for stores written before the primitive existed.
+
+This module provides an explicit migration. It does NOT run implicitly,
+and it does NOT silently reinterpret path order as causal order.
+
+Ordering basis
+--------------
+Legacy receipts have no witnessed global order, so migration must
+reconstruct one. The chosen basis is:
+
+    (sorted trace-file path, physical line number within file)
+
+Within a file this preserves append order exactly. Across files it uses
+lexicographic path order as a best-effort approximation. The migration
+records this basis explicitly so consumers can tell reconstructed order
+apart from witnessed order.
+
+Guarantees
+----------
+- Refuses to run if any receipt already carries a ``_store_seq`` (mixed
+  state is an operator decision, not a migration one).
+- Refuses to run on malformed JSON or unreadable files.
+- Atomic per-file rewrites via ``.tmp`` + ``rename``.
+- Updates ``<base_dir>/.store_seq`` so subsequent writes continue the
+  monotonic sequence.
+- Emits a summary dict that callers may log or persist as an audit trail.
+
+Invariant preserved
+-------------------
+Canonical payload hashes (``canonical_hash``, ``receipt_hash``) already
+exclude ``_store_seq`` from their input in every consumer updated by
+Slice 1, so adding the field does not invalidate existing signatures.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List
+
+from assay.commitment_fulfillment import ReceiptStoreIntegrityError
+from assay.store import AssayStore
+
+
+class StoreMigrationError(RuntimeError):
+    """Raised when migration cannot safely proceed.
+
+    Distinct from ``ReceiptStoreIntegrityError`` — this signals an
+    operator condition (mixed state, malformed data) rather than a
+    runtime invariant failure.
+    """
+
+
+@dataclass(frozen=True)
+class MigrationResult:
+    """Audit summary of a migration run."""
+
+    files_scanned: int
+    files_rewritten: int
+    receipts_backfilled: int
+    next_seq: int
+    ordering_basis: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "files_scanned": self.files_scanned,
+            "files_rewritten": self.files_rewritten,
+            "receipts_backfilled": self.receipts_backfilled,
+            "next_seq": self.next_seq,
+            "ordering_basis": self.ordering_basis,
+        }
+
+
+def migrate_legacy_store_seq(store: AssayStore) -> MigrationResult:
+    """Backfill ``_store_seq`` on legacy receipts in ``store``.
+
+    The store must be in a pre-migration state: either wholly free of
+    ``_store_seq`` (pure legacy) or wholly carrying it (already
+    migrated — no-op). Mixed state is refused explicitly.
+
+    After a successful run:
+        - Every receipt carries an integer ``_store_seq``.
+        - Within each file, ``_store_seq`` strictly increases in
+          physical line order.
+        - Across files, seqs assigned in lexicographic path order.
+        - ``<base_dir>/.store_seq`` is set to ``max(seq) + 1``.
+
+    Raises:
+        StoreMigrationError: Mixed legacy/migrated state, duplicate
+            pre-existing seqs, non-integer seqs, or malformed data.
+        ReceiptStoreIntegrityError: Relayed from lower-level readers.
+
+    Returns:
+        MigrationResult describing the run.
+    """
+    base = store.base_dir
+    if not base.exists():
+        return MigrationResult(
+            files_scanned=0,
+            files_rewritten=0,
+            receipts_backfilled=0,
+            next_seq=0,
+            ordering_basis="empty_store",
+        )
+
+    trace_files = sorted(base.rglob("trace_*.jsonl"))
+
+    # First pass: load everything, classify state.
+    loaded: List[tuple[Path, List[Dict[str, Any]]]] = []
+    existing_seqs: List[int] = []
+    total_entries = 0
+    entries_without_seq = 0
+
+    for trace_file in trace_files:
+        if not trace_file.is_file():
+            continue
+        try:
+            handle = open(trace_file)
+        except OSError as exc:
+            raise ReceiptStoreIntegrityError(
+                f"Cannot read trace file {trace_file}: {exc}"
+            ) from exc
+        entries: List[Dict[str, Any]] = []
+        with handle:
+            for line_number, line in enumerate(handle, start=1):
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    entry = json.loads(stripped)
+                except json.JSONDecodeError as exc:
+                    raise ReceiptStoreIntegrityError(
+                        f"Malformed JSON in {trace_file} line {line_number}: {exc}"
+                    ) from exc
+                total_entries += 1
+                seq = entry.get("_store_seq")
+                if seq is None:
+                    entries_without_seq += 1
+                elif isinstance(seq, int) and not isinstance(seq, bool):
+                    existing_seqs.append(seq)
+                else:
+                    raise StoreMigrationError(
+                        f"Non-integer _store_seq at {trace_file} line "
+                        f"{line_number}: {seq!r}. Refusing to migrate."
+                    )
+                entries.append(entry)
+        loaded.append((trace_file, entries))
+
+    if total_entries == 0:
+        return MigrationResult(
+            files_scanned=len(trace_files),
+            files_rewritten=0,
+            receipts_backfilled=0,
+            next_seq=0,
+            ordering_basis="empty_store",
+        )
+
+    # Reject mixed state.
+    if existing_seqs and entries_without_seq:
+        raise StoreMigrationError(
+            f"Mixed state: {entries_without_seq} receipts lack _store_seq "
+            f"and {len(existing_seqs)} receipts already carry one. "
+            "Refusing to migrate. Operator must decide how to repair."
+        )
+
+    # Reject duplicates in pre-existing seqs.
+    if len(existing_seqs) != len(set(existing_seqs)):
+        raise StoreMigrationError(
+            "Duplicate _store_seq values already present in store. "
+            "Refusing to migrate."
+        )
+
+    # Already fully migrated — no-op.
+    if entries_without_seq == 0:
+        next_seq = max(existing_seqs) + 1 if existing_seqs else 0
+        _persist_counter(store, next_seq)
+        return MigrationResult(
+            files_scanned=len(trace_files),
+            files_rewritten=0,
+            receipts_backfilled=0,
+            next_seq=next_seq,
+            ordering_basis="already_migrated",
+        )
+
+    # Pure legacy path: assign seqs in (file, line) order starting at 0.
+    next_seq = 0
+    files_rewritten = 0
+    receipts_backfilled = 0
+    for trace_file, entries in loaded:
+        file_changed = False
+        new_lines: List[str] = []
+        for entry in entries:
+            if "_store_seq" not in entry:
+                entry["_store_seq"] = next_seq
+                next_seq += 1
+                receipts_backfilled += 1
+                file_changed = True
+            new_lines.append(json.dumps(entry, default=str) + "\n")
+        if file_changed:
+            tmp_path = trace_file.with_suffix(trace_file.suffix + ".tmp")
+            tmp_path.write_text("".join(new_lines))
+            tmp_path.replace(trace_file)
+            files_rewritten += 1
+
+    _persist_counter(store, next_seq)
+
+    return MigrationResult(
+        files_scanned=len(trace_files),
+        files_rewritten=files_rewritten,
+        receipts_backfilled=receipts_backfilled,
+        next_seq=next_seq,
+        ordering_basis="path_then_line",
+    )
+
+
+def _persist_counter(store: AssayStore, next_seq: int) -> None:
+    """Write ``next_seq`` into ``<base_dir>/.store_seq`` atomically enough.
+
+    Uses ``.tmp`` + ``rename`` to avoid partial writes on crash. Does not
+    hold the cross-process seq lock because migration is expected to run
+    offline while no writers are active. Operators that cannot guarantee
+    that quiescence should serialize migration externally.
+    """
+    seq_file = store.base_dir / ".store_seq"
+    tmp_path = seq_file.with_suffix(seq_file.suffix + ".tmp")
+    tmp_path.write_text(str(next_seq))
+    tmp_path.replace(seq_file)
+
+
+__all__ = [
+    "MigrationResult",
+    "StoreMigrationError",
+    "migrate_legacy_store_seq",
+]
+
+
+def _cli_main(argv: List[str]) -> int:
+    """Operator CLI: migrate an AssayStore at the given base_dir.
+
+    Usage::
+
+        python -m assay.store_seq_migration <base_dir>
+
+    Exit codes:
+        0 — migration ran successfully (including already-migrated no-op).
+        2 — usage error (wrong number of arguments).
+        3 — StoreMigrationError (mixed state, duplicate seqs, etc.).
+        4 — ReceiptStoreIntegrityError (corruption during scan).
+        1 — any other unexpected error.
+    """
+    import sys
+
+    if len(argv) != 1:
+        sys.stderr.write(
+            "usage: python -m assay.store_seq_migration <base_dir>\n"
+        )
+        return 2
+
+    base_dir = Path(argv[0])
+    store = AssayStore(base_dir=base_dir)
+
+    try:
+        result = migrate_legacy_store_seq(store)
+    except StoreMigrationError as exc:
+        sys.stderr.write(f"migration refused: {exc}\n")
+        return 3
+    except ReceiptStoreIntegrityError as exc:
+        sys.stderr.write(f"integrity failure during migration: {exc}\n")
+        return 4
+    except Exception as exc:  # pragma: no cover - defensive
+        sys.stderr.write(f"unexpected migration error: {exc}\n")
+        return 1
+
+    sys.stdout.write(
+        "migration ok: "
+        f"files_scanned={result.files_scanned} "
+        f"files_rewritten={result.files_rewritten} "
+        f"receipts_backfilled={result.receipts_backfilled} "
+        f"next_seq={result.next_seq} "
+        f"ordering_basis={result.ordering_basis}\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via subprocess in tests
+    import sys
+
+    sys.exit(_cli_main(sys.argv[1:]))

--- a/tests/assay/test_commitment_lifecycle.py
+++ b/tests/assay/test_commitment_lifecycle.py
@@ -1,0 +1,2042 @@
+"""Commitment-Fulfillment Wedge — Slice 1.
+
+Doctrine source: loom-staging docs/architecture/authority_nouns.md (commit 9c5921d5, frozen).
+
+Scope: commitments only. Obligations (forward-looking inherited duty) are
+deferred to Slice 2 pending adjudication of the pre-existing
+src/assay/obligation.py namespace (which holds override-debt semantics,
+not inherited-duty semantics).
+
+Proves:
+    1. Event-type strings match doctrine exactly (anti-drift canary).
+    2. PolicyResolver resolves file:// refs, checks policy_hash match,
+       and raises NotImplementedError for kind="registry".
+    3. commitment.registered requires a resolvable policy_hash.
+    4. result.observed carries non-adjudicating references only.
+    5. fulfillment.commitment_kept | commitment_broken close a commitment.
+    6. A commitment has zero or one terminal fulfillment (uniqueness).
+    7. DOCTOR_COMMITMENT_001 detects overdue open commitments.
+    8. Detector is pure-read.
+
+This file mirrors tests/assay/test_contradiction_detector.py structurally.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from assay.commitment_closure_detector import (
+    CommitmentClosureResult,
+    OpenOverdueCommitment,
+    check_commitment_health,
+    detect_open_overdue_commitments,
+)
+from assay.commitment_fulfillment import (
+    COMMITMENT_REGISTRATION_RECEIPT_TYPE,
+    FULFILLMENT_COMMITMENT_BROKEN_RECEIPT_TYPE,
+    FULFILLMENT_COMMITMENT_KEPT_RECEIPT_TYPE,
+    RESULT_OBSERVATION_RECEIPT_TYPE,
+    CommitmentRegistrationArtifact,
+    FulfillmentBrokenArtifact,
+    FulfillmentKeptArtifact,
+    ReceiptStoreIntegrityError,
+    ResultObservationArtifact,
+    TerminalFulfillmentError,
+    UnanchoredFulfillmentError,
+    emit_commitment_registration,
+    emit_fulfillment_broken,
+    emit_fulfillment_kept,
+    emit_result_observation,
+)
+from assay.episode import open_episode
+from assay.policy_resolver import (
+    PolicyResolutionError,
+    PolicyResolver,
+    resolve_policy,
+)
+from assay.store import AssayStore
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_store(tmp_path):
+    """Isolated per-test AssayStore."""
+    return AssayStore(base_dir=tmp_path / "assay_store")
+
+
+@pytest.fixture
+def compile_receipt(tmp_path) -> tuple[Path, str]:
+    """Write a minimal COMPILE_RECEIPT.json fixture and return (path, policy_hash)."""
+    policy_body = b"base-profile-v0\n"
+    policy_hash = "sha256:" + hashlib.sha256(policy_body).hexdigest()
+    receipt = {
+        "compile_receipt_version": "0.1",
+        "policy_hash": policy_hash,
+        "compiled_at": "2026-04-20T12:00:00Z",
+        "profile": "base",
+        "sources": {
+            "law_md_hash": "sha256:" + "a" * 64,
+            "profile_toml_hash": "sha256:" + "b" * 64,
+        },
+        "generator_version": "0.2.0",
+    }
+    path = tmp_path / "COMPILE_RECEIPT.json"
+    path.write_text(json.dumps(receipt))
+    return path, policy_hash
+
+
+def _ref(path: Path) -> str:
+    return f"file://{path}"
+
+
+# ---------------------------------------------------------------------------
+# Helpers: direct writes (detector tests)
+# ---------------------------------------------------------------------------
+
+
+def _write_registered(
+    store,
+    commitment_id,
+    *,
+    episode_id="ep_test",
+    due_at=None,
+    timestamp="2026-01-01T00:00:00.000Z",
+):
+    data = {
+        "type": COMMITMENT_REGISTRATION_RECEIPT_TYPE,
+        "commitment_id": commitment_id,
+        "episode_id": episode_id,
+        "actor_id": "actor_test",
+        "text": "Ship the widget by Friday.",
+        "commitment_type": "delivery",
+        "policy_hash": "sha256:" + "c" * 64,
+        "timestamp": timestamp,
+    }
+    if due_at is not None:
+        data["due_at"] = due_at
+    store.append_dict(data)
+
+
+def _write_kept(store, commitment_id, result_id, *, episode_id="ep_test"):
+    store.append_dict({
+        "type": FULFILLMENT_COMMITMENT_KEPT_RECEIPT_TYPE,
+        "fulfillment_id": f"ful_{commitment_id}_kept",
+        "episode_id": episode_id,
+        "commitment_id": commitment_id,
+        "result_id": result_id,
+        "evaluator": "test",
+        "evaluator_version": "0.1",
+        "policy_hash": "sha256:" + "c" * 64,
+        "timestamp": "2026-01-02T00:00:00.000Z",
+    })
+
+
+def _write_broken(store, commitment_id, result_id, *, episode_id="ep_test", reason="missed_deadline"):
+    store.append_dict({
+        "type": FULFILLMENT_COMMITMENT_BROKEN_RECEIPT_TYPE,
+        "fulfillment_id": f"ful_{commitment_id}_broken",
+        "episode_id": episode_id,
+        "commitment_id": commitment_id,
+        "result_id": result_id,
+        "evaluator": "test",
+        "evaluator_version": "0.1",
+        "policy_hash": "sha256:" + "c" * 64,
+        "violation_reason": reason,
+        "timestamp": "2026-01-02T00:00:00.000Z",
+    })
+
+
+def _write_result(store, result_id, *, episode_id="ep_test", references=None):
+    store.append_dict({
+        "type": RESULT_OBSERVATION_RECEIPT_TYPE,
+        "result_id": result_id,
+        "episode_id": episode_id,
+        "text": "Widget shipped.",
+        "evidence_uri": "file:///tmp/widget.log",
+        "policy_hash": "sha256:" + "c" * 64,
+        "references": references or [],
+        "timestamp": "2026-01-01T12:00:00.000Z",
+    })
+
+
+# ---------------------------------------------------------------------------
+# 1. Anti-drift canary — serialized event type strings match doctrine
+# ---------------------------------------------------------------------------
+
+
+class TestEventTypeStrings:
+    """Serialized receipt_type strings must match doctrine exactly.
+
+    Python class names may be ergonomic; doctrine wire strings may not drift.
+    """
+
+    def test_commitment_registration_type_literal(self):
+        assert COMMITMENT_REGISTRATION_RECEIPT_TYPE == "commitment.registered"
+
+    def test_result_observation_type_literal(self):
+        assert RESULT_OBSERVATION_RECEIPT_TYPE == "result.observed"
+
+    def test_fulfillment_kept_type_literal(self):
+        assert FULFILLMENT_COMMITMENT_KEPT_RECEIPT_TYPE == "fulfillment.commitment_kept"
+
+    def test_fulfillment_broken_type_literal(self):
+        assert FULFILLMENT_COMMITMENT_BROKEN_RECEIPT_TYPE == "fulfillment.commitment_broken"
+
+
+# ---------------------------------------------------------------------------
+# 2. PolicyResolver
+# ---------------------------------------------------------------------------
+
+
+class TestPolicyResolver:
+    """Minimal reusable resolver for COMPILE_RECEIPT.json."""
+
+    def test_uri_kind_resolves_matching_hash(self, compile_receipt):
+        path, policy_hash = compile_receipt
+        resolver = PolicyResolver(kind="uri", ref=_ref(path), policy_hash=policy_hash)
+        resolved = resolve_policy(resolver)
+        assert resolved["policy_hash"] == policy_hash
+        assert resolved["compile_receipt_version"] == "0.1"
+
+    def test_uri_kind_rejects_hash_mismatch(self, compile_receipt):
+        path, _policy_hash = compile_receipt
+        resolver = PolicyResolver(
+            kind="uri",
+            ref=_ref(path),
+            policy_hash="sha256:" + "f" * 64,
+        )
+        with pytest.raises(PolicyResolutionError):
+            resolve_policy(resolver)
+
+    def test_uri_kind_missing_file_raises(self, tmp_path):
+        resolver = PolicyResolver(
+            kind="uri",
+            ref=f"file://{tmp_path / 'missing.json'}",
+            policy_hash="sha256:" + "0" * 64,
+        )
+        with pytest.raises(PolicyResolutionError):
+            resolve_policy(resolver)
+
+    def test_registry_kind_raises_not_implemented(self):
+        resolver = PolicyResolver(
+            kind="registry",
+            ref="policy://base/v0.1",
+            policy_hash="sha256:" + "0" * 64,
+        )
+        with pytest.raises(NotImplementedError):
+            resolve_policy(resolver)
+
+
+# ---------------------------------------------------------------------------
+# 3. commitment.registered — requires resolvable policy_hash
+# ---------------------------------------------------------------------------
+
+
+def _build_commitment(
+    policy_hash: str,
+    resolver_dict: dict,
+    *,
+    commitment_id: str = "cmt_001",
+    due_at: str | None = None,
+) -> CommitmentRegistrationArtifact:
+    return CommitmentRegistrationArtifact(
+        commitment_id=commitment_id,
+        timestamp="2026-04-20T12:00:00.000Z",
+        episode_id="ep_test",
+        actor_id="actor_alice",
+        text="Ship the widget by Friday.",
+        commitment_type="delivery",
+        policy_hash=policy_hash,
+        policy_resolver=resolver_dict,
+        due_at=due_at,
+    )
+
+
+class TestCommitmentRegistrationGuards:
+    """Registration requires a resolver whose COMPILE_RECEIPT matches policy_hash."""
+
+    def test_register_with_matching_resolver_succeeds(self, tmp_store, compile_receipt):
+        path, policy_hash = compile_receipt
+        resolver = PolicyResolver(kind="uri", ref=_ref(path), policy_hash=policy_hash)
+
+        with open_episode(store=tmp_store) as ep:
+            artifact = _build_commitment(policy_hash, resolver.to_dict())
+            returned = emit_commitment_registration(ep, artifact)
+
+        assert returned.commitment_id == "cmt_001"
+        entries = tmp_store.read_trace(tmp_store.trace_id)
+        types = [e.get("type") for e in entries]
+        assert COMMITMENT_REGISTRATION_RECEIPT_TYPE in types
+
+    def test_register_with_hash_mismatch_raises(self, tmp_store, compile_receipt):
+        path, policy_hash = compile_receipt
+        bad_hash = "sha256:" + "f" * 64
+        resolver = PolicyResolver(kind="uri", ref=_ref(path), policy_hash=bad_hash)
+
+        with open_episode(store=tmp_store) as ep:
+            artifact = _build_commitment(bad_hash, resolver.to_dict())
+            with pytest.raises(PolicyResolutionError):
+                emit_commitment_registration(ep, artifact)
+
+    def test_register_missing_compile_receipt_raises(self, tmp_store, tmp_path):
+        bad_hash = "sha256:" + "0" * 64
+        resolver = PolicyResolver(
+            kind="uri",
+            ref=f"file://{tmp_path / 'nope.json'}",
+            policy_hash=bad_hash,
+        )
+        with open_episode(store=tmp_store) as ep:
+            artifact = _build_commitment(bad_hash, resolver.to_dict())
+            with pytest.raises(PolicyResolutionError):
+                emit_commitment_registration(ep, artifact)
+
+    def test_artifact_policy_hash_must_equal_resolver_policy_hash(
+        self, tmp_store, compile_receipt
+    ):
+        path, policy_hash = compile_receipt
+        resolver = PolicyResolver(kind="uri", ref=_ref(path), policy_hash=policy_hash)
+
+        with open_episode(store=tmp_store) as ep:
+            artifact = _build_commitment(
+                policy_hash="sha256:" + "9" * 64,
+                resolver_dict=resolver.to_dict(),
+            )
+            with pytest.raises(PolicyResolutionError):
+                emit_commitment_registration(ep, artifact)
+
+
+# ---------------------------------------------------------------------------
+# 4. result.observed — non-adjudicating
+# ---------------------------------------------------------------------------
+
+
+class TestResultObservation:
+    """result.observed carries references only; it never closes a commitment."""
+
+    def test_result_artifact_has_no_fulfills_field(self):
+        artifact = ResultObservationArtifact(
+            result_id="res_001",
+            timestamp="2026-01-01T12:00:00.000Z",
+            episode_id="ep_test",
+            text="Widget shipped.",
+            evidence_uri="file:///tmp/widget.log",
+            policy_hash="sha256:" + "c" * 64,
+            policy_resolver={"kind": "uri", "ref": "file:///tmp/r.json",
+                             "policy_hash": "sha256:" + "c" * 64},
+            references=[{"kind": "commitment", "id": "cmt_001"}],
+        )
+        d = artifact.to_dict()
+        assert "fulfills" not in d
+        assert "closes" not in d
+        assert d["references"] == [{"kind": "commitment", "id": "cmt_001"}]
+
+    def test_result_observed_does_not_close_commitment(self, tmp_store):
+        """Emitting result.observed referencing a commitment leaves it OPEN."""
+        tmp_store.start_trace()
+        _write_registered(
+            tmp_store, "cmt_open", due_at="2020-01-01T00:00:00Z"
+        )
+        _write_result(
+            tmp_store,
+            "res_001",
+            references=[{"kind": "commitment", "id": "cmt_open"}],
+        )
+
+        result = detect_open_overdue_commitments(tmp_store)
+        ids = {c.commitment_id for c in result.open_commitments}
+        assert "cmt_open" in ids
+
+
+# ---------------------------------------------------------------------------
+# 5. fulfillment.commitment_kept | commitment_broken — terminal closure
+# ---------------------------------------------------------------------------
+
+
+class TestTerminalClosure:
+    """A terminal fulfillment closes exactly the named commitment."""
+
+    def test_kept_closes_exactly_one_commitment(self, tmp_store):
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_A", due_at="2020-01-01T00:00:00Z")
+        _write_registered(tmp_store, "cmt_B", due_at="2020-01-01T00:00:00Z")
+        _write_result(tmp_store, "res_1",
+                      references=[{"kind": "commitment", "id": "cmt_A"}])
+        _write_kept(tmp_store, "cmt_A", "res_1")
+
+        result = detect_open_overdue_commitments(tmp_store)
+        open_ids = {c.commitment_id for c in result.open_commitments}
+        assert "cmt_A" not in open_ids
+        assert "cmt_B" in open_ids
+
+    def test_broken_closes_exactly_one_commitment(self, tmp_store):
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_A", due_at="2020-01-01T00:00:00Z")
+        _write_registered(tmp_store, "cmt_B", due_at="2020-01-01T00:00:00Z")
+        _write_result(tmp_store, "res_1",
+                      references=[{"kind": "commitment", "id": "cmt_A"}])
+        _write_broken(tmp_store, "cmt_A", "res_1", reason="missed_deadline")
+
+        result = detect_open_overdue_commitments(tmp_store)
+        open_ids = {c.commitment_id for c in result.open_commitments}
+        assert "cmt_A" not in open_ids
+        assert "cmt_B" in open_ids
+
+
+# ---------------------------------------------------------------------------
+# 6. Terminal uniqueness — no competing terminals per commitment
+# ---------------------------------------------------------------------------
+
+
+def _register_and_observe(ep, tmp_store, compile_receipt_tuple, commitment_id):
+    """Register a commitment and observe one result referencing it."""
+    path, policy_hash = compile_receipt_tuple
+    resolver = PolicyResolver(kind="uri", ref=_ref(path), policy_hash=policy_hash)
+    cmt = _build_commitment(policy_hash, resolver.to_dict(), commitment_id=commitment_id)
+    emit_commitment_registration(ep, cmt)
+
+    result = ResultObservationArtifact(
+        result_id=f"res_{commitment_id}",
+        timestamp="2026-04-20T13:00:00.000Z",
+        episode_id=ep.episode_id,
+        text="Outcome observed.",
+        evidence_uri="file:///tmp/ev.log",
+        policy_hash=policy_hash,
+        policy_resolver=resolver.to_dict(),
+        references=[{"kind": "commitment", "id": commitment_id}],
+    )
+    emit_result_observation(ep, result)
+    return resolver, policy_hash, f"res_{commitment_id}"
+
+
+def _kept_artifact(ep_id, commitment_id, result_id, policy_hash, resolver_dict):
+    return FulfillmentKeptArtifact(
+        fulfillment_id=f"ful_{commitment_id}_k1",
+        timestamp="2026-04-20T14:00:00.000Z",
+        episode_id=ep_id,
+        commitment_id=commitment_id,
+        result_id=result_id,
+        evaluator="test",
+        evaluator_version="0.1",
+        policy_hash=policy_hash,
+        policy_resolver=resolver_dict,
+    )
+
+
+def _broken_artifact(ep_id, commitment_id, result_id, policy_hash, resolver_dict):
+    return FulfillmentBrokenArtifact(
+        fulfillment_id=f"ful_{commitment_id}_b1",
+        timestamp="2026-04-20T14:00:00.000Z",
+        episode_id=ep_id,
+        commitment_id=commitment_id,
+        result_id=result_id,
+        evaluator="test",
+        evaluator_version="0.1",
+        policy_hash=policy_hash,
+        policy_resolver=resolver_dict,
+        violation_reason="missed_deadline",
+    )
+
+
+class TestTerminalUniqueness:
+    """A commitment has zero or one terminal fulfillment."""
+
+    def test_duplicate_kept_raises(self, tmp_store, compile_receipt):
+        with open_episode(store=tmp_store) as ep:
+            resolver, ph, rid = _register_and_observe(ep, tmp_store, compile_receipt, "cmt_u1")
+            kept = _kept_artifact(ep.episode_id, "cmt_u1", rid, ph, resolver.to_dict())
+            emit_fulfillment_kept(ep, kept)
+
+            kept2 = _kept_artifact(ep.episode_id, "cmt_u1", rid, ph, resolver.to_dict())
+            kept2.fulfillment_id = "ful_cmt_u1_k2"
+            with pytest.raises(TerminalFulfillmentError):
+                emit_fulfillment_kept(ep, kept2)
+
+    def test_kept_then_broken_raises(self, tmp_store, compile_receipt):
+        with open_episode(store=tmp_store) as ep:
+            resolver, ph, rid = _register_and_observe(ep, tmp_store, compile_receipt, "cmt_u2")
+            kept = _kept_artifact(ep.episode_id, "cmt_u2", rid, ph, resolver.to_dict())
+            emit_fulfillment_kept(ep, kept)
+
+            broken = _broken_artifact(ep.episode_id, "cmt_u2", rid, ph, resolver.to_dict())
+            with pytest.raises(TerminalFulfillmentError):
+                emit_fulfillment_broken(ep, broken)
+
+    def test_broken_then_kept_raises(self, tmp_store, compile_receipt):
+        with open_episode(store=tmp_store) as ep:
+            resolver, ph, rid = _register_and_observe(ep, tmp_store, compile_receipt, "cmt_u3")
+            broken = _broken_artifact(ep.episode_id, "cmt_u3", rid, ph, resolver.to_dict())
+            emit_fulfillment_broken(ep, broken)
+
+            kept = _kept_artifact(ep.episode_id, "cmt_u3", rid, ph, resolver.to_dict())
+            with pytest.raises(TerminalFulfillmentError):
+                emit_fulfillment_kept(ep, kept)
+
+
+# ---------------------------------------------------------------------------
+# 7. Detector — DOCTOR_COMMITMENT_001 semantics
+# ---------------------------------------------------------------------------
+
+
+class TestDetector:
+    """detect_open_overdue_commitments flags overdue open commitments."""
+
+    def test_overdue_unfulfilled_is_open(self, tmp_store):
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_late", due_at="2020-01-01T00:00:00Z")
+        result = detect_open_overdue_commitments(tmp_store)
+        assert not result.clean
+        assert result.total_open_found == 1
+        assert result.open_commitments[0].commitment_id == "cmt_late"
+
+    def test_not_yet_due_is_clean(self, tmp_store):
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_future", due_at="2099-01-01T00:00:00Z")
+        result = detect_open_overdue_commitments(tmp_store)
+        assert result.clean
+        assert result.total_open_found == 0
+
+    def test_no_due_at_is_perpetual_clean(self, tmp_store):
+        """Slice 1 conservative: no due_at → never overdue."""
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_perpetual", due_at=None)
+        result = detect_open_overdue_commitments(tmp_store)
+        assert result.clean
+
+    def test_kept_closes_overdue(self, tmp_store):
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_done", due_at="2020-01-01T00:00:00Z")
+        _write_result(tmp_store, "res_x",
+                      references=[{"kind": "commitment", "id": "cmt_done"}])
+        _write_kept(tmp_store, "cmt_done", "res_x")
+        result = detect_open_overdue_commitments(tmp_store)
+        assert result.clean
+
+    def test_broken_closes_overdue(self, tmp_store):
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_failed", due_at="2020-01-01T00:00:00Z")
+        _write_result(tmp_store, "res_x",
+                      references=[{"kind": "commitment", "id": "cmt_failed"}])
+        _write_broken(tmp_store, "cmt_failed", "res_x")
+        result = detect_open_overdue_commitments(tmp_store)
+        assert result.clean
+
+    def test_empty_store_is_clean(self, tmp_store):
+        result = detect_open_overdue_commitments(tmp_store)
+        assert result.clean
+        assert result.total_registered_found == 0
+
+    def test_detector_is_pure_read(self, tmp_store):
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_read", due_at="2020-01-01T00:00:00Z")
+        before = tmp_store.read_trace(tmp_store.trace_id)
+        detect_open_overdue_commitments(tmp_store)
+        after = tmp_store.read_trace(tmp_store.trace_id)
+        assert len(before) == len(after)
+
+    def test_result_has_scanned_at(self, tmp_store):
+        result = detect_open_overdue_commitments(tmp_store)
+        assert result.scanned_at != ""
+
+    def test_to_dict_round_trip(self, tmp_store):
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_dict", due_at="2020-01-01T00:00:00Z")
+        d = detect_open_overdue_commitments(tmp_store).to_dict()
+        assert d["clean"] is False
+        assert d["total_open_found"] == 1
+        assert d["open_commitments"][0]["commitment_id"] == "cmt_dict"
+
+
+# ---------------------------------------------------------------------------
+# 8. Health check
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCommitmentHealth:
+    def test_health_true_when_clean(self, tmp_store):
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_ok", due_at="2099-01-01T00:00:00Z")
+        assert check_commitment_health(tmp_store, loud=False) is True
+
+    def test_health_false_when_overdue(self, tmp_store):
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_late", due_at="2020-01-01T00:00:00Z")
+        assert check_commitment_health(tmp_store, loud=False) is False
+
+    def test_health_empty_store_is_clean(self, tmp_store):
+        assert check_commitment_health(tmp_store, loud=False) is True
+
+
+# ---------------------------------------------------------------------------
+# 9. Doctor integration
+# ---------------------------------------------------------------------------
+
+
+class TestDoctorIntegration:
+    def test_commitment_check_runs_with_check_orphans(self, tmp_store):
+        from assay.doctor import CheckStatus, Profile, run_doctor
+
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_doc", due_at="2020-01-01T00:00:00Z")
+        report = run_doctor(Profile.LOCAL, store=tmp_store, check_orphans=True)
+
+        ids = [c.id for c in report.checks]
+        assert "DOCTOR_COMMITMENT_001" in ids
+
+        cmt_result = next(c for c in report.checks if c.id == "DOCTOR_COMMITMENT_001")
+        assert cmt_result.status == CheckStatus.FAIL
+        assert "1 overdue commitment" in cmt_result.message
+
+    def test_commitment_check_passes_when_clean(self, tmp_store):
+        from assay.doctor import CheckStatus, Profile, run_doctor
+
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_clean", due_at="2020-01-01T00:00:00Z")
+        _write_result(tmp_store, "res_ok",
+                      references=[{"kind": "commitment", "id": "cmt_clean"}])
+        _write_kept(tmp_store, "cmt_clean", "res_ok")
+
+        report = run_doctor(Profile.LOCAL, store=tmp_store, check_orphans=True)
+        cmt_result = next(c for c in report.checks if c.id == "DOCTOR_COMMITMENT_001")
+        assert cmt_result.status == CheckStatus.PASS
+
+    def test_commitment_check_not_in_default_run(self, tmp_store):
+        from assay.doctor import Profile, run_doctor
+
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_default", due_at="2020-01-01T00:00:00Z")
+        report = run_doctor(Profile.LOCAL, store=tmp_store, check_orphans=False)
+        ids = [c.id for c in report.checks]
+        assert "DOCTOR_COMMITMENT_001" not in ids
+
+
+# ---------------------------------------------------------------------------
+# 10. OpenOverdueCommitment forensic fields
+# ---------------------------------------------------------------------------
+
+
+class TestForensicFields:
+    def test_open_overdue_has_forensic_fields(self, tmp_store):
+        tmp_store.start_trace()
+        _write_registered(
+            tmp_store,
+            "cmt_forensic",
+            episode_id="ep_forensic",
+            due_at="2020-01-01T00:00:00Z",
+        )
+        result = detect_open_overdue_commitments(tmp_store)
+        c = result.open_commitments[0]
+        assert c.commitment_id == "cmt_forensic"
+        assert c.episode_id == "ep_forensic"
+        assert c.due_at == "2020-01-01T00:00:00Z"
+        assert c.registered_at != ""
+        assert c.trace_id != ""
+
+
+# ---------------------------------------------------------------------------
+# 11. Repair — policy binding enforced on result + fulfillment
+# ---------------------------------------------------------------------------
+
+
+class TestPolicyBindingOnNonRegistrationEmits:
+    """result.observed and fulfillment.commitment_* must clear the same
+    policy-binding bar as commitment.registered.
+    """
+
+    def test_result_observation_rejects_mismatched_hash(self, tmp_store, compile_receipt):
+        path, policy_hash = compile_receipt
+        # Resolver binds to the real hash; artifact declares a different one.
+        resolver_dict = {
+            "kind": "uri",
+            "ref": _ref(path),
+            "policy_hash": policy_hash,
+        }
+        bad_artifact_hash = "sha256:" + "9" * 64
+        artifact = ResultObservationArtifact(
+            result_id="res_bad_binding",
+            timestamp="2026-04-20T12:00:00.000Z",
+            episode_id="ep_bad",
+            text="bad.",
+            evidence_uri="file:///tmp/bad.log",
+            policy_hash=bad_artifact_hash,
+            policy_resolver=resolver_dict,
+            references=[],
+        )
+        with open_episode(store=tmp_store) as ep:
+            with pytest.raises(PolicyResolutionError):
+                emit_result_observation(ep, artifact)
+
+    def test_result_observation_rejects_missing_compile_receipt(
+        self, tmp_store, tmp_path
+    ):
+        bad_hash = "sha256:" + "0" * 64
+        resolver_dict = {
+            "kind": "uri",
+            "ref": f"file://{tmp_path / 'nope.json'}",
+            "policy_hash": bad_hash,
+        }
+        artifact = ResultObservationArtifact(
+            result_id="res_no_file",
+            timestamp="2026-04-20T12:00:00.000Z",
+            episode_id="ep_nope",
+            text="x",
+            evidence_uri="file:///tmp/x.log",
+            policy_hash=bad_hash,
+            policy_resolver=resolver_dict,
+            references=[],
+        )
+        with open_episode(store=tmp_store) as ep:
+            with pytest.raises(PolicyResolutionError):
+                emit_result_observation(ep, artifact)
+
+    def _prep(self, tmp_store, compile_receipt, commitment_id):
+        """Register and observe for a fulfillment policy-binding test."""
+        path, policy_hash = compile_receipt
+        resolver = PolicyResolver(kind="uri", ref=_ref(path), policy_hash=policy_hash)
+        ep = open_episode(store=tmp_store)
+        cmt = _build_commitment(policy_hash, resolver.to_dict(),
+                                commitment_id=commitment_id)
+        emit_commitment_registration(ep, cmt)
+        result = ResultObservationArtifact(
+            result_id=f"res_{commitment_id}",
+            timestamp="2026-04-20T13:00:00.000Z",
+            episode_id=ep.episode_id,
+            text="observation.",
+            evidence_uri="file:///tmp/e.log",
+            policy_hash=policy_hash,
+            policy_resolver=resolver.to_dict(),
+            references=[{"kind": "commitment", "id": commitment_id}],
+        )
+        emit_result_observation(ep, result)
+        return ep, resolver, policy_hash, result.result_id
+
+    def test_fulfillment_kept_rejects_mismatched_hash(self, tmp_store, compile_receipt):
+        ep, resolver, policy_hash, rid = self._prep(
+            tmp_store, compile_receipt, "cmt_kept_bad"
+        )
+        try:
+            bad_hash = "sha256:" + "9" * 64
+            kept = FulfillmentKeptArtifact(
+                fulfillment_id="ful_bad",
+                timestamp="2026-04-20T14:00:00.000Z",
+                episode_id=ep.episode_id,
+                commitment_id="cmt_kept_bad",
+                result_id=rid,
+                evaluator="test",
+                evaluator_version="0.1",
+                policy_hash=bad_hash,
+                policy_resolver=resolver.to_dict(),  # mismatches bad_hash
+            )
+            with pytest.raises(PolicyResolutionError):
+                emit_fulfillment_kept(ep, kept)
+        finally:
+            ep.close()
+
+    def test_fulfillment_broken_rejects_mismatched_hash(self, tmp_store, compile_receipt):
+        ep, resolver, policy_hash, rid = self._prep(
+            tmp_store, compile_receipt, "cmt_broken_bad"
+        )
+        try:
+            bad_hash = "sha256:" + "9" * 64
+            broken = FulfillmentBrokenArtifact(
+                fulfillment_id="ful_bad_b",
+                timestamp="2026-04-20T14:00:00.000Z",
+                episode_id=ep.episode_id,
+                commitment_id="cmt_broken_bad",
+                result_id=rid,
+                evaluator="test",
+                evaluator_version="0.1",
+                policy_hash=bad_hash,
+                policy_resolver=resolver.to_dict(),
+                violation_reason="x",
+            )
+            with pytest.raises(PolicyResolutionError):
+                emit_fulfillment_broken(ep, broken)
+        finally:
+            ep.close()
+
+
+# ---------------------------------------------------------------------------
+# 12. Repair — fulfillment existence anchors
+# ---------------------------------------------------------------------------
+
+
+class TestFulfillmentExistenceAnchors:
+    """fulfillment.commitment_* must anchor to real commitment + result receipts."""
+
+    def test_kept_rejects_missing_commitment(self, tmp_store, compile_receipt):
+        path, policy_hash = compile_receipt
+        resolver = PolicyResolver(kind="uri", ref=_ref(path), policy_hash=policy_hash)
+        with open_episode(store=tmp_store) as ep:
+            # Observe a result but never register the commitment.
+            result = ResultObservationArtifact(
+                result_id="res_orphan",
+                timestamp="2026-04-20T13:00:00.000Z",
+                episode_id=ep.episode_id,
+                text="x",
+                evidence_uri="file:///tmp/x.log",
+                policy_hash=policy_hash,
+                policy_resolver=resolver.to_dict(),
+                references=[],
+            )
+            emit_result_observation(ep, result)
+            kept = FulfillmentKeptArtifact(
+                fulfillment_id="ful_no_cmt",
+                timestamp="2026-04-20T14:00:00.000Z",
+                episode_id=ep.episode_id,
+                commitment_id="cmt_does_not_exist",
+                result_id="res_orphan",
+                evaluator="test",
+                evaluator_version="0.1",
+                policy_hash=policy_hash,
+                policy_resolver=resolver.to_dict(),
+            )
+            with pytest.raises(UnanchoredFulfillmentError):
+                emit_fulfillment_kept(ep, kept)
+
+    def test_kept_rejects_missing_result(self, tmp_store, compile_receipt):
+        path, policy_hash = compile_receipt
+        resolver = PolicyResolver(kind="uri", ref=_ref(path), policy_hash=policy_hash)
+        with open_episode(store=tmp_store) as ep:
+            cmt = _build_commitment(policy_hash, resolver.to_dict(),
+                                    commitment_id="cmt_no_res")
+            emit_commitment_registration(ep, cmt)
+            kept = FulfillmentKeptArtifact(
+                fulfillment_id="ful_no_res",
+                timestamp="2026-04-20T14:00:00.000Z",
+                episode_id=ep.episode_id,
+                commitment_id="cmt_no_res",
+                result_id="res_does_not_exist",
+                evaluator="test",
+                evaluator_version="0.1",
+                policy_hash=policy_hash,
+                policy_resolver=resolver.to_dict(),
+            )
+            with pytest.raises(UnanchoredFulfillmentError):
+                emit_fulfillment_kept(ep, kept)
+
+    def test_broken_rejects_missing_commitment(self, tmp_store, compile_receipt):
+        path, policy_hash = compile_receipt
+        resolver = PolicyResolver(kind="uri", ref=_ref(path), policy_hash=policy_hash)
+        with open_episode(store=tmp_store) as ep:
+            result = ResultObservationArtifact(
+                result_id="res_orphan_b",
+                timestamp="2026-04-20T13:00:00.000Z",
+                episode_id=ep.episode_id,
+                text="x",
+                evidence_uri="file:///tmp/x.log",
+                policy_hash=policy_hash,
+                policy_resolver=resolver.to_dict(),
+                references=[],
+            )
+            emit_result_observation(ep, result)
+            broken = FulfillmentBrokenArtifact(
+                fulfillment_id="ful_b_no_cmt",
+                timestamp="2026-04-20T14:00:00.000Z",
+                episode_id=ep.episode_id,
+                commitment_id="cmt_ghost",
+                result_id="res_orphan_b",
+                evaluator="test",
+                evaluator_version="0.1",
+                policy_hash=policy_hash,
+                policy_resolver=resolver.to_dict(),
+                violation_reason="x",
+            )
+            with pytest.raises(UnanchoredFulfillmentError):
+                emit_fulfillment_broken(ep, broken)
+
+    def test_broken_rejects_missing_result(self, tmp_store, compile_receipt):
+        path, policy_hash = compile_receipt
+        resolver = PolicyResolver(kind="uri", ref=_ref(path), policy_hash=policy_hash)
+        with open_episode(store=tmp_store) as ep:
+            cmt = _build_commitment(policy_hash, resolver.to_dict(),
+                                    commitment_id="cmt_b_no_res")
+            emit_commitment_registration(ep, cmt)
+            broken = FulfillmentBrokenArtifact(
+                fulfillment_id="ful_b_no_res",
+                timestamp="2026-04-20T14:00:00.000Z",
+                episode_id=ep.episode_id,
+                commitment_id="cmt_b_no_res",
+                result_id="res_ghost",
+                evaluator="test",
+                evaluator_version="0.1",
+                policy_hash=policy_hash,
+                policy_resolver=resolver.to_dict(),
+                violation_reason="x",
+            )
+            with pytest.raises(UnanchoredFulfillmentError):
+                emit_fulfillment_broken(ep, broken)
+
+    def test_existence_check_is_type_aware(self, tmp_store, compile_receipt):
+        """A receipt with matching id but wrong receipt_type does not count."""
+        path, policy_hash = compile_receipt
+        resolver = PolicyResolver(kind="uri", ref=_ref(path), policy_hash=policy_hash)
+        tmp_store.start_trace()
+        # Write a receipt that has result_id="res_fake" but wrong type.
+        tmp_store.append_dict({
+            "type": "model.invoked",  # NOT result.observed
+            "result_id": "res_fake",
+            "episode_id": "ep_spoof",
+            "timestamp": "2026-01-01T00:00:00Z",
+        })
+        # Register a real commitment so that anchor ≠ commitment failure.
+        with open_episode(store=tmp_store) as ep:
+            cmt = _build_commitment(policy_hash, resolver.to_dict(),
+                                    commitment_id="cmt_type_aware")
+            emit_commitment_registration(ep, cmt)
+            kept = FulfillmentKeptArtifact(
+                fulfillment_id="ful_type_aware",
+                timestamp="2026-04-20T14:00:00.000Z",
+                episode_id=ep.episode_id,
+                commitment_id="cmt_type_aware",
+                result_id="res_fake",
+                evaluator="test",
+                evaluator_version="0.1",
+                policy_hash=policy_hash,
+                policy_resolver=resolver.to_dict(),
+            )
+            with pytest.raises(UnanchoredFulfillmentError):
+                emit_fulfillment_kept(ep, kept)
+
+
+# ---------------------------------------------------------------------------
+# 13. Repair — detector rejects fabricated terminals
+# ---------------------------------------------------------------------------
+
+
+class TestDetectorRejectsFabricatedTerminals:
+    """Defense-in-depth: a fabricated terminal (direct append_dict, bypassing the
+    emitter) must not suppress detection. The detector requires the terminal
+    to anchor to a real result.observed receipt.
+    """
+
+    def test_fabricated_terminal_without_result_does_not_close(self, tmp_store):
+        """A terminal whose result_id has no matching result.observed is ignored."""
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_fab", due_at="2020-01-01T00:00:00Z")
+        # Fabricate a terminal without a corresponding result.observed.
+        _write_kept(tmp_store, "cmt_fab", "res_does_not_exist")
+
+        result = detect_open_overdue_commitments(tmp_store)
+        open_ids = {c.commitment_id for c in result.open_commitments}
+        assert "cmt_fab" in open_ids
+        assert not result.clean
+
+    def test_fabricated_terminal_for_unregistered_commitment_ignored(self, tmp_store):
+        """A terminal naming an unregistered commitment does not appear in closed_ids."""
+        tmp_store.start_trace()
+        # Only a terminal — no commitment.registered, no result.observed.
+        _write_kept(tmp_store, "cmt_ghost", "res_ghost")
+        result = detect_open_overdue_commitments(tmp_store)
+        assert result.clean  # nothing registered, nothing to flag
+        assert result.total_closed_found == 0
+
+
+# ---------------------------------------------------------------------------
+# 14. Repair — terminal uniqueness survives list_traces() truncation
+# ---------------------------------------------------------------------------
+
+
+class TestTerminalUniquenessGlobalScan:
+    """The uniqueness guard scans every JSONL file on disk, not list_traces()."""
+
+    def test_uniqueness_survives_list_traces_cap(self, tmp_store, compile_receipt):
+        """Monkey-patching list_traces to return empty does not bypass uniqueness.
+
+        This test would fail under the old implementation (which relied on
+        ``list_traces(limit=10_000)``): a capped or empty list_traces would
+        hide the prior terminal and allow a duplicate.
+        """
+        path, policy_hash = compile_receipt
+        resolver = PolicyResolver(kind="uri", ref=_ref(path), policy_hash=policy_hash)
+
+        # Emit legitimate commitment + result + terminal.
+        with open_episode(store=tmp_store) as ep:
+            cmt = _build_commitment(policy_hash, resolver.to_dict(),
+                                    commitment_id="cmt_cap")
+            emit_commitment_registration(ep, cmt)
+            result = ResultObservationArtifact(
+                result_id="res_cap",
+                timestamp="2026-04-20T13:00:00.000Z",
+                episode_id=ep.episode_id,
+                text="x",
+                evidence_uri="file:///tmp/x.log",
+                policy_hash=policy_hash,
+                policy_resolver=resolver.to_dict(),
+                references=[{"kind": "commitment", "id": "cmt_cap"}],
+            )
+            emit_result_observation(ep, result)
+            kept = FulfillmentKeptArtifact(
+                fulfillment_id="ful_cap_1",
+                timestamp="2026-04-20T14:00:00.000Z",
+                episode_id=ep.episode_id,
+                commitment_id="cmt_cap",
+                result_id="res_cap",
+                evaluator="test",
+                evaluator_version="0.1",
+                policy_hash=policy_hash,
+                policy_resolver=resolver.to_dict(),
+            )
+            emit_fulfillment_kept(ep, kept)
+
+        # Blind list_traces: simulates a cap that hides older traces.
+        tmp_store.list_traces = lambda limit=20: []
+
+        # A second terminal attempt must still be rejected (uniqueness holds
+        # because _iter_all_receipts walks the filesystem, not list_traces).
+        with open_episode(store=tmp_store) as ep2:
+            result2 = ResultObservationArtifact(
+                result_id="res_cap2",
+                timestamp="2026-04-20T15:00:00.000Z",
+                episode_id=ep2.episode_id,
+                text="x",
+                evidence_uri="file:///tmp/x.log",
+                policy_hash=policy_hash,
+                policy_resolver=resolver.to_dict(),
+                references=[{"kind": "commitment", "id": "cmt_cap"}],
+            )
+            emit_result_observation(ep2, result2)
+            kept2 = FulfillmentKeptArtifact(
+                fulfillment_id="ful_cap_2",
+                timestamp="2026-04-20T16:00:00.000Z",
+                episode_id=ep2.episode_id,
+                commitment_id="cmt_cap",
+                result_id="res_cap2",
+                evaluator="test",
+                evaluator_version="0.1",
+                policy_hash=policy_hash,
+                policy_resolver=resolver.to_dict(),
+            )
+            with pytest.raises(TerminalFulfillmentError):
+                emit_fulfillment_kept(ep2, kept2)
+
+
+# ---------------------------------------------------------------------------
+# 15. Repair — result anchor is commitment-specific, not bare existence
+# ---------------------------------------------------------------------------
+
+
+def _register_cmt(ep, policy_hash, resolver, cmt_id):
+    cmt = _build_commitment(policy_hash, resolver.to_dict(), commitment_id=cmt_id)
+    emit_commitment_registration(ep, cmt)
+
+
+def _observe_res(ep, policy_hash, resolver, result_id, commitment_ref_ids):
+    refs = [{"kind": "commitment", "id": c} for c in commitment_ref_ids]
+    res = ResultObservationArtifact(
+        result_id=result_id,
+        timestamp="2026-04-20T13:00:00.000Z",
+        episode_id=ep.episode_id,
+        text="x",
+        evidence_uri="file:///tmp/x.log",
+        policy_hash=policy_hash,
+        policy_resolver=resolver.to_dict(),
+        references=refs,
+    )
+    emit_result_observation(ep, res)
+
+
+class TestCommitmentSpecificResultAnchor:
+    """result.observed must explicitly reference the commitment being closed."""
+
+    def test_kept_rejects_result_observed_for_different_commitment(
+        self, tmp_store, compile_receipt
+    ):
+        """A result.observed that references cmt_B must not close cmt_A."""
+        path, policy_hash = compile_receipt
+        resolver = PolicyResolver(kind="uri", ref=_ref(path), policy_hash=policy_hash)
+        with open_episode(store=tmp_store) as ep:
+            _register_cmt(ep, policy_hash, resolver, "cmt_A")
+            _register_cmt(ep, policy_hash, resolver, "cmt_B")
+            # res_B is for cmt_B, not cmt_A.
+            _observe_res(ep, policy_hash, resolver, "res_B",
+                         commitment_ref_ids=["cmt_B"])
+            kept = FulfillmentKeptArtifact(
+                fulfillment_id="ful_wrong_anchor",
+                timestamp="2026-04-20T14:00:00.000Z",
+                episode_id=ep.episode_id,
+                commitment_id="cmt_A",
+                result_id="res_B",
+                evaluator="test",
+                evaluator_version="0.1",
+                policy_hash=policy_hash,
+                policy_resolver=resolver.to_dict(),
+            )
+            with pytest.raises(UnanchoredFulfillmentError):
+                emit_fulfillment_kept(ep, kept)
+
+    def test_broken_rejects_result_observed_for_different_commitment(
+        self, tmp_store, compile_receipt
+    ):
+        path, policy_hash = compile_receipt
+        resolver = PolicyResolver(kind="uri", ref=_ref(path), policy_hash=policy_hash)
+        with open_episode(store=tmp_store) as ep:
+            _register_cmt(ep, policy_hash, resolver, "cmt_X")
+            _register_cmt(ep, policy_hash, resolver, "cmt_Y")
+            _observe_res(ep, policy_hash, resolver, "res_Y",
+                         commitment_ref_ids=["cmt_Y"])
+            broken = FulfillmentBrokenArtifact(
+                fulfillment_id="ful_wrong_broken",
+                timestamp="2026-04-20T14:00:00.000Z",
+                episode_id=ep.episode_id,
+                commitment_id="cmt_X",
+                result_id="res_Y",
+                evaluator="test",
+                evaluator_version="0.1",
+                policy_hash=policy_hash,
+                policy_resolver=resolver.to_dict(),
+                violation_reason="attempted misclose",
+            )
+            with pytest.raises(UnanchoredFulfillmentError):
+                emit_fulfillment_broken(ep, broken)
+
+    def test_detector_reports_open_when_anchor_references_wrong_commitment(
+        self, tmp_store
+    ):
+        """Even if the fabricator bypasses the emitter, the detector refuses."""
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_A", due_at="2020-01-01T00:00:00Z")
+        _write_registered(tmp_store, "cmt_B", due_at="2020-01-01T00:00:00Z")
+        # Observation references cmt_B, not cmt_A.
+        _write_result(tmp_store, "res_B",
+                      references=[{"kind": "commitment", "id": "cmt_B"}])
+        # Fabricated terminal tries to close cmt_A with res_B.
+        _write_kept(tmp_store, "cmt_A", "res_B")
+        result = detect_open_overdue_commitments(tmp_store)
+        open_ids = {c.commitment_id for c in result.open_commitments}
+        assert "cmt_A" in open_ids  # not closed
+        assert "cmt_B" in open_ids  # never attempted
+
+
+# ---------------------------------------------------------------------------
+# 16. Repair — detector preserves order
+# ---------------------------------------------------------------------------
+
+
+class TestDetectorPreservesOrder:
+    """A later observation cannot retroactively legitimize a prior terminal."""
+
+    def test_terminal_written_before_observation_does_not_close(self, tmp_store):
+        """Forged terminal first, then observation — commitment stays open."""
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_forged", due_at="2020-01-01T00:00:00Z")
+        # Forged terminal BEFORE any result.observed.
+        _write_kept(tmp_store, "cmt_forged", "res_late")
+        # Observation appended AFTER — would have anchored, had order allowed.
+        _write_result(
+            tmp_store,
+            "res_late",
+            references=[{"kind": "commitment", "id": "cmt_forged"}],
+        )
+        result = detect_open_overdue_commitments(tmp_store)
+        open_ids = {c.commitment_id for c in result.open_commitments}
+        assert "cmt_forged" in open_ids
+
+    def test_proper_order_closes(self, tmp_store):
+        """Registered, then observed (with ref), then terminal — closes cleanly."""
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_ord", due_at="2020-01-01T00:00:00Z")
+        _write_result(
+            tmp_store,
+            "res_ord",
+            references=[{"kind": "commitment", "id": "cmt_ord"}],
+        )
+        _write_kept(tmp_store, "cmt_ord", "res_ord")
+        result = detect_open_overdue_commitments(tmp_store)
+        assert result.clean
+
+    def test_terminal_before_registration_does_not_close(self, tmp_store):
+        """Terminal preceding its own registration is invalid (ordering)."""
+        tmp_store.start_trace()
+        # Terminal appears BEFORE registration.
+        _write_kept(tmp_store, "cmt_early", "res_early")
+        # Then registration.
+        _write_registered(tmp_store, "cmt_early", due_at="2020-01-01T00:00:00Z")
+        # Then observation with correct ref.
+        _write_result(
+            tmp_store,
+            "res_early",
+            references=[{"kind": "commitment", "id": "cmt_early"}],
+        )
+        result = detect_open_overdue_commitments(tmp_store)
+        open_ids = {c.commitment_id for c in result.open_commitments}
+        assert "cmt_early" in open_ids
+
+
+# ---------------------------------------------------------------------------
+# 17. Repair — corruption fails closed as ReceiptStoreIntegrityError
+# ---------------------------------------------------------------------------
+
+
+def _corrupt_current_trace(store):
+    """Append a malformed JSON line to the most recent trace file."""
+    trace_files = sorted(store.base_dir.rglob("trace_*.jsonl"))
+    assert trace_files, "expected at least one trace file"
+    target = trace_files[-1]
+    with open(target, "a") as handle:
+        handle.write("{this is not valid json\n")
+
+
+class TestCorruptionFailsClosed:
+    """Malformed JSON / unreadable files surface as integrity errors."""
+
+    def test_detector_raises_on_malformed_json_line(self, tmp_store):
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_int", due_at="2099-01-01T00:00:00Z")
+        _corrupt_current_trace(tmp_store)
+        with pytest.raises(ReceiptStoreIntegrityError):
+            detect_open_overdue_commitments(tmp_store)
+
+    def test_iter_all_receipts_raises_on_malformed_json(self, tmp_store):
+        """Direct: _iter_all_receipts must raise rather than skip a bad line."""
+        from assay.commitment_fulfillment import _iter_all_receipts
+
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_iter", due_at="2099-01-01T00:00:00Z")
+        _corrupt_current_trace(tmp_store)
+        with pytest.raises(ReceiptStoreIntegrityError):
+            list(_iter_all_receipts(tmp_store))
+
+    def test_missing_store_seq_fails_closed(self, tmp_store):
+        """A receipt lacking _store_seq must surface as an integrity failure."""
+        from assay.commitment_fulfillment import _iter_all_receipts
+
+        tmp_store.start_trace()
+        # Write a legitimate receipt via append_dict (gets _store_seq stamped),
+        # then manually inject a line without _store_seq into the same file.
+        _write_registered(tmp_store, "cmt_seq", due_at="2099-01-01T00:00:00Z")
+        trace_files = sorted(tmp_store.base_dir.rglob("trace_*.jsonl"))
+        target = trace_files[-1]
+        with open(target, "a") as handle:
+            handle.write('{"type": "result.observed", "result_id": "sneaky"}\n')
+        with pytest.raises(ReceiptStoreIntegrityError):
+            list(_iter_all_receipts(tmp_store))
+
+    def test_duplicate_store_seq_fails_closed(self, tmp_store):
+        """Two receipts carrying the same _store_seq must raise integrity error."""
+        from assay.commitment_fulfillment import _iter_all_receipts
+
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_dup", due_at="2099-01-01T00:00:00Z")
+        # Inject a second receipt with a duplicate _store_seq.
+        trace_files = sorted(tmp_store.base_dir.rglob("trace_*.jsonl"))
+        target = trace_files[-1]
+        # The legitimate registration above got _store_seq=1 (or similar); we
+        # re-use 0 which AssayStore assigned to "episode.opened"/first write.
+        with open(target, "a") as handle:
+            handle.write(
+                '{"type": "result.observed", "result_id": "dup", '
+                '"_trace_id": "trace_dup", "_stored_at": "2026-01-01T00:00:00Z", '
+                '"_store_seq": 0}\n'
+            )
+        with pytest.raises(ReceiptStoreIntegrityError):
+            list(_iter_all_receipts(tmp_store))
+
+    def test_non_monotonic_store_seq_within_file_fails_closed(self, tmp_store):
+        """A within-file seq regression (tampering) surfaces as integrity error."""
+        from assay.commitment_fulfillment import _iter_all_receipts
+
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_mono", due_at="2099-01-01T00:00:00Z")
+        # Append a line with a _store_seq LOWER than any legitimate seq in the file.
+        trace_files = sorted(tmp_store.base_dir.rglob("trace_*.jsonl"))
+        target = trace_files[-1]
+        with open(target, "a") as handle:
+            handle.write(
+                '{"type": "result.observed", "result_id": "back", '
+                '"_trace_id": "trace_back", "_stored_at": "2026-01-01T00:00:00Z", '
+                '"_store_seq": -5}\n'
+            )
+        with pytest.raises(ReceiptStoreIntegrityError):
+            list(_iter_all_receipts(tmp_store))
+
+    def test_emit_path_fails_closed_when_older_trace_corrupt(
+        self, tmp_store
+    ):
+        """An older corrupted trace must surface as integrity failure on ANY write.
+
+        Under the strict rollout contract, a corrupt corpus fails every
+        write from the first attempt onward — including the implicit
+        episode.opened write inside ``open_episode``. This is the correct
+        semantic: if the store is lying, the next write must not make it
+        lie more.
+        """
+        # Pre-plant a corrupted trace that sort-orders BEFORE any real trace.
+        older_dir = tmp_store.base_dir / "2020-01-01"
+        older_dir.mkdir(parents=True, exist_ok=True)
+        (older_dir / "trace_20200101T000000_beefbeef.jsonl").write_text(
+            "{ this is not valid json\n"
+        )
+
+        # Any write attempt must raise — we exercise the most basic one.
+        tmp_store.start_trace(trace_id="trace_attempt")
+        with pytest.raises(ReceiptStoreIntegrityError):
+            tmp_store.append_dict({"type": "probe"})
+
+
+# ---------------------------------------------------------------------------
+# 18. Repair — order is _store_seq, not lexicographic trace path
+# ---------------------------------------------------------------------------
+
+
+class TestStoreSeqIsCausalOrder:
+    """The detector's causal order comes from _store_seq, not trace filename order.
+
+    Reviewer repro: AssayStore.start_trace(trace_id=...) accepts arbitrary
+    trace IDs, so ``sorted(rglob("trace_*.jsonl"))`` does NOT reflect write
+    chronology. A forged terminal in a trace whose name sorts LAST but was
+    written FIRST must not be closed by an observation in a trace that sorts
+    first but was written later.
+    """
+
+    def test_forged_terminal_in_trace_z_not_legitimized_by_later_trace_a(
+        self, tmp_store
+    ):
+        """trace_zzz written first, trace_aaa written later; closure must not happen."""
+        # trace_z is written FIRST chronologically (gets low _store_seq),
+        # but its path sorts AFTER trace_a alphabetically.
+        tmp_store.start_trace(trace_id="trace_zzzzzzzz_ffffffff")
+        _write_registered(tmp_store, "cmt_cross", due_at="2020-01-01T00:00:00Z")
+        # Forged terminal — no observation yet at this receipt-order point.
+        _write_kept(tmp_store, "cmt_cross", "res_cross")
+
+        # trace_a is written LATER (gets higher _store_seq), but its path
+        # sorts BEFORE trace_z. A path-sorted scan would see the observation
+        # before the terminal and wrongly close the commitment.
+        tmp_store.start_trace(trace_id="trace_aaaaaaaa_00000000")
+        _write_result(
+            tmp_store,
+            "res_cross",
+            references=[{"kind": "commitment", "id": "cmt_cross"}],
+        )
+
+        result = detect_open_overdue_commitments(tmp_store)
+        open_ids = {c.commitment_id for c in result.open_commitments}
+        assert "cmt_cross" in open_ids, (
+            "Detector must use _store_seq for causal order, not trace-path sort. "
+            "Under path-sort, trace_a (observation) would precede trace_z (terminal) "
+            "and close the commitment; under _store_seq, the forged terminal has "
+            "lower seq and is invalid at its encounter point."
+        )
+
+    def test_proper_cross_trace_order_closes(self, tmp_store):
+        """Inverted trace names: writes in causal order despite adversarial sort.
+
+        trace_zzz receives register+observe FIRST (lower _store_seq), trace_aaa
+        receives the terminal LATER (higher _store_seq). Under path-sort, this
+        would look like terminal precedes registration (wrongly invalid). Under
+        _store_seq, this is proper causal order and closes correctly.
+        """
+        tmp_store.start_trace(trace_id="trace_zzzzzzzz_00000000")
+        _write_registered(tmp_store, "cmt_cross_ok", due_at="2020-01-01T00:00:00Z")
+        _write_result(
+            tmp_store,
+            "res_cross_ok",
+            references=[{"kind": "commitment", "id": "cmt_cross_ok"}],
+        )
+
+        tmp_store.start_trace(trace_id="trace_aaaaaaaa_00000000")
+        _write_kept(tmp_store, "cmt_cross_ok", "res_cross_ok")
+
+        result = detect_open_overdue_commitments(tmp_store)
+        assert result.clean, (
+            "Proper causal order (register → observe → terminal) must close, "
+            "even when trace names invert the lexicographic order."
+        )
+
+    def test_store_seq_is_stamped_on_every_write(self, tmp_store):
+        """append_dict and append both stamp monotonic _store_seq."""
+        tmp_store.start_trace()
+        tmp_store.append_dict({"type": "alpha", "n": 1})
+        tmp_store.append_dict({"type": "beta", "n": 2})
+        tmp_store.append_dict({"type": "gamma", "n": 3})
+
+        trace_files = sorted(tmp_store.base_dir.rglob("trace_*.jsonl"))
+        entries = []
+        for f in trace_files:
+            with open(f) as handle:
+                for line in handle:
+                    line = line.strip()
+                    if line:
+                        entries.append(json.loads(line))
+        seqs = [e.get("_store_seq") for e in entries]
+        assert None not in seqs, f"missing _store_seq somewhere: {seqs}"
+        # Strictly increasing
+        assert all(a < b for a, b in zip(seqs, seqs[1:])), f"non-monotonic: {seqs}"
+
+
+# ---------------------------------------------------------------------------
+# 19. Repair — cross-process-safe _store_seq allocator
+# ---------------------------------------------------------------------------
+
+
+def _collect_all_store_seqs(base_dir):
+    """Helper: read every _store_seq in every trace file under base_dir."""
+    seqs = []
+    for trace_file in sorted(base_dir.rglob("trace_*.jsonl")):
+        with open(trace_file) as handle:
+            for line in handle:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                entry = json.loads(stripped)
+                seq = entry.get("_store_seq")
+                if seq is not None:
+                    seqs.append(seq)
+    return seqs
+
+
+class TestStoreSeqAllocatorIsCrossProcessSafe:
+    """Two independent AssayStore instances sharing base_dir must never
+    allocate the same _store_seq.
+    """
+
+    def test_two_instances_share_base_dir_unique_seqs(self, tmp_path):
+        """Two AssayStore instances, same base_dir, writes interleaved."""
+        base_dir = tmp_path / "shared"
+        store_a = AssayStore(base_dir=base_dir)
+        store_b = AssayStore(base_dir=base_dir)
+        store_a.start_trace(trace_id="trace_shared_a")
+        store_b.start_trace(trace_id="trace_shared_b")
+
+        # Interleave writes across instances.
+        for i in range(5):
+            store_a.append_dict({"type": "from_a", "i": i})
+            store_b.append_dict({"type": "from_b", "i": i})
+
+        seqs = _collect_all_store_seqs(base_dir)
+        assert len(seqs) == 10, f"expected 10 seqs, got {seqs}"
+        assert len(set(seqs)) == 10, f"duplicate _store_seq: {seqs}"
+
+    def test_multiprocess_writers_allocate_unique_seqs(self, tmp_path):
+        """Two OS processes writing to the same base_dir must not collide."""
+        import multiprocessing as mp
+
+        base_dir = tmp_path / "mp"
+        base_dir.mkdir(parents=True, exist_ok=True)
+
+        ctx = mp.get_context("spawn")
+        procs = [
+            ctx.Process(
+                target=_mp_writer_body,
+                args=(str(base_dir), f"trace_mp_{i}", 10),
+            )
+            for i in range(2)
+        ]
+        for p in procs:
+            p.start()
+        for p in procs:
+            p.join(timeout=30)
+            assert p.exitcode == 0, (
+                f"subprocess exited {p.exitcode}; "
+                "see stderr above for allocator failure."
+            )
+
+        seqs = _collect_all_store_seqs(base_dir)
+        assert len(seqs) == 20, f"expected 20 seqs, got {len(seqs)}: {seqs}"
+        assert len(set(seqs)) == 20, f"duplicate _store_seq across processes: {seqs}"
+
+    def test_detector_accepts_store_after_concurrent_writes(self, tmp_path):
+        """Concurrent-writer output must still pass _iter_all_receipts integrity."""
+        from assay.commitment_fulfillment import _iter_all_receipts
+
+        base_dir = tmp_path / "post_mp"
+        store_a = AssayStore(base_dir=base_dir)
+        store_b = AssayStore(base_dir=base_dir)
+        store_a.start_trace(trace_id="trace_post_a")
+        store_b.start_trace(trace_id="trace_post_b")
+        for i in range(5):
+            store_a.append_dict({"type": "from_a", "i": i})
+            store_b.append_dict({"type": "from_b", "i": i})
+
+        # Scan uses either store instance — they share base_dir.
+        entries = list(_iter_all_receipts(store_a))
+        assert len(entries) == 10
+        seqs = [e["_store_seq"] for e in entries]
+        # Sort is inherent to _iter_all_receipts.
+        assert seqs == sorted(seqs)
+        assert len(set(seqs)) == 10
+
+
+# Module-level helper (must be picklable for multiprocessing "spawn").
+def _mp_writer_body(base_dir_str, trace_id, count):
+    """Write ``count`` receipts from a subprocess to the named base_dir."""
+    from assay.store import AssayStore as _AssayStore
+
+    store = _AssayStore(base_dir=Path(base_dir_str))
+    store.start_trace(trace_id=trace_id)
+    for i in range(count):
+        store.append_dict({"type": "subproc", "trace_id": trace_id, "i": i})
+
+
+# ---------------------------------------------------------------------------
+# 20. Repair — legacy-store migration path
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyStoreMigration:
+    """Backfill _store_seq on pre-Slice-1 stores without silent reinterpretation."""
+
+    def _write_legacy_entry(self, path, entry):
+        """Write a single legacy receipt (no _store_seq) to path."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "a") as handle:
+            handle.write(json.dumps(entry) + "\n")
+
+    def test_migration_backfills_pure_legacy_store(self, tmp_path):
+        from assay.store_seq_migration import migrate_legacy_store_seq
+
+        base_dir = tmp_path / "legacy"
+        day = base_dir / "2026-04-20"
+        # Three legacy entries across two trace files, no _store_seq.
+        self._write_legacy_entry(
+            day / "trace_20260420T010000_aaaaaaaa.jsonl",
+            {"type": "alpha", "_trace_id": "trace_20260420T010000_aaaaaaaa",
+             "_stored_at": "2026-04-20T01:00:00Z"},
+        )
+        self._write_legacy_entry(
+            day / "trace_20260420T010000_aaaaaaaa.jsonl",
+            {"type": "beta", "_trace_id": "trace_20260420T010000_aaaaaaaa",
+             "_stored_at": "2026-04-20T01:00:01Z"},
+        )
+        self._write_legacy_entry(
+            day / "trace_20260420T020000_bbbbbbbb.jsonl",
+            {"type": "gamma", "_trace_id": "trace_20260420T020000_bbbbbbbb",
+             "_stored_at": "2026-04-20T02:00:00Z"},
+        )
+
+        store = AssayStore(base_dir=base_dir)
+        result = migrate_legacy_store_seq(store)
+
+        assert result.receipts_backfilled == 3
+        assert result.next_seq == 3
+        assert result.ordering_basis == "path_then_line"
+
+        seqs = _collect_all_store_seqs(base_dir)
+        assert sorted(seqs) == [0, 1, 2]
+
+    def test_migration_enables_subsequent_writes_to_continue_sequence(
+        self, tmp_path
+    ):
+        from assay.store_seq_migration import migrate_legacy_store_seq
+
+        base_dir = tmp_path / "legacy_continue"
+        day = base_dir / "2026-04-20"
+        self._write_legacy_entry(
+            day / "trace_20260420T010000_aaaaaaaa.jsonl",
+            {"type": "old"},
+        )
+        store = AssayStore(base_dir=base_dir)
+        migrate_legacy_store_seq(store)
+
+        # New write continues the monotonic sequence.
+        store.start_trace()
+        store.append_dict({"type": "new_after_migration"})
+        seqs = _collect_all_store_seqs(base_dir)
+        assert sorted(seqs) == [0, 1]
+
+    def test_migration_refuses_mixed_state(self, tmp_path):
+        from assay.store_seq_migration import (
+            StoreMigrationError,
+            migrate_legacy_store_seq,
+        )
+
+        base_dir = tmp_path / "mixed"
+        day = base_dir / "2026-04-20"
+        # One legacy, one already-migrated.
+        self._write_legacy_entry(
+            day / "trace_20260420T010000_aaaaaaaa.jsonl",
+            {"type": "legacy"},
+        )
+        self._write_legacy_entry(
+            day / "trace_20260420T010000_aaaaaaaa.jsonl",
+            {"type": "new", "_store_seq": 42},
+        )
+        store = AssayStore(base_dir=base_dir)
+        with pytest.raises(StoreMigrationError):
+            migrate_legacy_store_seq(store)
+
+    def test_migration_refuses_duplicate_existing_seqs(self, tmp_path):
+        from assay.store_seq_migration import (
+            StoreMigrationError,
+            migrate_legacy_store_seq,
+        )
+
+        base_dir = tmp_path / "dupseq"
+        day = base_dir / "2026-04-20"
+        self._write_legacy_entry(
+            day / "trace_20260420T010000_aaaaaaaa.jsonl",
+            {"type": "x", "_store_seq": 5},
+        )
+        self._write_legacy_entry(
+            day / "trace_20260420T010000_aaaaaaaa.jsonl",
+            {"type": "y", "_store_seq": 5},
+        )
+        store = AssayStore(base_dir=base_dir)
+        with pytest.raises(StoreMigrationError):
+            migrate_legacy_store_seq(store)
+
+    def test_migration_is_idempotent(self, tmp_path):
+        from assay.store_seq_migration import migrate_legacy_store_seq
+
+        base_dir = tmp_path / "idem"
+        day = base_dir / "2026-04-20"
+        self._write_legacy_entry(
+            day / "trace_20260420T010000_aaaaaaaa.jsonl",
+            {"type": "alpha"},
+        )
+        store = AssayStore(base_dir=base_dir)
+        first = migrate_legacy_store_seq(store)
+        second = migrate_legacy_store_seq(store)
+        assert first.receipts_backfilled == 1
+        assert second.receipts_backfilled == 0
+        assert second.ordering_basis == "already_migrated"
+
+    def test_migration_makes_legacy_store_detector_ready(self, tmp_path):
+        """After migration, _iter_all_receipts succeeds on previously-legacy data."""
+        from assay.commitment_fulfillment import _iter_all_receipts
+        from assay.store_seq_migration import migrate_legacy_store_seq
+
+        base_dir = tmp_path / "post_migrate"
+        day = base_dir / "2026-04-20"
+        self._write_legacy_entry(
+            day / "trace_20260420T010000_aaaaaaaa.jsonl",
+            {"type": "legacy1"},
+        )
+        self._write_legacy_entry(
+            day / "trace_20260420T010000_aaaaaaaa.jsonl",
+            {"type": "legacy2"},
+        )
+        store = AssayStore(base_dir=base_dir)
+
+        # Before migration: detector fails closed.
+        with pytest.raises(ReceiptStoreIntegrityError):
+            list(_iter_all_receipts(store))
+
+        migrate_legacy_store_seq(store)
+
+        # After migration: detector walks cleanly.
+        entries = list(_iter_all_receipts(store))
+        assert len(entries) == 2
+        assert [e["_store_seq"] for e in entries] == [0, 1]
+
+
+# ---------------------------------------------------------------------------
+# 21. Repair — write path refuses unmigrated legacy stores
+# ---------------------------------------------------------------------------
+
+
+class TestWritePathRefusesLegacyStore:
+    """A single ordinary write must NOT be able to strand a legacy store in
+    mixed state. The write path must refuse until migration has run.
+    """
+
+    def _write_legacy_entry(self, path, entry):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "a") as handle:
+            handle.write(json.dumps(entry) + "\n")
+
+    def test_append_dict_refuses_unmigrated_legacy_store(self, tmp_path):
+        from assay.store import MigrationRequiredError
+
+        base_dir = tmp_path / "refuse_legacy"
+        day = base_dir / "2026-04-20"
+        self._write_legacy_entry(
+            day / "trace_20260420T010000_aaaaaaaa.jsonl",
+            {"type": "legacy_alpha"},
+        )
+        store = AssayStore(base_dir=base_dir)
+        store.start_trace(trace_id="trace_attempted_write")
+        with pytest.raises(MigrationRequiredError):
+            store.append_dict({"type": "new_write"})
+
+    def test_refusal_does_not_create_mixed_state(self, tmp_path):
+        """Refused write must leave legacy files and .store_seq untouched."""
+        from assay.store import MigrationRequiredError
+
+        base_dir = tmp_path / "refuse_unmutated"
+        day = base_dir / "2026-04-20"
+        legacy_path = day / "trace_20260420T010000_aaaaaaaa.jsonl"
+        self._write_legacy_entry(legacy_path, {"type": "legacy_x"})
+        legacy_bytes_before = legacy_path.read_bytes()
+
+        store = AssayStore(base_dir=base_dir)
+        store.start_trace(trace_id="trace_untouched")
+        with pytest.raises(MigrationRequiredError):
+            store.append_dict({"type": "new"})
+
+        # Legacy file unchanged.
+        assert legacy_path.read_bytes() == legacy_bytes_before
+        # .store_seq counter MUST NOT have been created.
+        assert not (base_dir / ".store_seq").exists(), (
+            "refused write must not create .store_seq — that would make the "
+            "next write think the store is pre-initialized and bypass the "
+            "legacy guard."
+        )
+        # And the migration path still works.
+        from assay.store_seq_migration import migrate_legacy_store_seq
+
+        result = migrate_legacy_store_seq(store)
+        assert result.receipts_backfilled == 1
+
+    def test_post_migration_writes_succeed_and_continue_sequence(self, tmp_path):
+        from assay.store_seq_migration import migrate_legacy_store_seq
+
+        base_dir = tmp_path / "post_ok"
+        day = base_dir / "2026-04-20"
+        self._write_legacy_entry(
+            day / "trace_20260420T010000_aaaaaaaa.jsonl",
+            {"type": "legacy_seed"},
+        )
+        store = AssayStore(base_dir=base_dir)
+        migrate_legacy_store_seq(store)
+
+        store.start_trace(trace_id="trace_post_mig")
+        store.append_dict({"type": "fresh_after_migration"})
+
+        seqs = _collect_all_store_seqs(base_dir)
+        assert sorted(seqs) == [0, 1]
+
+    def test_append_method_also_refuses_legacy_store(self, tmp_path):
+        """BaseModel.append() path must refuse the same way as append_dict."""
+        from assay._receipts.compat.pyd import BaseModel as _PydBase
+        from assay.store import MigrationRequiredError
+
+        class _Tiny(_PydBase):
+            type: str
+            receipt_id: str
+
+        base_dir = tmp_path / "refuse_legacy_append"
+        day = base_dir / "2026-04-20"
+        self._write_legacy_entry(
+            day / "trace_20260420T010000_aaaaaaaa.jsonl",
+            {"type": "legacy_append"},
+        )
+        store = AssayStore(base_dir=base_dir)
+        store.start_trace(trace_id="trace_append_attempt")
+        with pytest.raises(MigrationRequiredError):
+            store.append(_Tiny(type="probe", receipt_id="r_probe"))
+
+    def test_cli_migrates_legacy_store(self, tmp_path):
+        """`python -m assay.store_seq_migration <base_dir>` migrates successfully."""
+        import subprocess
+        import sys
+
+        base_dir = tmp_path / "cli_legacy"
+        day = base_dir / "2026-04-20"
+        self._write_legacy_entry(
+            day / "trace_20260420T010000_aaaaaaaa.jsonl",
+            {"type": "cli_legacy_1"},
+        )
+        self._write_legacy_entry(
+            day / "trace_20260420T010000_aaaaaaaa.jsonl",
+            {"type": "cli_legacy_2"},
+        )
+
+        proc = subprocess.run(
+            [sys.executable, "-m", "assay.store_seq_migration", str(base_dir)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert proc.returncode == 0, (
+            f"CLI migration failed: stdout={proc.stdout!r} stderr={proc.stderr!r}"
+        )
+        assert "receipts_backfilled=2" in proc.stdout
+        assert "ordering_basis=path_then_line" in proc.stdout
+
+        seqs = _collect_all_store_seqs(base_dir)
+        assert sorted(seqs) == [0, 1]
+
+    def test_cli_returns_nonzero_on_mixed_state(self, tmp_path):
+        """CLI must exit nonzero when migration refuses mixed state."""
+        import subprocess
+        import sys
+
+        base_dir = tmp_path / "cli_mixed"
+        day = base_dir / "2026-04-20"
+        self._write_legacy_entry(
+            day / "trace_20260420T010000_aaaaaaaa.jsonl",
+            {"type": "legacy_cli"},
+        )
+        self._write_legacy_entry(
+            day / "trace_20260420T010000_aaaaaaaa.jsonl",
+            {"type": "migrated_cli", "_store_seq": 42},
+        )
+
+        proc = subprocess.run(
+            [sys.executable, "-m", "assay.store_seq_migration", str(base_dir)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert proc.returncode == 3, (
+            f"expected exit 3 on mixed state, got {proc.returncode}: "
+            f"stderr={proc.stderr!r}"
+        )
+        assert "migration refused" in proc.stderr.lower()
+
+    def test_cli_rejects_missing_argument(self, tmp_path):
+        """Usage error exits 2."""
+        import subprocess
+        import sys
+
+        proc = subprocess.run(
+            [sys.executable, "-m", "assay.store_seq_migration"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert proc.returncode == 2
+
+
+# ---------------------------------------------------------------------------
+# 22. Repair — strict write-path validation for corrupt and mixed stores
+# ---------------------------------------------------------------------------
+
+
+class TestWritePathStrictCorpusValidation:
+    """``.store_seq`` is NOT a health certificate. The write path must
+    validate the full trace corpus on every write and fail closed on
+    corruption or mixed state, regardless of whether ``.store_seq`` exists.
+    """
+
+    def _write_legacy_entry(self, path, entry):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "a") as handle:
+            handle.write(json.dumps(entry) + "\n")
+
+    def test_corrupt_trace_without_counter_refuses_write(self, tmp_path):
+        """Malformed JSON + absent .store_seq → write refused as integrity error."""
+        from assay.store import ReceiptStoreIntegrityError
+
+        base_dir = tmp_path / "corrupt_no_counter"
+        day = base_dir / "2026-04-20"
+        day.mkdir(parents=True, exist_ok=True)
+        (day / "trace_20260420T000000_aaaaaaaa.jsonl").write_text(
+            "{this is not valid json\n"
+        )
+        store = AssayStore(base_dir=base_dir)
+        store.start_trace(trace_id="trace_attempt")
+        with pytest.raises(ReceiptStoreIntegrityError):
+            store.append_dict({"type": "probe"})
+
+    def test_corrupt_trace_refusal_does_not_create_counter_file(self, tmp_path):
+        """Refused write on corrupt store must not silently create .store_seq."""
+        from assay.store import ReceiptStoreIntegrityError
+
+        base_dir = tmp_path / "corrupt_no_side_effect"
+        day = base_dir / "2026-04-20"
+        day.mkdir(parents=True, exist_ok=True)
+        (day / "trace_20260420T000000_aaaaaaaa.jsonl").write_text(
+            "{bad\n"
+        )
+        store = AssayStore(base_dir=base_dir)
+        store.start_trace(trace_id="trace_attempt")
+        with pytest.raises(ReceiptStoreIntegrityError):
+            store.append_dict({"type": "probe"})
+        assert not (base_dir / ".store_seq").exists()
+
+    def test_corrupt_trace_with_existing_counter_still_refuses(self, tmp_path):
+        """.store_seq existence must not pardon a corrupt corpus."""
+        from assay.store import ReceiptStoreIntegrityError
+
+        base_dir = tmp_path / "corrupt_with_counter"
+        day = base_dir / "2026-04-20"
+        day.mkdir(parents=True, exist_ok=True)
+        # Legitimate stamped receipt.
+        self._write_legacy_entry(
+            day / "trace_20260420T000000_aaaaaaaa.jsonl",
+            {"type": "legit", "_store_seq": 0},
+        )
+        # Counter says next_seq=1.
+        (base_dir / ".store_seq").write_text("1")
+        # Now append malformed JSON to the same file.
+        with open(day / "trace_20260420T000000_aaaaaaaa.jsonl", "a") as handle:
+            handle.write("{gibberish\n")
+
+        store = AssayStore(base_dir=base_dir)
+        store.start_trace(trace_id="trace_corrupt_attempt")
+        with pytest.raises(ReceiptStoreIntegrityError):
+            store.append_dict({"type": "probe"})
+
+    def test_mixed_state_with_existing_counter_refuses_write(self, tmp_path):
+        """Mixed state with .store_seq must still refuse writes."""
+        from assay.store import ReceiptStoreIntegrityError
+
+        base_dir = tmp_path / "mixed_with_counter"
+        day = base_dir / "2026-04-20"
+        day.mkdir(parents=True, exist_ok=True)
+        self._write_legacy_entry(
+            day / "trace_20260420T000000_aaaaaaaa.jsonl",
+            {"type": "legacy_half"},
+        )
+        self._write_legacy_entry(
+            day / "trace_20260420T000000_aaaaaaaa.jsonl",
+            {"type": "stamped_half", "_store_seq": 0},
+        )
+        (base_dir / ".store_seq").write_text("1")
+
+        store = AssayStore(base_dir=base_dir)
+        store.start_trace(trace_id="trace_mixed_attempt")
+        with pytest.raises(ReceiptStoreIntegrityError):
+            store.append_dict({"type": "probe"})
+
+    def test_healthy_current_store_allows_writes(self, tmp_path):
+        """All receipts stamped + valid counter → writes proceed normally."""
+        base_dir = tmp_path / "healthy_current"
+        day = base_dir / "2026-04-20"
+        day.mkdir(parents=True, exist_ok=True)
+        self._write_legacy_entry(
+            day / "trace_20260420T000000_aaaaaaaa.jsonl",
+            {"type": "first", "_store_seq": 0},
+        )
+        self._write_legacy_entry(
+            day / "trace_20260420T000000_aaaaaaaa.jsonl",
+            {"type": "second", "_store_seq": 1},
+        )
+        (base_dir / ".store_seq").write_text("2")
+
+        store = AssayStore(base_dir=base_dir)
+        store.start_trace(trace_id="trace_healthy_new")
+        store.append_dict({"type": "fresh"})
+
+        seqs = _collect_all_store_seqs(base_dir)
+        assert sorted(seqs) == [0, 1, 2]
+
+    def test_current_store_without_counter_reconstructs_from_corpus(self, tmp_path):
+        """All receipts stamped + absent .store_seq → write reconstructs next seq.
+
+        This is the "pardon-less" path: even without the counter file,
+        strict validation must pass first, then next_seq is derived as
+        ``max(_store_seq) + 1`` under the flock.
+        """
+        base_dir = tmp_path / "current_no_counter"
+        day = base_dir / "2026-04-20"
+        day.mkdir(parents=True, exist_ok=True)
+        self._write_legacy_entry(
+            day / "trace_20260420T000000_aaaaaaaa.jsonl",
+            {"type": "stamped_0", "_store_seq": 0},
+        )
+        self._write_legacy_entry(
+            day / "trace_20260420T000000_aaaaaaaa.jsonl",
+            {"type": "stamped_1", "_store_seq": 1},
+        )
+        # .store_seq deliberately absent.
+        assert not (base_dir / ".store_seq").exists()
+
+        store = AssayStore(base_dir=base_dir)
+        store.start_trace(trace_id="trace_reconstruct")
+        store.append_dict({"type": "resumed"})
+
+        seqs = _collect_all_store_seqs(base_dir)
+        assert sorted(seqs) == [0, 1, 2]
+        # Counter now persisted.
+        assert (base_dir / ".store_seq").read_text().strip() == "3"
+
+    def test_duplicate_store_seq_in_corpus_refuses_write(self, tmp_path):
+        """Two stamped receipts with the same _store_seq is integrity corruption,
+        not a legacy/migration situation. Write must be refused with
+        ReceiptStoreIntegrityError regardless of .store_seq counter.
+        """
+        from assay.store import ReceiptStoreIntegrityError
+
+        base_dir = tmp_path / "dup_corpus"
+        day = base_dir / "2026-04-20"
+        day.mkdir(parents=True, exist_ok=True)
+        self._write_legacy_entry(
+            day / "trace_20260420T000000_aaaaaaaa.jsonl",
+            {"type": "a", "_store_seq": 5},
+        )
+        # Second file (sorts later); second receipt has same seq=5.
+        self._write_legacy_entry(
+            day / "trace_20260420T000001_bbbbbbbb.jsonl",
+            {"type": "b", "_store_seq": 5},
+        )
+        (base_dir / ".store_seq").write_text("6")
+
+        store = AssayStore(base_dir=base_dir)
+        store.start_trace(trace_id="trace_dup_attempt")
+        with pytest.raises(ReceiptStoreIntegrityError):
+            store.append_dict({"type": "probe"})
+
+    def test_within_file_store_seq_regression_refuses_write(self, tmp_path):
+        """A stamped file whose _store_seq regresses (10 then 3) is corrupt.
+        Write must be refused."""
+        from assay.store import ReceiptStoreIntegrityError
+
+        base_dir = tmp_path / "regress_corpus"
+        day = base_dir / "2026-04-20"
+        day.mkdir(parents=True, exist_ok=True)
+        f = day / "trace_20260420T000000_aaaaaaaa.jsonl"
+        self._write_legacy_entry(f, {"type": "first", "_store_seq": 10})
+        self._write_legacy_entry(f, {"type": "regress", "_store_seq": 3})
+        (base_dir / ".store_seq").write_text("11")
+
+        store = AssayStore(base_dir=base_dir)
+        store.start_trace(trace_id="trace_regress_attempt")
+        with pytest.raises(ReceiptStoreIntegrityError):
+            store.append_dict({"type": "probe"})
+
+    def test_non_integer_store_seq_is_integrity_error_not_migration(self, tmp_path):
+        """A receipt with _store_seq set to a non-integer is corpus corruption,
+        not legacy data. The error must be ReceiptStoreIntegrityError —
+        sending operators to migration would mislead them (migration would
+        refuse the store anyway).
+        """
+        from assay.store import MigrationRequiredError, ReceiptStoreIntegrityError
+
+        base_dir = tmp_path / "non_int_corpus"
+        day = base_dir / "2026-04-20"
+        day.mkdir(parents=True, exist_ok=True)
+        self._write_legacy_entry(
+            day / "trace_20260420T000000_aaaaaaaa.jsonl",
+            {"type": "x", "_store_seq": "oops"},
+        )
+
+        store = AssayStore(base_dir=base_dir)
+        store.start_trace(trace_id="trace_nonint_attempt")
+        with pytest.raises(ReceiptStoreIntegrityError) as exc_info:
+            store.append_dict({"type": "probe"})
+        # Important: NOT MigrationRequiredError — "oops" is not legacy data.
+        assert not isinstance(exc_info.value, MigrationRequiredError)
+
+    def test_error_taxonomy_distinguishes_legacy_from_corrupt(self, tmp_path):
+        """Pure legacy → MigrationRequiredError; mixed/corrupt → integrity error."""
+        from assay.store import MigrationRequiredError, ReceiptStoreIntegrityError
+
+        # Pure legacy.
+        legacy_dir = tmp_path / "legacy_taxo"
+        day = legacy_dir / "2026-04-20"
+        day.mkdir(parents=True, exist_ok=True)
+        self._write_legacy_entry(
+            day / "trace_20260420T000000_aaaaaaaa.jsonl",
+            {"type": "legacy_only"},
+        )
+        store_legacy = AssayStore(base_dir=legacy_dir)
+        store_legacy.start_trace(trace_id="trace_legacy_attempt")
+        with pytest.raises(MigrationRequiredError):
+            store_legacy.append_dict({"type": "probe"})
+
+        # Mixed.
+        mixed_dir = tmp_path / "mixed_taxo"
+        day = mixed_dir / "2026-04-20"
+        day.mkdir(parents=True, exist_ok=True)
+        self._write_legacy_entry(
+            day / "trace_20260420T000000_aaaaaaaa.jsonl",
+            {"type": "leg"},
+        )
+        self._write_legacy_entry(
+            day / "trace_20260420T000000_aaaaaaaa.jsonl",
+            {"type": "stamped", "_store_seq": 99},
+        )
+        store_mixed = AssayStore(base_dir=mixed_dir)
+        store_mixed.start_trace(trace_id="trace_mixed_attempt")
+        with pytest.raises(ReceiptStoreIntegrityError):
+            store_mixed.append_dict({"type": "probe"})

--- a/tests/assay/test_store_hardening.py
+++ b/tests/assay/test_store_hardening.py
@@ -396,7 +396,17 @@ class TestBackwardCompat:
         assert entries[1]["type"] == "old2"
 
     def test_append_to_old_trace(self, tmp_path: Path) -> None:
-        """New store can append to traces created by old store."""
+        """New store can append to traces created by old store after migration.
+
+        Appending directly to a legacy trace is refused with
+        MigrationRequiredError — silently mixing unstamped legacy receipts
+        with new _store_seq-carrying ones would strand the store (mixed
+        state is refused by migrate_legacy_store_seq). The supported
+        rollout path is: migrate first, then append.
+        """
+        from assay.store import MigrationRequiredError
+        from assay.store_seq_migration import migrate_legacy_store_seq
+
         day_dir = tmp_path / "2026-01-01"
         day_dir.mkdir()
         trace_file = day_dir / "trace_old.jsonl"
@@ -404,6 +414,14 @@ class TestBackwardCompat:
             f.write(json.dumps({"type": "old", "_trace_id": "trace_old"}) + "\n")
 
         store = AssayStore(base_dir=tmp_path)
+        store.start_trace("trace_old")
+
+        # Direct append refused: legacy store has no _store_seq envelope.
+        with pytest.raises(MigrationRequiredError):
+            store.append_dict({"type": "new"})
+
+        # Migrate, then append succeeds.
+        migrate_legacy_store_seq(store)
         store.start_trace("trace_old")
         store.append_dict({"type": "new"})
 


### PR DESCRIPTION
## Summary

Implements the Slice 1 commitment-fulfillment wedge and hardens receipt-store ordering semantics.

New event types — `commitment.registered`, `result.observed`, `fulfillment.commitment_kept`, `fulfillment.commitment_broken` — plus `DOCTOR_COMMITMENT_001`, a reusable `PolicyResolver`, and the `_store_seq` order primitive that makes closure semantics honest at the storage layer.

The narrow invariant proved by this slice:

> Results do not close commitments; only ordered, policy-bound fulfillment receipts do.

## Commitment-fulfillment wedge

- `commitment.registered` — declared forward-looking commitment, requires a resolvable `policy_hash`
- `result.observed` — non-adjudicating observation; `references` list is typed but never closes anything
- `fulfillment.commitment_kept` / `fulfillment.commitment_broken` — terminal closure, guards four invariants before emit:
  1. Policy binding consistent and resolvable
  2. Referenced commitment exists (`commitment.registered` receipt on disk)
  3. Referenced result exists AND its `references` explicitly anchor `{kind:"commitment", id:C}`
  4. No prior terminal names this commitment (zero-or-one terminal invariant)
- `DOCTOR_COMMITMENT_001` — detects overdue open commitments; walks receipts in `_store_seq` order, treats a terminal as closure only if at its encounter point the anchor edge exists

## Storage contract hardening

- write-path strict validation rejects duplicate `_store_seq`
- write-path strict validation rejects within-file `_store_seq` regressions
- present-but-invalid `_store_seq` values are treated as corpus corruption, not legacy receipts
- `.store_seq` no longer pardons mixed or corrupt stores
- cross-process-safe allocator: `fcntl.flock(LOCK_EX)` on `<base_dir>/.store_seq`, allocation and persistence held in a single critical section
- fail-closed on unreadable files and malformed JSON lines

Taxonomy:

| Corpus state | Write behavior |
|---|---|
| empty | allowed; `next_seq = 0` |
| current (all stamped + valid) | allowed; `next_seq = max(counter, max+1)` |
| pure legacy (all receipts missing `_store_seq`) | `MigrationRequiredError` |
| mixed (stamped AND legacy receipts present) | `ReceiptStoreIntegrityError` |
| corrupt (duplicate / regressing / non-integer / unreadable / malformed) | `ReceiptStoreIntegrityError` |

## Legacy migration path

`python -m assay.store_seq_migration <base_dir>` backfills `_store_seq` on pre-Slice-1 stores using `(path, line)` order. Refuses mixed state. Refuses pre-existing duplicates. Idempotent. Atomic per-file `.tmp`+rename rewrites. Emits a `MigrationResult` audit summary.

Exit codes: `0` success, `2` usage, `3` `StoreMigrationError`, `4` `ReceiptStoreIntegrityError`.

## Proof run

Targeted local regression proof for the most recent review round:

```bash
.venv/bin/python -m pytest tests/assay/test_commitment_lifecycle.py -q --no-header --tb=short \
  -k 'duplicate_store_seq_fails_closed or duplicate_store_seq_in_corpus_refuses_write or within_file_store_seq_regression_refuses_write or non_integer_store_seq_is_integrity_error_not_migration'
```

Result: **4 passed, 84 deselected, 2 warnings** — no blocking findings on `6de2437`.

Broader scope:

- Commitment lifecycle + store hardening tests: **110 passing** in this branch
- Focused + adjacent (`test_contradiction_detector`, `test_doctor`): passing
- Full `tests/assay/` on a clean-`~/.assay` machine: identical failing set to `origin/main` (54 pre-existing failures in `test_trust_cli`, `test_v2_sign`, `test_xray`, unrelated to Slice 1)

## Test plan

- [ ] CI runs focused lifecycle + store hardening tests
- [ ] CI runs the broader `tests/assay/` suite on a clean store
- [ ] Confirm failing test set matches `origin/main` baseline (no new regressions)
- [ ] One fresh human review pass against this diff before promoting out of draft

## Residual risks / follow-ups (non-blockers)

- Write-time validation is currently full-corpus and O(corpus) per write. Fine for Slice 1; will need incremental/cached validation as stores grow.
- Mixed-state repair tooling is intentionally out of scope. Current contract is "refuse + escalate," not "self-heal." A future slice can add `assay store repair-mixed` with explicit operator consent.
- Pytest `asyncio_mode` / `asyncio_default_fixture_loop_scope` config warnings remain, unrelated to this change.
- Slice 2 (obligation side of the wedge) remains blocked on adjudicating the pre-existing `src/assay/obligation.py` namespace (override-debt semantics) vs the Loom `authority_nouns.md` inherited-duty meaning.

## Review state

Opened as a draft. Please let CI run and give this one fresh review pass before marking ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
