### PR TITLE
feat(commitments): add list and overdue CLI commands

### DIFF
--- a/src/assay/commitment_explain.py
+++ b/src/assay/commitment_explain.py
@@ -49,6 +49,10 @@ from assay.commitment_fulfillment import (
     TERMINAL_FULFILLMENT_TYPES,
     _iter_all_receipts,
 )
+from assay.commitment_summary import (
+    SummariesResult,
+    summarize_all_commitments,
+)
 from assay.store import (
     AssayStore,
     ReceiptStoreIntegrityError,
@@ -322,7 +326,8 @@ commitments_app = typer.Typer(
     name="commitments",
     help=(
         "Commitment-lifecycle operator surface. "
-        "Subcommands: explain (inspect a single commitment's state)."
+        "Subcommands: list (all commitments), overdue (OPEN past due_at), "
+        "explain (single commitment state)."
     ),
     no_args_is_help=True,
 )
@@ -394,10 +399,143 @@ def explain_commitment_cmd(
     typer.echo(f"  {result.decision}")
 
 
+def _resolve_store(base_dir: Optional[Path]) -> AssayStore:
+    """Shared base-dir resolution for commitments_app subcommands."""
+    if base_dir is not None:
+        return AssayStore(base_dir=base_dir)
+    return get_default_store()
+
+
+def _format_summary_line(s) -> str:
+    """One-line operator text for a CommitmentSummary. Stable shape for
+    easy grepping by operators; tests should assert structured fields
+    from ``--json``, not this prose format.
+    """
+    overdue_marker = " [OVERDUE]" if s.is_overdue else ""
+    closing = (
+        f" via seq={s.closing_terminal_seq} ({s.closing_terminal_type})"
+        if s.closing_terminal_seq is not None
+        else ""
+    )
+    return (
+        f"{s.commitment_id}  {s.state}{overdue_marker}  "
+        f"registered_seq={s.registered_seq}  "
+        f"due={s.due_at or 'perpetual'}  actor={s.actor_id}{closing}"
+    )
+
+
+@commitments_app.command("list")
+def list_commitments_cmd(
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit the result as JSON instead of plain text.",
+    ),
+    base_dir: Optional[Path] = typer.Option(
+        None,
+        "--base-dir",
+        help=(
+            "Override the default AssayStore location. Useful for "
+            "inspecting a specific store; defaults to ~/.assay."
+        ),
+    ),
+) -> None:
+    """List all commitments in the store with their current state.
+
+    Open commitments past their ``due_at`` are flagged ``[OVERDUE]``.
+    Read-only: does not mutate store state, does not emit receipts.
+
+    Exits nonzero if the store fails strict integrity validation.
+    """
+    store = _resolve_store(base_dir)
+    result = summarize_all_commitments(store)
+
+    if json_output:
+        typer.echo(json.dumps(result.to_dict(), indent=2))
+        if result.integrity_error:
+            raise typer.Exit(1)
+        return
+
+    if result.integrity_error:
+        typer.echo(f"INVALID_STORE: {result.integrity_error}")
+        raise typer.Exit(1)
+
+    if not result.commitments:
+        typer.echo("No commitments registered.")
+        return
+
+    typer.echo(
+        f"{len(result.commitments)} commitment(s) "
+        f"(scanned_at={result.scanned_at})"
+    )
+    for s in result.commitments:
+        typer.echo(_format_summary_line(s))
+        if s.text:
+            typer.echo(f"    {s.text}")
+
+
+@commitments_app.command("overdue")
+def overdue_commitments_cmd(
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit the result as JSON instead of plain text.",
+    ),
+    base_dir: Optional[Path] = typer.Option(
+        None,
+        "--base-dir",
+        help=(
+            "Override the default AssayStore location. Useful for "
+            "inspecting a specific store; defaults to ~/.assay."
+        ),
+    ),
+) -> None:
+    """Show only commitments that are OPEN and past their ``due_at``.
+
+    Filtered view over the same bulk scan used by ``commitments list``.
+    Read-only: does not mutate store state, does not emit receipts.
+
+    Exits nonzero if the store fails strict integrity validation.
+    """
+    store = _resolve_store(base_dir)
+    full_result = summarize_all_commitments(store)
+    overdue_only = [c for c in full_result.commitments if c.is_overdue]
+    filtered = SummariesResult(
+        commitments=overdue_only,
+        scanned_at=full_result.scanned_at,
+        integrity_error=full_result.integrity_error,
+    )
+
+    if json_output:
+        typer.echo(json.dumps(filtered.to_dict(), indent=2))
+        if filtered.integrity_error:
+            raise typer.Exit(1)
+        return
+
+    if filtered.integrity_error:
+        typer.echo(f"INVALID_STORE: {filtered.integrity_error}")
+        raise typer.Exit(1)
+
+    if not overdue_only:
+        typer.echo("No overdue commitments.")
+        return
+
+    typer.echo(
+        f"{len(overdue_only)} overdue commitment(s) "
+        f"(scanned_at={filtered.scanned_at})"
+    )
+    for s in overdue_only:
+        typer.echo(_format_summary_line(s))
+        if s.text:
+            typer.echo(f"    {s.text}")
+
+
 __all__ = [
     "ExplainLine",
     "ExplainResult",
     "explain_commitment",
     "commitments_app",
     "explain_commitment_cmd",
+    "list_commitments_cmd",
+    "overdue_commitments_cmd",
 ]

--- a/src/assay/commitment_explain.py
+++ b/src/assay/commitment_explain.py
@@ -50,6 +50,7 @@ from assay.commitment_fulfillment import (
     _iter_all_receipts,
 )
 from assay.commitment_summary import (
+    CommitmentSummary,
     SummariesResult,
     summarize_all_commitments,
 )
@@ -406,10 +407,11 @@ def _resolve_store(base_dir: Optional[Path]) -> AssayStore:
     return get_default_store()
 
 
-def _format_summary_line(s) -> str:
-    """One-line operator text for a CommitmentSummary. Stable shape for
-    easy grepping by operators; tests should assert structured fields
-    from ``--json``, not this prose format.
+def _format_summary_line(s: CommitmentSummary) -> str:
+    """One-line operator text for a :class:`CommitmentSummary`.
+
+    Stable shape for easy grepping by operators; tests should assert
+    structured fields from ``--json``, not this prose format.
     """
     overdue_marker = " [OVERDUE]" if s.is_overdue else ""
     closing = (

--- a/src/assay/commitment_summary.py
+++ b/src/assay/commitment_summary.py
@@ -1,0 +1,229 @@
+"""Single-pass bulk summary of every commitment in the store.
+
+Used as the shared data source for ``assay commitments list`` and
+``assay commitments overdue``. The underlying walk is the same
+causal-order primitive the detector/explainer trust
+(``_iter_all_receipts``); this module never re-implements lifecycle
+semantics — it just aggregates them in one pass.
+
+Design constraint (from slice review):
+    ``list`` must NOT call ``explain_commitment`` per id (N×corpus
+    rescan). This module does one full-store walk and emits a per-
+    commitment summary; ``overdue`` is a filtered view over the same
+    summaries.
+
+Read-only. Fails closed on corrupt / mixed / legacy corpus by returning
+an empty summaries list with ``integrity_error`` set — callers decide
+whether to exit nonzero or continue.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from assay.commitment_fulfillment import (
+    COMMITMENT_REGISTRATION_RECEIPT_TYPE,
+    RESULT_OBSERVATION_RECEIPT_TYPE,
+    TERMINAL_FULFILLMENT_TYPES,
+    _iter_all_receipts,
+)
+from assay.store import AssayStore, ReceiptStoreIntegrityError
+
+
+@dataclass(frozen=True)
+class CommitmentSummary:
+    """Compact per-commitment state for list/overdue views."""
+
+    commitment_id: str
+    state: str  # OPEN | CLOSED
+    actor_id: str
+    text: str
+    commitment_type: str
+    due_at: Optional[str]
+    registered_seq: int
+    closing_terminal_seq: Optional[int]
+    closing_terminal_type: Optional[str]
+    is_overdue: bool
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "commitment_id": self.commitment_id,
+            "state": self.state,
+            "actor_id": self.actor_id,
+            "text": self.text,
+            "commitment_type": self.commitment_type,
+            "due_at": self.due_at,
+            "registered_seq": self.registered_seq,
+            "closing_terminal_seq": self.closing_terminal_seq,
+            "closing_terminal_type": self.closing_terminal_type,
+            "is_overdue": self.is_overdue,
+        }
+
+
+@dataclass(frozen=True)
+class SummariesResult:
+    """Output of ``summarize_all_commitments``.
+
+    ``integrity_error`` is ``None`` on a clean walk; otherwise
+    ``commitments`` is empty and the error message describes the
+    integrity failure (malformed JSON, missing ``_store_seq``, etc.).
+    """
+
+    commitments: List[CommitmentSummary]
+    scanned_at: str
+    integrity_error: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "commitments": [c.to_dict() for c in self.commitments],
+            "scanned_at": self.scanned_at,
+            "integrity_error": self.integrity_error,
+        }
+
+
+def summarize_all_commitments(
+    store: AssayStore,
+    *,
+    now: Optional[datetime] = None,
+) -> SummariesResult:
+    """Bulk-summarize every commitment in ``store`` in one corpus pass.
+
+    Closure rule matches the detector/explainer: a terminal closes
+    commitment C iff, at the terminal's ``_store_seq`` encounter point:
+
+        - C has been registered
+        - some prior ``result.observed`` carries the terminal's
+          ``result_id`` AND lists ``{"kind": "commitment", "id": C}``
+          in its ``references``
+
+    Later observations do not retroactively legitimize earlier terminals.
+    The first valid terminal wins per commitment; later valid-looking
+    terminals are ignored (they would be ``invalid anchor`` in the
+    explainer's timeline).
+
+    Returns an empty list with ``integrity_error`` set on
+    ``ReceiptStoreIntegrityError`` from the underlying iterator.
+    """
+    reference = now or datetime.now(timezone.utc)
+    scanned_at = reference.isoformat()
+
+    try:
+        entries = list(_iter_all_receipts(store))
+    except ReceiptStoreIntegrityError as exc:
+        return SummariesResult(
+            commitments=[],
+            scanned_at=scanned_at,
+            integrity_error=str(exc),
+        )
+
+    registered: Dict[str, Dict[str, Any]] = {}
+    observed_result_anchors: Dict[str, Set[str]] = {}
+    closing_terminals: Dict[str, Tuple[int, str]] = {}
+
+    for entry in entries:
+        rt = str(entry.get("type") or entry.get("receipt_type") or "")
+        seq = entry.get("_store_seq")
+        if not isinstance(seq, int) or isinstance(seq, bool):
+            # Defensive: _iter_all_receipts already enforces this.
+            continue
+
+        if rt == COMMITMENT_REGISTRATION_RECEIPT_TYPE:
+            cmt_id = entry.get("commitment_id")
+            if cmt_id and cmt_id not in registered:
+                registered[str(cmt_id)] = {
+                    "registered_seq": seq,
+                    "actor_id": str(entry.get("actor_id") or ""),
+                    "text": str(entry.get("text") or ""),
+                    "commitment_type": str(entry.get("commitment_type") or ""),
+                    "due_at": entry.get("due_at") or None,
+                }
+            continue
+
+        if rt == RESULT_OBSERVATION_RECEIPT_TYPE:
+            result_id = entry.get("result_id")
+            if not result_id:
+                continue
+            for ref in entry.get("references") or []:
+                if (
+                    isinstance(ref, dict)
+                    and ref.get("kind") == "commitment"
+                    and ref.get("id")
+                ):
+                    observed_result_anchors.setdefault(
+                        str(result_id), set()
+                    ).add(str(ref["id"]))
+            continue
+
+        if rt in TERMINAL_FULFILLMENT_TYPES:
+            cmt_id = entry.get("commitment_id")
+            result_id = entry.get("result_id")
+            if not cmt_id or not result_id:
+                continue
+            cmt_s = str(cmt_id)
+            result_s = str(result_id)
+            if cmt_s not in registered:
+                continue
+            if cmt_s not in observed_result_anchors.get(result_s, set()):
+                continue
+            # First valid terminal wins. Later terminals for an already-
+            # closed commitment are ignored for summary purposes.
+            if cmt_s not in closing_terminals:
+                closing_terminals[cmt_s] = (seq, rt)
+            continue
+
+    summaries: List[CommitmentSummary] = []
+    # Stable order: by registered_seq so CLI output is reproducible.
+    for cmt_id, info in sorted(
+        registered.items(), key=lambda item: item[1]["registered_seq"]
+    ):
+        closing = closing_terminals.get(cmt_id)
+        state = "CLOSED" if closing else "OPEN"
+        closing_seq = closing[0] if closing else None
+        closing_type = closing[1] if closing else None
+
+        is_overdue = False
+        if state == "OPEN" and info["due_at"]:
+            parsed = _parse_iso(str(info["due_at"]))
+            if parsed is not None and parsed < reference:
+                is_overdue = True
+
+        summaries.append(
+            CommitmentSummary(
+                commitment_id=cmt_id,
+                state=state,
+                actor_id=info["actor_id"],
+                text=info["text"],
+                commitment_type=info["commitment_type"],
+                due_at=info["due_at"],
+                registered_seq=info["registered_seq"],
+                closing_terminal_seq=closing_seq,
+                closing_terminal_type=closing_type,
+                is_overdue=is_overdue,
+            )
+        )
+
+    return SummariesResult(commitments=summaries, scanned_at=scanned_at)
+
+
+def _parse_iso(value: str) -> Optional[datetime]:
+    """Parse ISO-8601; return None if unparseable."""
+    if not value:
+        return None
+    v = value.strip()
+    if v.endswith("Z"):
+        v = v[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(v)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+__all__ = [
+    "CommitmentSummary",
+    "SummariesResult",
+    "summarize_all_commitments",
+]

--- a/tests/assay/test_commitments_list_overdue.py
+++ b/tests/assay/test_commitments_list_overdue.py
@@ -1,0 +1,450 @@
+"""Tests for ``assay commitments list`` and ``assay commitments overdue``.
+
+These commands round out the operator surface for the commitment
+wedge. They share a single-pass corpus scan (``summarize_all_commitments``)
+and differ only in how they filter/render the same summaries.
+
+Scope discipline:
+    - Read-only. No writes, no receipt emissions, no ``.store_seq``
+      mutation.
+    - Same data source as ``explain`` and the detector
+      (``_iter_all_receipts``) — no parallel rule.
+    - Top-level CLI integration tests go through ``assay_app``, not
+      the sub-app in isolation (same regression canary as PR #83).
+    - Tests assert structured JSON fields, not fragile prose.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from assay.commitment_closure_detector import detect_open_overdue_commitments
+from assay.commitment_fulfillment import (
+    COMMITMENT_REGISTRATION_RECEIPT_TYPE,
+    FULFILLMENT_COMMITMENT_KEPT_RECEIPT_TYPE,
+    RESULT_OBSERVATION_RECEIPT_TYPE,
+)
+from assay.commitment_summary import (
+    CommitmentSummary,
+    SummariesResult,
+    summarize_all_commitments,
+)
+from assay.store import AssayStore
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_store(tmp_path):
+    return AssayStore(base_dir=tmp_path / "store")
+
+
+def _write_registered(store, commitment_id, *, actor_id="alice", due_at=None,
+                      text=None, commitment_type="delivery"):
+    data = {
+        "type": COMMITMENT_REGISTRATION_RECEIPT_TYPE,
+        "commitment_id": commitment_id,
+        "episode_id": "ep_test",
+        "actor_id": actor_id,
+        "text": text or f"Commitment {commitment_id}.",
+        "commitment_type": commitment_type,
+        "policy_hash": "sha256:" + "c" * 64,
+        "timestamp": "2026-04-20T10:00:00.000Z",
+    }
+    if due_at is not None:
+        data["due_at"] = due_at
+    store.append_dict(data)
+
+
+def _write_result(store, result_id, *, references=None):
+    store.append_dict({
+        "type": RESULT_OBSERVATION_RECEIPT_TYPE,
+        "result_id": result_id,
+        "episode_id": "ep_test",
+        "text": f"Observed {result_id}.",
+        "evidence_uri": "file:///tmp/evidence.log",
+        "policy_hash": "sha256:" + "c" * 64,
+        "references": references or [],
+        "timestamp": "2026-04-20T11:00:00.000Z",
+    })
+
+
+def _write_kept(store, commitment_id, result_id):
+    store.append_dict({
+        "type": FULFILLMENT_COMMITMENT_KEPT_RECEIPT_TYPE,
+        "fulfillment_id": f"ful_{commitment_id}",
+        "episode_id": "ep_test",
+        "commitment_id": commitment_id,
+        "result_id": result_id,
+        "evaluator": "test",
+        "evaluator_version": "0.1",
+        "policy_hash": "sha256:" + "c" * 64,
+        "timestamp": "2026-04-20T12:00:00.000Z",
+    })
+
+
+# ---------------------------------------------------------------------------
+# 1. summarize_all_commitments core behavior
+# ---------------------------------------------------------------------------
+
+
+class TestSummarize:
+    """The shared bulk-scan helper."""
+
+    def test_empty_store(self, tmp_store):
+        result = summarize_all_commitments(tmp_store)
+        assert isinstance(result, SummariesResult)
+        assert result.commitments == []
+        assert result.integrity_error is None
+
+    def test_single_open_not_overdue(self, tmp_store):
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_future",
+                          due_at="2099-01-01T00:00:00Z")
+        result = summarize_all_commitments(tmp_store)
+        assert len(result.commitments) == 1
+        s = result.commitments[0]
+        assert s.commitment_id == "cmt_future"
+        assert s.state == "OPEN"
+        assert s.is_overdue is False
+        assert s.closing_terminal_seq is None
+
+    def test_single_open_overdue(self, tmp_store):
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_late",
+                          due_at="2020-01-01T00:00:00Z")
+        result = summarize_all_commitments(tmp_store)
+        assert len(result.commitments) == 1
+        s = result.commitments[0]
+        assert s.state == "OPEN"
+        assert s.is_overdue is True
+
+    def test_single_closed(self, tmp_store):
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_done",
+                          due_at="2020-01-01T00:00:00Z")
+        _write_result(tmp_store, "res_1",
+                      references=[{"kind": "commitment", "id": "cmt_done"}])
+        _write_kept(tmp_store, "cmt_done", "res_1")
+        result = summarize_all_commitments(tmp_store)
+        assert len(result.commitments) == 1
+        s = result.commitments[0]
+        assert s.state == "CLOSED"
+        # is_overdue is False for closed commitments regardless of due_at.
+        assert s.is_overdue is False
+        assert s.closing_terminal_seq is not None
+        assert s.closing_terminal_type == FULFILLMENT_COMMITMENT_KEPT_RECEIPT_TYPE
+
+    def test_perpetual_open_never_overdue(self, tmp_store):
+        """A commitment with no due_at is perpetual, never overdue."""
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_perpetual", due_at=None)
+        result = summarize_all_commitments(tmp_store)
+        assert len(result.commitments) == 1
+        assert result.commitments[0].state == "OPEN"
+        assert result.commitments[0].is_overdue is False
+
+    def test_mixed_view(self, tmp_store):
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_open_future",
+                          due_at="2099-01-01T00:00:00Z")
+        _write_registered(tmp_store, "cmt_open_overdue",
+                          due_at="2020-01-01T00:00:00Z")
+        _write_registered(tmp_store, "cmt_closed",
+                          due_at="2020-06-01T00:00:00Z")
+        _write_result(tmp_store, "res_closed",
+                      references=[{"kind": "commitment", "id": "cmt_closed"}])
+        _write_kept(tmp_store, "cmt_closed", "res_closed")
+
+        result = summarize_all_commitments(tmp_store)
+        by_id = {s.commitment_id: s for s in result.commitments}
+        assert by_id["cmt_open_future"].state == "OPEN"
+        assert by_id["cmt_open_future"].is_overdue is False
+        assert by_id["cmt_open_overdue"].state == "OPEN"
+        assert by_id["cmt_open_overdue"].is_overdue is True
+        assert by_id["cmt_closed"].state == "CLOSED"
+        assert by_id["cmt_closed"].is_overdue is False
+
+    def test_order_is_by_registered_seq(self, tmp_store):
+        """Summaries are returned in registration (causal) order."""
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_first")
+        _write_registered(tmp_store, "cmt_second")
+        _write_registered(tmp_store, "cmt_third")
+        result = summarize_all_commitments(tmp_store)
+        ids = [s.commitment_id for s in result.commitments]
+        assert ids == ["cmt_first", "cmt_second", "cmt_third"]
+        seqs = [s.registered_seq for s in result.commitments]
+        assert seqs == sorted(seqs)
+
+
+# ---------------------------------------------------------------------------
+# 2. Invariant: detector and summarizer agree on overdue set
+# ---------------------------------------------------------------------------
+
+
+class TestDetectorSummarizerAgreement:
+    """``detect_open_overdue_commitments`` and ``summarize_all_commitments``
+    must produce the same overdue set. Both use the same ``_iter_all_receipts``
+    and the same anchored-terminal rule; divergence would indicate a fork
+    in closure semantics between the two readers.
+    """
+
+    def test_overdue_set_matches_detector(self, tmp_store):
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_a", due_at="2020-01-01T00:00:00Z")
+        _write_registered(tmp_store, "cmt_b", due_at="2020-02-01T00:00:00Z")
+        _write_registered(tmp_store, "cmt_c", due_at="2099-01-01T00:00:00Z")
+        _write_registered(tmp_store, "cmt_d", due_at="2020-03-01T00:00:00Z")
+        _write_result(tmp_store, "res_d",
+                      references=[{"kind": "commitment", "id": "cmt_d"}])
+        _write_kept(tmp_store, "cmt_d", "res_d")
+
+        detector = detect_open_overdue_commitments(tmp_store)
+        summaries = summarize_all_commitments(tmp_store)
+
+        det_ids = {c.commitment_id for c in detector.open_commitments}
+        sum_overdue_ids = {s.commitment_id for s in summaries.commitments if s.is_overdue}
+        assert det_ids == sum_overdue_ids
+
+
+# ---------------------------------------------------------------------------
+# 3. Read-only invariant
+# ---------------------------------------------------------------------------
+
+
+class TestSummarizeIsReadOnly:
+    def test_summarize_does_not_mutate_store(self, tmp_store):
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_ro", due_at="2020-01-01T00:00:00Z")
+        seq_before = (tmp_store.base_dir / ".store_seq").read_text()
+
+        summarize_all_commitments(tmp_store)
+        summarize_all_commitments(tmp_store)  # call twice; still no writes
+
+        seq_after = (tmp_store.base_dir / ".store_seq").read_text()
+        assert seq_before == seq_after
+
+
+# ---------------------------------------------------------------------------
+# 4. INVALID_STORE behavior
+# ---------------------------------------------------------------------------
+
+
+class TestSummarizeInvalidStore:
+    def test_malformed_json_line(self, tmp_store):
+        tmp_store.start_trace()
+        _write_registered(tmp_store, "cmt_x", due_at="2099-01-01T00:00:00Z")
+        trace_files = sorted(tmp_store.base_dir.rglob("trace_*.jsonl"))
+        with open(trace_files[-1], "a") as f:
+            f.write("{not valid json\n")
+
+        result = summarize_all_commitments(tmp_store)
+        assert result.commitments == []
+        assert result.integrity_error is not None
+
+
+# ---------------------------------------------------------------------------
+# 5. Sub-app CLI smoke (bypasses assay_app; keep for fast iteration)
+# ---------------------------------------------------------------------------
+
+
+class TestSubAppCLI:
+    def test_list_empty_plain(self, tmp_path):
+        from typer.testing import CliRunner
+        from assay.commitment_explain import commitments_app
+
+        runner = CliRunner()
+        result = runner.invoke(
+            commitments_app, ["list", "--base-dir", str(tmp_path / "s")]
+        )
+        assert result.exit_code == 0, result.output
+        assert "No commitments" in result.output
+
+    def test_list_json_structure(self, tmp_path):
+        from typer.testing import CliRunner
+        from assay.commitment_explain import commitments_app
+
+        base = tmp_path / "s"
+        store = AssayStore(base_dir=base)
+        store.start_trace()
+        _write_registered(store, "cmt_one", due_at="2020-01-01T00:00:00Z")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            commitments_app,
+            ["list", "--base-dir", str(base), "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert "commitments" in parsed
+        assert len(parsed["commitments"]) == 1
+        assert parsed["commitments"][0]["commitment_id"] == "cmt_one"
+        assert parsed["commitments"][0]["state"] == "OPEN"
+        assert parsed["commitments"][0]["is_overdue"] is True
+
+    def test_overdue_filters_out_non_overdue(self, tmp_path):
+        from typer.testing import CliRunner
+        from assay.commitment_explain import commitments_app
+
+        base = tmp_path / "s"
+        store = AssayStore(base_dir=base)
+        store.start_trace()
+        _write_registered(store, "cmt_future", due_at="2099-01-01T00:00:00Z")
+        _write_registered(store, "cmt_past", due_at="2020-01-01T00:00:00Z")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            commitments_app,
+            ["overdue", "--base-dir", str(base), "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        ids = [c["commitment_id"] for c in parsed["commitments"]]
+        assert ids == ["cmt_past"]
+
+    def test_overdue_excludes_closed(self, tmp_path):
+        from typer.testing import CliRunner
+        from assay.commitment_explain import commitments_app
+
+        base = tmp_path / "s"
+        store = AssayStore(base_dir=base)
+        store.start_trace()
+        _write_registered(store, "cmt_done", due_at="2020-01-01T00:00:00Z")
+        _write_result(store, "res_1",
+                      references=[{"kind": "commitment", "id": "cmt_done"}])
+        _write_kept(store, "cmt_done", "res_1")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            commitments_app,
+            ["overdue", "--base-dir", str(base), "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert parsed["commitments"] == []
+
+
+# ---------------------------------------------------------------------------
+# 6. Top-level assay_app integration (regression canary)
+# ---------------------------------------------------------------------------
+
+
+class TestAssayAppIntegration:
+    """Invoke the real top-level ``assay_app`` — the surface users hit
+    via ``python -m assay.cli``. Sub-app tests alone miss dispatch-layer
+    regressions (this is the same class of bug PR #83 fixed when the
+    commitment sub-app was accidentally mounted at ``explain``).
+    """
+
+    def test_commitments_list_reachable_from_top_level(self, tmp_path):
+        from typer.testing import CliRunner
+        from assay.commands import assay_app
+
+        base = tmp_path / "topcli"
+        store = AssayStore(base_dir=base)
+        store.start_trace()
+        _write_registered(store, "cmt_top", due_at="2099-01-01T00:00:00Z")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            assay_app,
+            ["commitments", "list", "--base-dir", str(base), "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert len(parsed["commitments"]) == 1
+        assert parsed["commitments"][0]["commitment_id"] == "cmt_top"
+
+    def test_commitments_overdue_reachable_from_top_level(self, tmp_path):
+        from typer.testing import CliRunner
+        from assay.commands import assay_app
+
+        base = tmp_path / "topcli_overdue"
+        store = AssayStore(base_dir=base)
+        store.start_trace()
+        _write_registered(store, "cmt_late", due_at="2020-01-01T00:00:00Z")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            assay_app,
+            ["commitments", "overdue", "--base-dir", str(base), "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        ids = [c["commitment_id"] for c in parsed["commitments"]]
+        assert ids == ["cmt_late"]
+
+    def test_commitments_help_lists_all_three_subcommands(self):
+        """`assay commitments --help` must surface list, overdue, explain."""
+        from typer.testing import CliRunner
+        from assay.commands import assay_app
+
+        runner = CliRunner()
+        result = runner.invoke(assay_app, ["commitments", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "list" in result.output
+        assert "overdue" in result.output
+        assert "explain" in result.output
+
+    def test_assay_explain_still_goes_to_pack_explainer(self):
+        """Regression canary: adding new commitments subcommands must not
+        affect the top-level ``assay explain <pack_dir>`` dispatch.
+        """
+        from typer.testing import CliRunner
+        from assay.commands import assay_app
+
+        runner = CliRunner()
+        result = runner.invoke(
+            assay_app, ["explain", "/nonexistent/proof/pack", "--json"]
+        )
+        output = (result.output or "") + (result.stderr or "")
+        assert "No such command" not in output, output
+        assert "Missing command" not in output, output
+        assert "Got unexpected extra argument" not in output, output
+
+
+# ---------------------------------------------------------------------------
+# 7. CLI exits nonzero on corrupt store
+# ---------------------------------------------------------------------------
+
+
+class TestCliInvalidStoreExit:
+    def _populate_then_corrupt(self, base: Path):
+        store = AssayStore(base_dir=base)
+        store.start_trace()
+        _write_registered(store, "cmt_corrupt", due_at="2099-01-01T00:00:00Z")
+        trace_files = sorted(store.base_dir.rglob("trace_*.jsonl"))
+        with open(trace_files[-1], "a") as f:
+            f.write("{not valid json\n")
+
+    def test_list_exits_nonzero_on_corrupt_store(self, tmp_path):
+        from typer.testing import CliRunner
+        from assay.commitment_explain import commitments_app
+
+        base = tmp_path / "corrupt"
+        self._populate_then_corrupt(base)
+        runner = CliRunner()
+        result = runner.invoke(
+            commitments_app, ["list", "--base-dir", str(base)]
+        )
+        assert result.exit_code == 1, result.output
+        assert "INVALID_STORE" in result.output
+
+    def test_overdue_exits_nonzero_on_corrupt_store(self, tmp_path):
+        from typer.testing import CliRunner
+        from assay.commitment_explain import commitments_app
+
+        base = tmp_path / "corrupt_o"
+        self._populate_then_corrupt(base)
+        runner = CliRunner()
+        result = runner.invoke(
+            commitments_app, ["overdue", "--base-dir", str(base)]
+        )
+        assert result.exit_code == 1, result.output
+        assert "INVALID_STORE" in result.output

--- a/tests/assay/test_commitments_list_overdue.py
+++ b/tests/assay/test_commitments_list_overdue.py
@@ -448,3 +448,176 @@ class TestCliInvalidStoreExit:
         )
         assert result.exit_code == 1, result.output
         assert "INVALID_STORE" in result.output
+
+
+# ---------------------------------------------------------------------------
+# 8. Adversarial closure semantics (order / anchor hostility)
+# ---------------------------------------------------------------------------
+#
+# ``commitment_summary.py`` re-implements the anchored-terminal closure
+# projection. ``TestDetectorSummarizerAgreement`` above guards against
+# drift on the happy path. These tests add hostile-order cases so that
+# drift in any direction (summarizer closes something the detector would
+# leave open, or vice versa) also fails loudly.
+#
+# Longer-term, the three readers (detector / explainer / summarizer)
+# should consume a single ``project_commitment_lifecycle(store)``
+# primitive. Until that refactor lands, these tests are the tripwire.
+
+
+class TestAdversarialClosureSemantics:
+    """Hostile-order and wrong-anchor scenarios the summarizer must handle
+    identically to the detector/explainer. Tests run through the top-level
+    ``assay_app`` where natural, asserting structured JSON output — not
+    prose.
+    """
+
+    def _invoke_list_json(self, runner, base):
+        from assay.commands import assay_app
+
+        result = runner.invoke(
+            assay_app,
+            ["commitments", "list", "--base-dir", str(base), "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        return json.loads(result.output)
+
+    def _invoke_overdue_json(self, runner, base):
+        from assay.commands import assay_app
+
+        result = runner.invoke(
+            assay_app,
+            ["commitments", "overdue", "--base-dir", str(base), "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        return json.loads(result.output)
+
+    def test_terminal_before_result_observed_does_not_close(self, tmp_path):
+        """A terminal whose anchor observation appears *after* it in
+        ``_store_seq`` order must not be counted as a closure.
+
+        Same causal rule the detector enforces: at the terminal's
+        encounter point, the anchor edge must already be present. Later
+        observations do not retroactively legitimize earlier terminals.
+        """
+        from typer.testing import CliRunner
+
+        base = tmp_path / "adv_terminal_first"
+        store = AssayStore(base_dir=base)
+        store.start_trace()
+        _write_registered(store, "cmt_forged",
+                          due_at="2020-01-01T00:00:00Z")
+        # Forged terminal: no observation yet at this receipt-order point.
+        _write_kept(store, "cmt_forged", "res_late")
+        # Observation arrives AFTER — would have anchored, had order allowed.
+        _write_result(store, "res_late",
+                      references=[{"kind": "commitment", "id": "cmt_forged"}])
+
+        runner = CliRunner()
+        list_result = self._invoke_list_json(runner, base)
+        by_id = {c["commitment_id"]: c for c in list_result["commitments"]}
+        assert by_id["cmt_forged"]["state"] == "OPEN", (
+            f"terminal-before-observation must NOT close commitment; "
+            f"got state={by_id['cmt_forged']['state']!r}"
+        )
+        assert by_id["cmt_forged"]["is_overdue"] is True
+        assert by_id["cmt_forged"]["closing_terminal_seq"] is None
+
+        overdue_result = self._invoke_overdue_json(runner, base)
+        overdue_ids = [c["commitment_id"] for c in overdue_result["commitments"]]
+        assert "cmt_forged" in overdue_ids
+
+    def test_result_observed_after_terminal_does_not_retroactively_close(
+        self, tmp_path
+    ):
+        """Equivalent in spirit to the test above, phrased from the
+        observation side: appending a matching observation after the
+        terminal must not retroactively close the commitment."""
+        from typer.testing import CliRunner
+
+        base = tmp_path / "adv_observation_later"
+        store = AssayStore(base_dir=base)
+        store.start_trace()
+        _write_registered(store, "cmt_retro",
+                          due_at="2020-01-01T00:00:00Z")
+        _write_kept(store, "cmt_retro", "res_retro")
+        # Sequence of events *cannot* rescue the terminal after the fact.
+        _write_result(store, "res_retro",
+                      references=[{"kind": "commitment", "id": "cmt_retro"}])
+
+        runner = CliRunner()
+        list_result = self._invoke_list_json(runner, base)
+        by_id = {c["commitment_id"]: c for c in list_result["commitments"]}
+        assert by_id["cmt_retro"]["state"] == "OPEN"
+        assert by_id["cmt_retro"]["closing_terminal_seq"] is None
+
+    def test_terminal_citing_result_for_wrong_commitment_does_not_close(
+        self, tmp_path
+    ):
+        """A terminal whose ``result_id`` was observed but the observation's
+        references point to a *different* commitment must not close this
+        commitment. Bare result-id existence is not sufficient — the
+        anchor must be the specific ``(result_id, commitment_id)`` edge.
+        """
+        from typer.testing import CliRunner
+
+        base = tmp_path / "adv_wrong_anchor"
+        store = AssayStore(base_dir=base)
+        store.start_trace()
+        _write_registered(store, "cmt_A", due_at="2020-01-01T00:00:00Z")
+        _write_registered(store, "cmt_B", due_at="2020-01-01T00:00:00Z")
+        # res_B was observed *for cmt_B only*.
+        _write_result(store, "res_B",
+                      references=[{"kind": "commitment", "id": "cmt_B"}])
+        # Terminal tries to close cmt_A by citing res_B — not allowed.
+        _write_kept(store, "cmt_A", "res_B")
+
+        runner = CliRunner()
+        list_result = self._invoke_list_json(runner, base)
+        by_id = {c["commitment_id"]: c for c in list_result["commitments"]}
+        assert by_id["cmt_A"]["state"] == "OPEN", (
+            "terminal citing result observed for a different commitment "
+            "must NOT close this one"
+        )
+        # cmt_B was never fulfilled at all; must remain open too.
+        assert by_id["cmt_B"]["state"] == "OPEN"
+
+        overdue_ids = {
+            c["commitment_id"]
+            for c in self._invoke_overdue_json(runner, base)["commitments"]
+        }
+        assert overdue_ids == {"cmt_A", "cmt_B"}
+
+    def test_unparseable_due_at_is_treated_as_perpetual_not_overdue(
+        self, tmp_path
+    ):
+        """A commitment with an unparseable ``due_at`` string must not be
+        flagged as overdue. Treating malformed due dates as "past" would
+        be strictly worse than treating them as perpetual: malformed
+        data could be silent corruption, and guessing overdue on garbage
+        produces false operator alarms.
+        """
+        from typer.testing import CliRunner
+
+        base = tmp_path / "adv_bad_due_at"
+        store = AssayStore(base_dir=base)
+        store.start_trace()
+        _write_registered(
+            store,
+            "cmt_bad_due",
+            due_at="not-a-real-iso-8601-string",
+        )
+
+        runner = CliRunner()
+        list_result = self._invoke_list_json(runner, base)
+        by_id = {c["commitment_id"]: c for c in list_result["commitments"]}
+        assert by_id["cmt_bad_due"]["state"] == "OPEN"
+        assert by_id["cmt_bad_due"]["is_overdue"] is False, (
+            "unparseable due_at must not be treated as overdue"
+        )
+
+        overdue_ids = [
+            c["commitment_id"]
+            for c in self._invoke_overdue_json(runner, base)["commitments"]
+        ]
+        assert "cmt_bad_due" not in overdue_ids


### PR DESCRIPTION
## Summary

Rounds out the commitment operator surface. Adds two new read-only CLI commands to the existing `commitments_app` namespace:

- `assay commitments list` — all commitments, registered-seq order, with OVERDUE inline markers
- `assay commitments overdue` — filtered view showing only commitments that are OPEN and past their `due_at`

Both commands share a single bulk scan (`summarize_all_commitments`) — no N×rescan pattern.

## The three commitments subcommands, together

| Command | Intent |
|---|---|
| `assay commitments list` | Full view. All registered commitments with state (OPEN/CLOSED) and OVERDUE marker. |
| `assay commitments overdue` | Filtered view over the same summaries. Only `state == OPEN AND is_overdue == True`. |
| `assay commitments explain <id>` | Single-commitment deep dive (landed in PR #83). |

All three use the same causal-order primitive (`_iter_all_receipts` → `_store_seq`), fail closed on corrupt stores, and are strictly read-only.

## Design constraint honored

Per the review brief, `list` does **not** N×rescan via per-id `explain_commitment` calls:

```
summarize_all_commitments(store)    ← one corpus pass
  ├── list    → renders all summaries
  └── overdue → filters is_overdue and renders
```

`explain_commitment` is left untouched — different contract, different shape.

## What's in the PR (after hardening patch `ce120e5`)

| File | Role |
|---|---|
| `src/assay/commitment_summary.py` | **New, 223 LOC.** `CommitmentSummary`, `SummariesResult`, `summarize_all_commitments(store, *, now=None)`. One corpus pass; same closure rule as detector/explainer. |
| `src/assay/commitment_explain.py` | +145 LOC: two `@commitments_app.command` wrappers (`list`, `overdue`), shared `_resolve_store` / `_format_summary_line: CommitmentSummary -> str` helpers. Group help text updated. |
| `tests/assay/test_commitments_list_overdue.py` | **New, 24 tests across 8 classes.** |

No changes to `commands.py` — `commitments_app` was already mounted in PR #83; the two new subcommands attach to it.

## Test coverage (24 tests, 8 classes)

- `TestSummarize` — core helper: empty, open/not-overdue, open/overdue, closed, perpetual (no due_at), mixed view, causal registered_seq ordering
- `TestDetectorSummarizerAgreement` — cross-reader invariant: summarizer's overdue set equals `detect_open_overdue_commitments`'s open set
- `TestSummarizeIsReadOnly` — `.store_seq` unchanged across repeated scans
- `TestSummarizeInvalidStore` — malformed JSON → `integrity_error`, not silent data loss
- `TestSubAppCLI` — sub-app dispatch shape (empty / populated / overdue filters future / overdue excludes closed)
- `TestAssayAppIntegration` — real top-level `assay_app`: `commitments list`, `commitments overdue`, `--help` lists all three subcommands; `assay explain <pack_dir>` still routes to proof-pack explainer (PR #83 regression canary)
- `TestCliInvalidStoreExit` — nonzero exit + INVALID_STORE banner for both new commands
- **`TestAdversarialClosureSemantics` (new this round)** — hostile-order and wrong-anchor cases:
  - terminal before `result.observed` → must NOT close (causal order)
  - `result.observed` after terminal → must NOT retroactively close
  - terminal citing `result_id` observed for a different commitment → must NOT close this one
  - unparseable `due_at` → treated as perpetual, not overdue

All adversarial tests invoke the top-level `assay_app` via CliRunner and assert structured JSON — no fragile prose assertions.

## Test totals

- `test_commitments_list_overdue.py` — **24 passing** (20 original + 4 adversarial)
- Focused + adjacent (list/overdue + explain + lifecycle + terminal_invariant + contradiction_detector + doctor) — **204 passing, 0 failing**

## CI status

As of latest head, `MERGEABLE + CLEAN`, all triggered checks green (16/17 SUCCESS + 1 expected SKIPPED on the pre-hardening commit). CI will re-run against `ce120e5` post-push.

## End-to-end smoke (real CLI)

```
$ assay commitments list --base-dir /tmp/explain-smoke
1 commitment(s) (scanned_at=2026-04-20T...)
cmt_ship_widget  CLOSED  registered_seq=0  due=2026-04-18T00:00:00Z  actor=alice via seq=2 (fulfillment.commitment_kept)
    Ship widget by Friday.

$ assay commitments overdue --base-dir /tmp/explain-smoke
No overdue commitments.
```

## Test plan

- [x] CI runs `tests/assay/test_commitments_list_overdue.py` (24 tests)
- [x] CI runs the broader adjacent slice — zero regressions vs `origin/main` baseline
- [x] Adversarial closure-semantics tripwires added
- [ ] Wait for CI green on `ce120e5` before promoting to Ready

## Boundary held

- Read-only operator surface only
- Same `commitments_app` namespace as PR #83
- Same underlying data source as detector + explainer
- No new storage code, no ordering-model changes, no repair tooling, no Slice 2 work
- `explain_commitment` untouched

## Next refactor candidate (not this PR)

Three readers — `detect_open_overdue_commitments`, `explain_commitment`, `summarize_all_commitments` — now encode the anchored-terminal closure rule three times. The hostile-order tests guard against drift, but longer-term the right shape is:

```
project_commitment_lifecycle(store) -> CommitmentLifecycleProjection
```

Consumed by detector + explainer + summarizer, eliminating the three-readers-three-constitutions risk structurally. This is debt, not blocking. Queue after the global-vs-per-commitment `_store_seq` ordering memo.

## Review state

Draft. Awaiting CI green on `ce120e5`, then Ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
