### PR TITLE
refactor(commitments): extract shared lifecycle projection

### DIFF
--- a/src/assay/commitment_closure_detector.py
+++ b/src/assay/commitment_closure_detector.py
@@ -1,23 +1,22 @@
 """Commitment closure detector — DOCTOR_COMMITMENT_001.
 
-Pure-read scan of an AssayStore that flags ``commitment.registered`` receipts
-with a past ``due_at`` and no terminal fulfillment
-(``fulfillment.commitment_kept`` | ``fulfillment.commitment_broken``).
+Pure-read detection of overdue open commitments. Consumes the shared
+projection from
+:func:`assay.commitment_projection.project_commitment_lifecycle`;
+previously carried its own corpus walk.
 
-Mirrors ``contradiction_detector.py`` structurally. No mutations.
+Responsibility boundary:
+    This module contributes only the "overdue + open" filter. Closure
+    semantics, registration tracking, observation anchoring, and
+    validity checks all live in the projector now.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional
 
-from assay.commitment_fulfillment import (
-    COMMITMENT_REGISTRATION_RECEIPT_TYPE,
-    RESULT_OBSERVATION_RECEIPT_TYPE,
-    TERMINAL_FULFILLMENT_TYPES,
-    _iter_all_receipts,
-)
+from assay.commitment_projection import project_commitment_lifecycle
 from assay.store import AssayStore
 
 
@@ -76,14 +75,6 @@ class CommitmentClosureResult:
         }
 
 
-def _extract_receipt_type(entry: Dict[str, Any]) -> str:
-    return str(entry.get("type") or entry.get("receipt_type") or "")
-
-
-def _extract_timestamp(entry: Dict[str, Any]) -> str:
-    return str(entry.get("timestamp") or entry.get("_stored_at") or "")
-
-
 def _parse_iso(value: str) -> Optional[datetime]:
     """Parse ISO-8601; return None if unparseable."""
     if not value:
@@ -107,133 +98,66 @@ def detect_open_overdue_commitments(
 ) -> CommitmentClosureResult:
     """Scan a store for open, overdue commitments.
 
-    Closure rule (order-aware):
-        A terminal fulfillment closes commitment C if, *at the point the
-        terminal is encountered in receipt order*:
-          - C was already registered (``commitment.registered``); AND
-          - result R was already observed (``result.observed`` with
-            ``result_id == terminal.result_id``); AND
-          - that observation's ``references`` list explicitly carried
-            ``{"kind": "commitment", "id": C}``.
+    Closure semantics and corpus-walk logic are handled by the shared
+    projection (see :func:`project_commitment_lifecycle`). This
+    function's remaining job is the overdue filter:
 
-    Future observations cannot retroactively legitimize prior terminals.
-    Forged terminals written before any observation — or naming a result
-    that observed a different commitment — do not close anything.
+        - the commitment is registered
+        - no valid closure exists for it (per the projection)
+        - its ``due_at`` is parseable and in the past relative to ``now``
 
-    A commitment is "open and overdue" when:
-        - It is registered.
-        - Its ``due_at`` is parseable and in the past relative to ``now``.
-        - No valid closure edge was observed for it.
+    Commitments without ``due_at`` are treated as perpetual.
+    Commitments whose ``due_at`` is unparseable are also treated as
+    perpetual (conservative — matches pre-extraction behavior).
 
-    Commitments without ``due_at`` are treated as perpetual in Slice 1
-    and never flagged. Commitments whose ``due_at`` is unparseable are
-    treated conservatively as perpetual.
-
-    Scan is full-store and fail-closed: corruption surfaces as
-    ``ReceiptStoreIntegrityError``, not as missing evidence.
-
-    Args:
-        store: The AssayStore to scan.
-        now: Reference time for overdue comparison. Defaults to
-            ``datetime.now(timezone.utc)``.
-
-    Returns:
-        CommitmentClosureResult with all findings.
+    Corruption surfaces as ``ReceiptStoreIntegrityError`` from the
+    underlying projection walk; this function does not swallow it.
     """
     reference = now or datetime.now(timezone.utc)
-    scanned_at = reference.isoformat()
 
-    registered: Dict[str, Dict[str, Any]] = {}
-    # result_id -> set of commitment_ids the observation explicitly referenced.
-    observed_result_anchors: Dict[str, Set[str]] = {}
-    closed_ids: Set[str] = set()
-    trace_ids_seen: Set[str] = set()
+    projection = project_commitment_lifecycle(store, now=reference)
 
-    # Walk receipts in store order (path-sorted, then line order).
-    # _iter_all_receipts raises ReceiptStoreIntegrityError on corruption.
-    for entry in _iter_all_receipts(store):
-        rt = _extract_receipt_type(entry)
-        trace_id = str(entry.get("_trace_id") or "")
-        if trace_id:
-            trace_ids_seen.add(trace_id)
+    # Integrity failure parity: the pre-extraction detector propagated
+    # ``ReceiptStoreIntegrityError`` directly rather than returning a
+    # result with an error field. Preserve that contract so existing
+    # tests that expect a raised exception still work.
+    if projection.integrity_error is not None:
+        from assay.store import ReceiptStoreIntegrityError
 
-        if rt == COMMITMENT_REGISTRATION_RECEIPT_TYPE:
-            cmt_id = entry.get("commitment_id")
-            if cmt_id and cmt_id not in registered:
-                registered[cmt_id] = {
-                    "trace_id": trace_id,
-                    "trace_path": None,
-                    "episode_id": str(entry.get("episode_id") or ""),
-                    "actor_id": str(entry.get("actor_id") or ""),
-                    "text": str(entry.get("text") or ""),
-                    "commitment_type": str(entry.get("commitment_type") or ""),
-                    "registered_at": _extract_timestamp(entry),
-                    "due_at": str(entry.get("due_at") or ""),
-                }
-            continue
-
-        if rt == RESULT_OBSERVATION_RECEIPT_TYPE:
-            result_id = entry.get("result_id")
-            if not result_id:
-                continue
-            anchors = observed_result_anchors.setdefault(str(result_id), set())
-            for ref in entry.get("references") or []:
-                if (
-                    isinstance(ref, dict)
-                    and ref.get("kind") == "commitment"
-                    and ref.get("id")
-                ):
-                    anchors.add(str(ref["id"]))
-            continue
-
-        if rt in TERMINAL_FULFILLMENT_TYPES:
-            cmt_id = entry.get("commitment_id")
-            result_id = entry.get("result_id")
-            if not cmt_id or not result_id:
-                continue
-            cmt_id_s = str(cmt_id)
-            result_id_s = str(result_id)
-            # At the temporal point of THIS terminal:
-            #   - commitment must already be registered
-            #   - result must already be observed with this commitment in refs
-            if cmt_id_s not in registered:
-                continue  # terminal precedes registration — invalid
-            if cmt_id_s not in observed_result_anchors.get(result_id_s, set()):
-                continue  # no valid (result_id, commitment_id) edge yet — invalid
-            closed_ids.add(cmt_id_s)
-            continue
+        raise ReceiptStoreIntegrityError(projection.integrity_error)
 
     open_commitments: List[OpenOverdueCommitment] = []
-    for cmt_id, info in registered.items():
-        if cmt_id in closed_ids:
-            continue
-        due_at_str = info["due_at"]
-        if not due_at_str:
+    for cmt_id, reg in projection.registrations.items():
+        if cmt_id in projection.closures:
+            continue  # closed — not overdue
+        if not reg.due_at:
             continue  # perpetual
-        due_at_dt = _parse_iso(due_at_str)
-        if due_at_dt is None:
+        due_dt = _parse_iso(reg.due_at)
+        if due_dt is None:
             continue  # unparseable → perpetual (conservative)
-        if due_at_dt >= reference:
+        if due_dt >= reference:
             continue  # not yet overdue
-        open_commitments.append(OpenOverdueCommitment(
-            commitment_id=cmt_id,
-            trace_id=info["trace_id"],
-            episode_id=info["episode_id"],
-            actor_id=info["actor_id"],
-            text=info["text"],
-            commitment_type=info["commitment_type"],
-            registered_at=info["registered_at"],
-            due_at=info["due_at"],
-            trace_path=info["trace_path"],
-        ))
+        open_commitments.append(
+            OpenOverdueCommitment(
+                commitment_id=reg.commitment_id,
+                trace_id=reg.trace_id,
+                episode_id=reg.episode_id,
+                actor_id=reg.actor_id,
+                text=reg.text,
+                commitment_type=reg.commitment_type,
+                registered_at=reg.registered_at,
+                due_at=reg.due_at,
+                trace_path=None,
+            )
+        )
 
     return CommitmentClosureResult(
         open_commitments=open_commitments,
-        total_traces_scanned=len(trace_ids_seen),
-        total_registered_found=len(registered),
-        total_closed_found=len(closed_ids),
+        total_traces_scanned=projection.total_traces_scanned,
+        total_registered_found=len(projection.registrations),
+        total_closed_found=len(projection.closures),
         total_open_found=len(open_commitments),
-        scanned_at=scanned_at,
+        scanned_at=projection.scanned_at,
     )
 
 

--- a/src/assay/commitment_explain.py
+++ b/src/assay/commitment_explain.py
@@ -39,16 +39,15 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional
 
 import typer
 
 from assay.commitment_fulfillment import (
     COMMITMENT_REGISTRATION_RECEIPT_TYPE,
     RESULT_OBSERVATION_RECEIPT_TYPE,
-    TERMINAL_FULFILLMENT_TYPES,
-    _iter_all_receipts,
 )
+from assay.commitment_projection import project_commitment_lifecycle
 from assay.commitment_summary import (
     CommitmentSummary,
     SummariesResult,
@@ -56,7 +55,6 @@ from assay.commitment_summary import (
 )
 from assay.store import (
     AssayStore,
-    ReceiptStoreIntegrityError,
     get_default_store,
 )
 
@@ -104,26 +102,22 @@ class ExplainResult:
 
 
 def explain_commitment(store: AssayStore, commitment_id: str) -> ExplainResult:
-    """Walk ``store`` in ``_store_seq`` order and explain ``commitment_id``'s state.
+    """Explain ``commitment_id``'s state from the shared lifecycle projection.
 
     Pure-read. Fails closed on corpus corruption: returns
     ``state="INVALID_STORE"`` with the integrity error, rather than
     proceeding with partial / mixed / corrupt evidence.
 
-    Closure rule matches the detector:
-        A terminal fulfillment closes commitment C at the point it is
-        encountered IFF, at that seq position:
-            - C has been registered
-            - some prior result.observed receipt with result_id=R
-              exists whose references explicitly include
-              ``{"kind": "commitment", "id": C}``
-
-        Later observations cannot retroactively legitimize earlier
-        terminals.
+    Closure semantics come from
+    :func:`assay.commitment_projection.project_commitment_lifecycle`;
+    this function's remaining job is the per-commitment presentation:
+    selecting the commitment's own registration / anchor-observation /
+    terminal lines from the projection, building the timeline in
+    ``_store_seq`` order, and composing the plain-text decision string.
     """
-    try:
-        entries = list(_iter_all_receipts(store))
-    except ReceiptStoreIntegrityError as exc:
+    projection = project_commitment_lifecycle(store)
+
+    if projection.integrity_error is not None:
         return ExplainResult(
             commitment_id=commitment_id,
             state="INVALID_STORE",
@@ -134,126 +128,73 @@ def explain_commitment(store: AssayStore, commitment_id: str) -> ExplainResult:
                 "validation. Cannot reason about commitment state until the "
                 "store is repaired."
             ),
-            integrity_error=str(exc),
+            integrity_error=projection.integrity_error,
         )
 
+    reg_fact = projection.registrations.get(commitment_id)
+    closure_fact = projection.closures.get(commitment_id)
+
+    # Build the per-commitment timeline. The projection already has
+    # everything we need; we just filter and translate facts into the
+    # presentation-layer ``ExplainLine`` shape, then sort by seq.
+
     registration: Optional[ExplainLine] = None
-    timeline: List[ExplainLine] = []
-    # result_id -> set of commitment_ids whose anchor edge is present
-    # by the point we reach each receipt in seq order.
-    observed_result_anchors: Dict[str, Set[str]] = {}
+    if reg_fact is not None:
+        due_at_display = reg_fact.due_at if reg_fact.due_at else "perpetual"
+        registration = ExplainLine(
+            seq=reg_fact.seq,
+            receipt_type=COMMITMENT_REGISTRATION_RECEIPT_TYPE,
+            summary=(
+                f"registered by actor_id={reg_fact.actor_id!r}, "
+                f"due_at={due_at_display}"
+            ),
+            note="ok",
+        )
 
-    closing_terminal_seq: Optional[int] = None
-    closing_terminal_type: Optional[str] = None
-    closing_anchor_seq: Optional[int] = None
+    # Observation lines: only those referencing this commitment.
+    observation_lines: List[ExplainLine] = []
+    for obs in projection.observation_anchors:
+        if commitment_id not in obs.referenced_commitment_ids:
+            continue
+        observation_lines.append(
+            ExplainLine(
+                seq=obs.seq,
+                receipt_type=RESULT_OBSERVATION_RECEIPT_TYPE,
+                summary=f"observed result_id={obs.result_id!r}",
+                note="anchor edge present",
+            )
+        )
+
+    # Terminal lines: only those naming this commitment.
     terminal_lines_for_cmt: List[ExplainLine] = []
-
-    for entry in entries:
-        rt = str(entry.get("type") or entry.get("receipt_type") or "")
-        seq = entry.get("_store_seq")
-        if not isinstance(seq, int) or isinstance(seq, bool):
-            # _iter_all_receipts already fails closed on missing/invalid seq;
-            # this branch is defensive and should not be reachable.
+    for term in projection.terminals:
+        if term.commitment_id != commitment_id:
             continue
-
-        if rt == COMMITMENT_REGISTRATION_RECEIPT_TYPE:
-            if entry.get("commitment_id") != commitment_id:
-                continue
+        if term.is_valid_closure:
             line = ExplainLine(
-                seq=seq,
-                receipt_type=rt,
-                summary=(
-                    f"registered by actor_id={entry.get('actor_id', '?')!r}, "
-                    f"due_at={entry.get('due_at', 'perpetual')}"
-                ),
-                note="ok",
+                seq=term.seq,
+                receipt_type=term.receipt_type,
+                summary=f"fulfillment for result_id={term.result_id!r}",
+                note="closes commitment",
             )
-            if registration is None:
-                registration = line
-            timeline.append(line)
-            continue
-
-        if rt == RESULT_OBSERVATION_RECEIPT_TYPE:
-            result_id = entry.get("result_id")
-            if not result_id:
-                continue
-            referenced: Set[str] = set()
-            for ref in entry.get("references") or []:
-                if (
-                    isinstance(ref, dict)
-                    and ref.get("kind") == "commitment"
-                    and ref.get("id")
-                ):
-                    referenced.add(str(ref["id"]))
-            observed_result_anchors.setdefault(str(result_id), set()).update(
-                referenced
+        else:
+            reason_text = "; ".join(term.invalid_reasons) or "unknown"
+            line = ExplainLine(
+                seq=term.seq,
+                receipt_type=term.receipt_type,
+                summary=f"fulfillment for result_id={term.result_id!r}",
+                note=f"invalid anchor ({reason_text})",
             )
+        terminal_lines_for_cmt.append(line)
 
-            if commitment_id in referenced:
-                timeline.append(ExplainLine(
-                    seq=seq,
-                    receipt_type=rt,
-                    summary=f"observed result_id={result_id!r}",
-                    note="anchor edge present",
-                ))
-            continue
-
-        if rt in TERMINAL_FULFILLMENT_TYPES:
-            if entry.get("commitment_id") != commitment_id:
-                continue
-            result_id = str(entry.get("result_id") or "")
-            has_registration = registration is not None
-            anchors_for_result = observed_result_anchors.get(result_id, set())
-            has_anchor_edge = commitment_id in anchors_for_result
-            already_closed = closing_terminal_seq is not None
-            is_valid_closure = (
-                has_registration and has_anchor_edge and not already_closed
-            )
-
-            if is_valid_closure:
-                closing_terminal_seq = seq
-                closing_terminal_type = rt
-                # Find the most recent matching observation line for the
-                # decision text (seq of the anchor edge).
-                for prev in timeline:
-                    if (
-                        prev.receipt_type == RESULT_OBSERVATION_RECEIPT_TYPE
-                        and f"result_id={result_id!r}" in prev.summary
-                    ):
-                        closing_anchor_seq = prev.seq
-                line = ExplainLine(
-                    seq=seq,
-                    receipt_type=rt,
-                    summary=f"fulfillment for result_id={result_id!r}",
-                    note="closes commitment",
-                )
-            else:
-                reasons: List[str] = []
-                if not has_registration:
-                    reasons.append(
-                        "no registration seen before this terminal"
-                    )
-                if not has_anchor_edge:
-                    reasons.append(
-                        f"no anchor edge from result_id={result_id!r} "
-                        f"to commitment={commitment_id!r} "
-                        "at the terminal's encounter point"
-                    )
-                if already_closed:
-                    reasons.append(
-                        f"post-closure terminal (commitment already closed "
-                        f"by seq={closing_terminal_seq})"
-                    )
-                reason_text = "; ".join(reasons) or "unknown"
-                line = ExplainLine(
-                    seq=seq,
-                    receipt_type=rt,
-                    summary=f"fulfillment for result_id={result_id!r}",
-                    note=f"invalid anchor ({reason_text})",
-                )
-            timeline.append(line)
-            terminal_lines_for_cmt.append(line)
-            continue
+    # Compose the timeline in seq order. The projection guarantees seq
+    # is the authoritative causal key for this per-aggregate view.
+    timeline: List[ExplainLine] = []
+    if registration is not None:
+        timeline.append(registration)
+    timeline.extend(observation_lines)
+    timeline.extend(terminal_lines_for_cmt)
+    timeline.sort(key=lambda line: line.seq)
 
     # ----- Decision -----
 
@@ -269,17 +210,15 @@ def explain_commitment(store: AssayStore, commitment_id: str) -> ExplainResult:
             ),
         )
 
-    if closing_terminal_seq is not None:
+    if closure_fact is not None:
         anchor_hint = (
-            f" and anchor result.observed seq={closing_anchor_seq} "
+            f" and anchor result.observed seq={closure_fact.anchor_observation_seq} "
             "explicitly references this commitment"
-            if closing_anchor_seq is not None
-            else ""
         )
         decision = (
-            f"CLOSED because terminal {closing_terminal_type!r} "
-            f"seq={closing_terminal_seq} occurred with a valid anchor edge"
-            f"{anchor_hint}."
+            f"CLOSED because terminal {closure_fact.closing_terminal_type!r} "
+            f"seq={closure_fact.closing_terminal_seq} occurred with a valid "
+            f"anchor edge{anchor_hint}."
         )
         return ExplainResult(
             commitment_id=commitment_id,

--- a/src/assay/commitment_fulfillment.py
+++ b/src/assay/commitment_fulfillment.py
@@ -231,8 +231,14 @@ class FulfillmentBrokenArtifact:
 def _iter_all_receipts(store: AssayStore) -> Iterator[Dict[str, Any]]:
     """Iterate all receipts in store-wide ``_store_seq`` order.
 
-    Slice 1's receipt-order primitive is the monotonic ``_store_seq``
-    envelope field assigned by ``AssayStore.append`` / ``append_dict``.
+    ``_store_seq`` is the store's witnessed append order: the monotonic,
+    immutable envelope field assigned by ``AssayStore.append`` /
+    ``append_dict`` at write time. It is a STORAGE primitive — used for
+    deterministic traversal, tie-breaking, and tamper detection. It is
+    NOT a semantic global happens-before relation between unrelated
+    aggregates; that is always a per-aggregate question.
+    See ``docs/doctrine/COMMITMENT_ORDERING.md``.
+
     Lexicographic trace-path order is NOT a valid chronology because
     ``AssayStore.start_trace(trace_id=...)`` accepts arbitrary trace IDs.
 

--- a/src/assay/commitment_projection.py
+++ b/src/assay/commitment_projection.py
@@ -40,6 +40,19 @@ Purity contract:
     - No prose. No CLI formatting. No ``is_overdue`` derivation (that
       is a per-reader, ``now``-dependent derivation — the projector
       records the facts, consumers interpret them).
+
+Scope boundary (deliberate):
+    This module projects **commitment** lifecycle facts only.
+    Obligation lifecycle (Slice 2) must not be added here. The intended
+    shape when obligations land:
+
+        src/assay/commitment_projection.py  — this file
+        src/assay/obligation_projection.py  — Slice 2 sibling
+
+    Shared primitives go in a third module only if duplication becomes
+    materially painful; one-pass corpus walks are cheap, so the default
+    is two independent projections. Do not let "projection" become a
+    catch-all home for all doctrine logic.
 """
 from __future__ import annotations
 

--- a/src/assay/commitment_projection.py
+++ b/src/assay/commitment_projection.py
@@ -1,0 +1,366 @@
+"""Shared commitment-lifecycle projector.
+
+Single source of truth for the per-aggregate closure doctrine ratified
+in ``docs/doctrine/COMMITMENT_ORDERING.md``:
+
+    - Lifecycle semantics project per commitment.
+    - ``_store_seq`` is immutable witnessed append order; used for
+      traversal and tie-breaking, never as a semantic global order.
+    - A terminal fulfillment closes commitment ``C`` iff, at the
+      terminal's ``_store_seq`` encounter point:
+        * ``C`` was already registered, AND
+        * a prior ``result.observed`` with the terminal's ``result_id``
+          explicitly included ``{"kind": "commitment", "id": C}`` in
+          its ``references`` list.
+
+Before this module existed, the detector, explainer, and summarizer
+each re-derived that rule from ``_iter_all_receipts`` independently.
+Three readers, three near-identical walks, three opportunities for
+semantic drift. This module collapses them into one pass.
+
+Consumers (in order of how they derive their outputs from the
+projection):
+
+    1. ``commitment_summary.summarize_all_commitments``
+    2. ``commitment_closure_detector.detect_open_overdue_commitments``
+    3. ``commitment_explain.explain_commitment``
+
+The projector is behavior-preserving by construction — every fact it
+records is what each of the three readers already computed, just in a
+shared structured form.
+
+Purity contract:
+    - Read-only. Never calls ``store.append`` / ``append_dict``.
+    - Walks via ``_iter_all_receipts``, which fails closed on
+      unreadable files, malformed JSON, missing/duplicate/negative/
+      non-integer/non-monotonic ``_store_seq``, and mixed legacy+
+      stamped state.
+    - Integrity failures surface as ``integrity_error``; all other
+      projection fields are empty in that case.
+    - No prose. No CLI formatting. No ``is_overdue`` derivation (that
+      is a per-reader, ``now``-dependent derivation — the projector
+      records the facts, consumers interpret them).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from assay.commitment_fulfillment import (
+    COMMITMENT_REGISTRATION_RECEIPT_TYPE,
+    RESULT_OBSERVATION_RECEIPT_TYPE,
+    TERMINAL_FULFILLMENT_TYPES,
+    _iter_all_receipts,
+)
+from assay.store import AssayStore, ReceiptStoreIntegrityError
+
+
+# ---------------------------------------------------------------------------
+# Projected fact dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RegistrationFact:
+    """The first ``commitment.registered`` receipt seen for a commitment.
+
+    Subsequent registrations with the same commitment_id are ignored
+    (first-seen wins) — matches the pre-extraction behavior in every
+    reader.
+    """
+
+    commitment_id: str
+    seq: int  # _store_seq of the registration receipt
+    trace_id: str
+    episode_id: str
+    actor_id: str
+    text: str
+    commitment_type: str
+    due_at: Optional[str]
+    registered_at: str  # receipt-side timestamp (not _stored_at)
+
+
+@dataclass(frozen=True)
+class ObservationAnchorFact:
+    """A ``result.observed`` receipt that names at least one commitment.
+
+    Observations with an empty / missing ``references`` list do not
+    anchor anything and are not recorded here.
+    """
+
+    seq: int  # _store_seq of the observation receipt
+    result_id: str
+    referenced_commitment_ids: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class TerminalFact:
+    """A terminal fulfillment receipt naming a commitment.
+
+    Validity is determined at the terminal's encounter point in
+    ``_store_seq`` order. Invalid terminals are kept — the explainer
+    surfaces them in its timeline with the reason — but they do not
+    produce a ``ClosureFact``.
+    """
+
+    seq: int  # _store_seq of the terminal receipt
+    receipt_type: str  # "fulfillment.commitment_kept" | "commitment_broken"
+    commitment_id: str
+    result_id: str
+    is_valid_closure: bool
+    invalid_reasons: Tuple[str, ...]  # empty iff is_valid_closure
+
+
+@dataclass(frozen=True)
+class ClosureFact:
+    """Derived: the single terminal (if any) that closed a commitment.
+
+    First valid terminal in ``_store_seq`` order wins. Subsequent
+    valid-looking terminals for the same commitment are recorded as
+    ``TerminalFact`` with ``is_valid_closure=False`` and reason
+    ``"post-closure terminal ..."``.
+    """
+
+    commitment_id: str
+    closing_terminal_seq: int
+    closing_terminal_type: str
+    anchor_observation_seq: int  # seq of the result.observed that anchored it
+
+
+@dataclass(frozen=True)
+class CommitmentLifecycleProjection:
+    """Ground-truth projection of the commitment lifecycle as recorded in
+    the store's receipt corpus, in ``_store_seq`` order.
+
+    Consumers derive their specific outputs by filtering / interpreting
+    these facts; the projector itself never formats or decides.
+    """
+
+    # Per-commitment registration (first-seen wins), keyed by commitment_id
+    registrations: Dict[str, RegistrationFact] = field(default_factory=dict)
+
+    # Every observation that referenced at least one commitment, in
+    # ``_store_seq`` order. Explainer filters this for per-commitment
+    # timeline lines.
+    observation_anchors: List[ObservationAnchorFact] = field(default_factory=list)
+
+    # Every terminal receipt naming a commitment, in ``_store_seq``
+    # order, with validity marked.
+    terminals: List[TerminalFact] = field(default_factory=list)
+
+    # Derived: commitment_id -> ClosureFact for commitments that have a
+    # valid closing terminal.
+    closures: Dict[str, ClosureFact] = field(default_factory=dict)
+
+    # For detector's total_traces_scanned
+    total_traces_scanned: int = 0
+
+    # ISO-8601 timestamp when the projection was computed
+    scanned_at: str = ""
+
+    # Integrity failure from ``_iter_all_receipts`` surfaces here.
+    # On integrity failure, all other fields are empty.
+    integrity_error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# The projector
+# ---------------------------------------------------------------------------
+
+
+def project_commitment_lifecycle(
+    store: AssayStore,
+    *,
+    now: Optional[datetime] = None,
+) -> CommitmentLifecycleProjection:
+    """Walk ``store`` in ``_store_seq`` order and project lifecycle facts.
+
+    Single pass. Same closure rule as the detector/explainer/summarizer.
+    No derivations (e.g. ``is_overdue``) — those are per-reader,
+    ``now``-dependent, and do not belong in the shared projection.
+
+    Raises nothing; integrity failures from ``_iter_all_receipts`` are
+    caught and surfaced via the ``integrity_error`` field so every
+    consumer handles them uniformly.
+
+    Args:
+        store: the AssayStore to scan.
+        now: reference time for the ``scanned_at`` stamp. Defaults to
+            ``datetime.now(timezone.utc)``.
+
+    Returns:
+        ``CommitmentLifecycleProjection`` with registrations, anchors,
+        terminals (valid + invalid with reasons), and derived closures.
+    """
+    reference = now or datetime.now(timezone.utc)
+    scanned_at = reference.isoformat()
+
+    try:
+        entries = list(_iter_all_receipts(store))
+    except ReceiptStoreIntegrityError as exc:
+        return CommitmentLifecycleProjection(
+            scanned_at=scanned_at,
+            integrity_error=str(exc),
+        )
+
+    registrations: Dict[str, RegistrationFact] = {}
+    observation_anchors: List[ObservationAnchorFact] = []
+    terminals: List[TerminalFact] = []
+    closures: Dict[str, ClosureFact] = {}
+    trace_ids_seen: Set[str] = set()
+
+    # Rolling state used to decide terminal validity at encounter time.
+    # Keyed by (result_id, commitment_id); value is the most recent
+    # observation seq where that pair was anchored. Updated on every
+    # observation; consulted on every terminal.
+    anchor_seq_by_pair: Dict[Tuple[str, str], int] = {}
+
+    for entry in entries:
+        rt = _extract_receipt_type(entry)
+        seq = entry.get("_store_seq")
+        if not isinstance(seq, int) or isinstance(seq, bool):
+            # Defensive: _iter_all_receipts already enforces this.
+            continue
+
+        trace_id = str(entry.get("_trace_id") or "")
+        if trace_id:
+            trace_ids_seen.add(trace_id)
+
+        if rt == COMMITMENT_REGISTRATION_RECEIPT_TYPE:
+            cmt_id_raw = entry.get("commitment_id")
+            if not cmt_id_raw:
+                continue
+            cmt_id = str(cmt_id_raw)
+            if cmt_id in registrations:
+                # First-seen wins. Matches pre-extraction behavior.
+                continue
+            registrations[cmt_id] = RegistrationFact(
+                commitment_id=cmt_id,
+                seq=seq,
+                trace_id=trace_id,
+                episode_id=str(entry.get("episode_id") or ""),
+                actor_id=str(entry.get("actor_id") or ""),
+                text=str(entry.get("text") or ""),
+                commitment_type=str(entry.get("commitment_type") or ""),
+                due_at=_opt_str(entry.get("due_at")),
+                registered_at=_extract_timestamp(entry),
+            )
+            continue
+
+        if rt == RESULT_OBSERVATION_RECEIPT_TYPE:
+            result_id_raw = entry.get("result_id")
+            if not result_id_raw:
+                continue
+            result_id = str(result_id_raw)
+            referenced: List[str] = []
+            for ref in entry.get("references") or []:
+                if (
+                    isinstance(ref, dict)
+                    and ref.get("kind") == "commitment"
+                    and ref.get("id")
+                ):
+                    ref_cmt = str(ref["id"])
+                    referenced.append(ref_cmt)
+                    # Latest observation seq wins (still strictly < future
+                    # terminal seqs because we walk in _store_seq order).
+                    anchor_seq_by_pair[(result_id, ref_cmt)] = seq
+
+            if referenced:
+                observation_anchors.append(
+                    ObservationAnchorFact(
+                        seq=seq,
+                        result_id=result_id,
+                        referenced_commitment_ids=tuple(referenced),
+                    )
+                )
+            continue
+
+        if rt in TERMINAL_FULFILLMENT_TYPES:
+            cmt_id_raw = entry.get("commitment_id")
+            result_id_raw = entry.get("result_id")
+            if not cmt_id_raw or not result_id_raw:
+                continue
+            cmt_id = str(cmt_id_raw)
+            result_id = str(result_id_raw)
+
+            has_registration = cmt_id in registrations
+            anchor_seq = anchor_seq_by_pair.get((result_id, cmt_id))
+            has_anchor = anchor_seq is not None
+            already_closed = cmt_id in closures
+
+            reasons: List[str] = []
+            if not has_registration:
+                reasons.append("no registration seen before this terminal")
+            if not has_anchor:
+                reasons.append(
+                    f"no anchor edge from result_id={result_id!r} to "
+                    f"commitment={cmt_id!r} at the terminal's encounter point"
+                )
+            if already_closed:
+                reasons.append(
+                    f"post-closure terminal (commitment already closed "
+                    f"by seq={closures[cmt_id].closing_terminal_seq})"
+                )
+
+            is_valid = not reasons
+
+            terminals.append(
+                TerminalFact(
+                    seq=seq,
+                    receipt_type=rt,
+                    commitment_id=cmt_id,
+                    result_id=result_id,
+                    is_valid_closure=is_valid,
+                    invalid_reasons=tuple(reasons),
+                )
+            )
+
+            if is_valid:
+                # anchor_seq is not None here because has_anchor was True.
+                closures[cmt_id] = ClosureFact(
+                    commitment_id=cmt_id,
+                    closing_terminal_seq=seq,
+                    closing_terminal_type=rt,
+                    anchor_observation_seq=anchor_seq,  # type: ignore[arg-type]
+                )
+            continue
+
+    return CommitmentLifecycleProjection(
+        registrations=registrations,
+        observation_anchors=observation_anchors,
+        terminals=terminals,
+        closures=closures,
+        total_traces_scanned=len(trace_ids_seen),
+        scanned_at=scanned_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Small internal helpers (kept local to this module — not exported)
+# ---------------------------------------------------------------------------
+
+
+def _extract_receipt_type(entry: Dict[str, Any]) -> str:
+    return str(entry.get("type") or entry.get("receipt_type") or "")
+
+
+def _extract_timestamp(entry: Dict[str, Any]) -> str:
+    return str(entry.get("timestamp") or entry.get("_stored_at") or "")
+
+
+def _opt_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    s = str(value)
+    return s if s else None
+
+
+__all__ = [
+    "RegistrationFact",
+    "ObservationAnchorFact",
+    "TerminalFact",
+    "ClosureFact",
+    "CommitmentLifecycleProjection",
+    "project_commitment_lifecycle",
+]

--- a/src/assay/commitment_summary.py
+++ b/src/assay/commitment_summary.py
@@ -1,34 +1,31 @@
-"""Single-pass bulk summary of every commitment in the store.
+"""Bulk summary of every commitment in the store.
 
-Used as the shared data source for ``assay commitments list`` and
-``assay commitments overdue``. The underlying walk is the same
-causal-order primitive the detector/explainer trust
-(``_iter_all_receipts``); this module never re-implements lifecycle
-semantics — it just aggregates them in one pass.
+Shared data source for ``assay commitments list`` and
+``assay commitments overdue``. Previously carried its own corpus walk;
+now delegates to :func:`assay.commitment_projection.project_commitment_lifecycle`
+so the detector, explainer, and summarizer all consume one projection
+instead of each re-deriving lifecycle semantics.
 
-Design constraint (from slice review):
-    ``list`` must NOT call ``explain_commitment`` per id (N×corpus
-    rescan). This module does one full-store walk and emits a per-
-    commitment summary; ``overdue`` is a filtered view over the same
-    summaries.
+This module contributes only:
+    - the ``CommitmentSummary`` / ``SummariesResult`` shape
+      (``is_overdue`` is derived here because it depends on ``now``)
+    - the sort key (``registered_seq`` ascending) for reproducible
+      CLI output
 
-Read-only. Fails closed on corrupt / mixed / legacy corpus by returning
-an empty summaries list with ``integrity_error`` set — callers decide
-whether to exit nonzero or continue.
+Everything else — registration facts, closure semantics, integrity
+handling — comes from the shared projection.
+
+Read-only. Integrity failures from the projection surface via the
+``integrity_error`` field; callers decide whether to exit nonzero.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional
 
-from assay.commitment_fulfillment import (
-    COMMITMENT_REGISTRATION_RECEIPT_TYPE,
-    RESULT_OBSERVATION_RECEIPT_TYPE,
-    TERMINAL_FULFILLMENT_TYPES,
-    _iter_all_receipts,
-)
-from assay.store import AssayStore, ReceiptStoreIntegrityError
+from assay.commitment_projection import project_commitment_lifecycle
+from assay.store import AssayStore
 
 
 @dataclass(frozen=True)
@@ -65,7 +62,7 @@ class CommitmentSummary:
 class SummariesResult:
     """Output of ``summarize_all_commitments``.
 
-    ``integrity_error`` is ``None`` on a clean walk; otherwise
+    ``integrity_error`` is ``None`` on a clean projection; otherwise
     ``commitments`` is empty and the error message describes the
     integrity failure (malformed JSON, missing ``_store_seq``, etc.).
     """
@@ -87,123 +84,59 @@ def summarize_all_commitments(
     *,
     now: Optional[datetime] = None,
 ) -> SummariesResult:
-    """Bulk-summarize every commitment in ``store`` in one corpus pass.
+    """Bulk-summarize every commitment in ``store`` via the shared projection.
 
-    Closure rule matches the detector/explainer: a terminal closes
-    commitment C iff, at the terminal's ``_store_seq`` encounter point:
-
-        - C has been registered
-        - some prior ``result.observed`` carries the terminal's
-          ``result_id`` AND lists ``{"kind": "commitment", "id": C}``
-          in its ``references``
-
-    Later observations do not retroactively legitimize earlier terminals.
-    The first valid terminal wins per commitment; later valid-looking
-    terminals are ignored (they would be ``invalid anchor`` in the
-    explainer's timeline).
-
-    Returns an empty list with ``integrity_error`` set on
-    ``ReceiptStoreIntegrityError`` from the underlying iterator.
+    Delegates the corpus walk and closure semantics to
+    :func:`project_commitment_lifecycle`. This function's remaining
+    job is to derive the ``is_overdue`` flag (``now``-dependent) and
+    render the per-commitment summaries in a stable
+    ``registered_seq``-ascending order for reproducible CLI output.
     """
     reference = now or datetime.now(timezone.utc)
-    scanned_at = reference.isoformat()
 
-    try:
-        entries = list(_iter_all_receipts(store))
-    except ReceiptStoreIntegrityError as exc:
+    projection = project_commitment_lifecycle(store, now=reference)
+
+    if projection.integrity_error is not None:
         return SummariesResult(
             commitments=[],
-            scanned_at=scanned_at,
-            integrity_error=str(exc),
+            scanned_at=projection.scanned_at,
+            integrity_error=projection.integrity_error,
         )
 
-    registered: Dict[str, Dict[str, Any]] = {}
-    observed_result_anchors: Dict[str, Set[str]] = {}
-    closing_terminals: Dict[str, Tuple[int, str]] = {}
-
-    for entry in entries:
-        rt = str(entry.get("type") or entry.get("receipt_type") or "")
-        seq = entry.get("_store_seq")
-        if not isinstance(seq, int) or isinstance(seq, bool):
-            # Defensive: _iter_all_receipts already enforces this.
-            continue
-
-        if rt == COMMITMENT_REGISTRATION_RECEIPT_TYPE:
-            cmt_id = entry.get("commitment_id")
-            if cmt_id and cmt_id not in registered:
-                registered[str(cmt_id)] = {
-                    "registered_seq": seq,
-                    "actor_id": str(entry.get("actor_id") or ""),
-                    "text": str(entry.get("text") or ""),
-                    "commitment_type": str(entry.get("commitment_type") or ""),
-                    "due_at": entry.get("due_at") or None,
-                }
-            continue
-
-        if rt == RESULT_OBSERVATION_RECEIPT_TYPE:
-            result_id = entry.get("result_id")
-            if not result_id:
-                continue
-            for ref in entry.get("references") or []:
-                if (
-                    isinstance(ref, dict)
-                    and ref.get("kind") == "commitment"
-                    and ref.get("id")
-                ):
-                    observed_result_anchors.setdefault(
-                        str(result_id), set()
-                    ).add(str(ref["id"]))
-            continue
-
-        if rt in TERMINAL_FULFILLMENT_TYPES:
-            cmt_id = entry.get("commitment_id")
-            result_id = entry.get("result_id")
-            if not cmt_id or not result_id:
-                continue
-            cmt_s = str(cmt_id)
-            result_s = str(result_id)
-            if cmt_s not in registered:
-                continue
-            if cmt_s not in observed_result_anchors.get(result_s, set()):
-                continue
-            # First valid terminal wins. Later terminals for an already-
-            # closed commitment are ignored for summary purposes.
-            if cmt_s not in closing_terminals:
-                closing_terminals[cmt_s] = (seq, rt)
-            continue
-
     summaries: List[CommitmentSummary] = []
-    # Stable order: by registered_seq so CLI output is reproducible.
-    for cmt_id, info in sorted(
-        registered.items(), key=lambda item: item[1]["registered_seq"]
+    for reg in sorted(
+        projection.registrations.values(), key=lambda r: r.seq
     ):
-        closing = closing_terminals.get(cmt_id)
-        state = "CLOSED" if closing else "OPEN"
-        closing_seq = closing[0] if closing else None
-        closing_type = closing[1] if closing else None
+        closure = projection.closures.get(reg.commitment_id)
+        state = "CLOSED" if closure else "OPEN"
+        closing_seq = closure.closing_terminal_seq if closure else None
+        closing_type = closure.closing_terminal_type if closure else None
 
         is_overdue = False
-        if state == "OPEN" and info["due_at"]:
-            parsed = _parse_iso(str(info["due_at"]))
+        if state == "OPEN" and reg.due_at:
+            parsed = _parse_iso(reg.due_at)
             if parsed is not None and parsed < reference:
                 is_overdue = True
 
         summaries.append(
             CommitmentSummary(
-                commitment_id=cmt_id,
+                commitment_id=reg.commitment_id,
                 state=state,
-                actor_id=info["actor_id"],
-                text=info["text"],
-                commitment_type=info["commitment_type"],
-                due_at=info["due_at"],
-                registered_seq=info["registered_seq"],
+                actor_id=reg.actor_id,
+                text=reg.text,
+                commitment_type=reg.commitment_type,
+                due_at=reg.due_at,
+                registered_seq=reg.seq,
                 closing_terminal_seq=closing_seq,
                 closing_terminal_type=closing_type,
                 is_overdue=is_overdue,
             )
         )
 
-    return SummariesResult(commitments=summaries, scanned_at=scanned_at)
+    return SummariesResult(
+        commitments=summaries,
+        scanned_at=projection.scanned_at,
+    )
 
 
 def _parse_iso(value: str) -> Optional[datetime]:

--- a/src/assay/store.py
+++ b/src/assay/store.py
@@ -104,15 +104,22 @@ class AssayStore:
         self._current_trace_id: Optional[str] = None
         self._current_file: Optional[Path] = None
         self._lock = threading.RLock()
-        # Store-wide monotonic receipt sequence primitive. Its state lives
-        # ON DISK at ``<base_dir>/.store_seq`` and is mutated under
-        # ``fcntl.flock(LOCK_EX)`` so that multiple AssayStore instances
-        # (including across processes) cannot allocate the same seq.
-        # Allocation + receipt persistence run in a single critical section:
-        # no writer releases the seq-file lock between "take a seq" and
-        # "put the receipt bearing that seq on disk". Lexicographic trace-
-        # path order is NOT a valid chronology; ``_store_seq`` is the
-        # authority.
+        # ``_store_seq`` is the store's **witnessed append order** — a
+        # monotonic, immutable primitive stamped atomically at write
+        # time. State lives ON DISK at ``<base_dir>/.store_seq`` and is
+        # mutated under ``fcntl.flock(LOCK_EX)`` so that multiple
+        # AssayStore instances (including across processes) cannot
+        # allocate the same seq. Allocation and receipt persistence run
+        # in a single critical section: no writer releases the seq-file
+        # lock between "take a seq" and "put the receipt bearing that
+        # seq on disk". Once written, ``_store_seq`` is not rewritten
+        # by any supported code path — repair tooling must use a
+        # separate reconstructed-order marker if it needs one.
+        #
+        # Doctrine note: this is a STORAGE primitive (witnessed append
+        # order, tamper detection, deterministic traversal). It is NOT
+        # a semantic global happens-before relation between unrelated
+        # aggregates. See docs/doctrine/COMMITMENT_ORDERING.md.
         self._seq_file = self.base_dir / ".store_seq"
 
     def start_trace(self, trace_id: Optional[str] = None) -> str:

--- a/tests/assay/test_commitment_projection_parity.py
+++ b/tests/assay/test_commitment_projection_parity.py
@@ -1,0 +1,353 @@
+"""Parity test: the three readers agree on one adversarial corpus.
+
+Purpose:
+    After extracting ``project_commitment_lifecycle`` as the shared
+    source of truth, the detector / explainer / summarizer all derive
+    their outputs from the same projection. This test verifies their
+    outputs stay consistent on a single corpus that exercises every
+    adversarial case Slice 1's reviews surfaced.
+
+    If any reader drifts (e.g. a future change re-derives lifecycle
+    semantics locally instead of going through the projection), this
+    test fails before the drift ships.
+
+Adversarial corpus:
+    A hand-crafted event sequence designed to trip on each class of
+    closure pathology simultaneously, on one store, in one walk:
+
+        - VALID_CLOSED  — registered, observed with anchor, then kept
+        - INVALID_TERMINAL — terminal before any observation exists
+        - RETROACTIVE_OBS  — observation appended AFTER a terminal
+                             (does not retroactively close)
+        - WRONG_ANCHOR     — observation references a different
+                             commitment than the terminal names
+        - BAD_DUE_AT       — malformed ``due_at`` string (not overdue)
+        - NOT_REGISTERED   — a commitment_id that never appears
+        - PERPETUAL        — open, no due_at, must never appear
+                             overdue
+
+Read-only. No receipts emitted.
+"""
+from __future__ import annotations
+
+import pytest
+
+from assay.commitment_closure_detector import detect_open_overdue_commitments
+from assay.commitment_explain import explain_commitment
+from assay.commitment_fulfillment import (
+    COMMITMENT_REGISTRATION_RECEIPT_TYPE,
+    FULFILLMENT_COMMITMENT_KEPT_RECEIPT_TYPE,
+    RESULT_OBSERVATION_RECEIPT_TYPE,
+)
+from assay.commitment_summary import summarize_all_commitments
+from assay.store import AssayStore
+
+
+def _build_adversarial_corpus(tmp_path) -> AssayStore:
+    """Return a store with an event sequence hitting every closure pathology.
+
+    Ordering is significant — each case is arranged in ``_store_seq``
+    order such that the reader's anchor/encounter rules are the thing
+    actually being tested.
+    """
+    store = AssayStore(base_dir=tmp_path / "adversarial")
+    store.start_trace()
+
+    # --- VALID_CLOSED: proper register → observe → kept chain ---------------
+    store.append_dict({
+        "type": COMMITMENT_REGISTRATION_RECEIPT_TYPE,
+        "commitment_id": "cmt_valid_closed",
+        "episode_id": "ep",
+        "actor_id": "alice",
+        "text": "Deliverable A.",
+        "commitment_type": "delivery",
+        "policy_hash": "sha256:" + "c" * 64,
+        "due_at": "2020-01-01T00:00:00Z",
+        "timestamp": "2026-04-20T10:00:00Z",
+    })
+    store.append_dict({
+        "type": RESULT_OBSERVATION_RECEIPT_TYPE,
+        "result_id": "res_valid",
+        "episode_id": "ep",
+        "text": "shipped",
+        "evidence_uri": "file:///t/e.log",
+        "policy_hash": "sha256:" + "c" * 64,
+        "references": [{"kind": "commitment", "id": "cmt_valid_closed"}],
+        "timestamp": "2026-04-20T11:00:00Z",
+    })
+    store.append_dict({
+        "type": FULFILLMENT_COMMITMENT_KEPT_RECEIPT_TYPE,
+        "fulfillment_id": "ful_valid",
+        "episode_id": "ep",
+        "commitment_id": "cmt_valid_closed",
+        "result_id": "res_valid",
+        "evaluator": "qa",
+        "evaluator_version": "0.1",
+        "policy_hash": "sha256:" + "c" * 64,
+        "timestamp": "2026-04-20T12:00:00Z",
+    })
+
+    # --- INVALID_TERMINAL: terminal before any observation ------------------
+    store.append_dict({
+        "type": COMMITMENT_REGISTRATION_RECEIPT_TYPE,
+        "commitment_id": "cmt_invalid_terminal",
+        "episode_id": "ep",
+        "actor_id": "alice",
+        "text": "forged",
+        "commitment_type": "delivery",
+        "policy_hash": "sha256:" + "c" * 64,
+        "due_at": "2020-01-01T00:00:00Z",
+        "timestamp": "2026-04-20T10:00:00Z",
+    })
+    # Terminal at this seq has NO prior observation referencing this cmt.
+    store.append_dict({
+        "type": FULFILLMENT_COMMITMENT_KEPT_RECEIPT_TYPE,
+        "fulfillment_id": "ful_forged_early",
+        "episode_id": "ep",
+        "commitment_id": "cmt_invalid_terminal",
+        "result_id": "res_never_observed",
+        "evaluator": "qa",
+        "evaluator_version": "0.1",
+        "policy_hash": "sha256:" + "c" * 64,
+        "timestamp": "2026-04-20T11:00:00Z",
+    })
+
+    # --- RETROACTIVE_OBS: terminal first, observation later -----------------
+    store.append_dict({
+        "type": COMMITMENT_REGISTRATION_RECEIPT_TYPE,
+        "commitment_id": "cmt_retro",
+        "episode_id": "ep",
+        "actor_id": "alice",
+        "text": "retro",
+        "commitment_type": "delivery",
+        "policy_hash": "sha256:" + "c" * 64,
+        "due_at": "2020-01-01T00:00:00Z",
+        "timestamp": "2026-04-20T10:00:00Z",
+    })
+    store.append_dict({
+        "type": FULFILLMENT_COMMITMENT_KEPT_RECEIPT_TYPE,
+        "fulfillment_id": "ful_retro_early",
+        "episode_id": "ep",
+        "commitment_id": "cmt_retro",
+        "result_id": "res_retro",
+        "evaluator": "qa",
+        "evaluator_version": "0.1",
+        "policy_hash": "sha256:" + "c" * 64,
+        "timestamp": "2026-04-20T11:00:00Z",
+    })
+    # Observation arrives AFTER the terminal — cannot retroactively close.
+    store.append_dict({
+        "type": RESULT_OBSERVATION_RECEIPT_TYPE,
+        "result_id": "res_retro",
+        "episode_id": "ep",
+        "text": "late observation",
+        "evidence_uri": "file:///t/e.log",
+        "policy_hash": "sha256:" + "c" * 64,
+        "references": [{"kind": "commitment", "id": "cmt_retro"}],
+        "timestamp": "2026-04-20T12:00:00Z",
+    })
+
+    # --- WRONG_ANCHOR: observation references a different commitment --------
+    store.append_dict({
+        "type": COMMITMENT_REGISTRATION_RECEIPT_TYPE,
+        "commitment_id": "cmt_wrong_A",
+        "episode_id": "ep",
+        "actor_id": "alice",
+        "text": "A",
+        "commitment_type": "delivery",
+        "policy_hash": "sha256:" + "c" * 64,
+        "due_at": "2020-01-01T00:00:00Z",
+        "timestamp": "2026-04-20T10:00:00Z",
+    })
+    store.append_dict({
+        "type": COMMITMENT_REGISTRATION_RECEIPT_TYPE,
+        "commitment_id": "cmt_wrong_B",
+        "episode_id": "ep",
+        "actor_id": "alice",
+        "text": "B",
+        "commitment_type": "delivery",
+        "policy_hash": "sha256:" + "c" * 64,
+        "due_at": "2020-01-01T00:00:00Z",
+        "timestamp": "2026-04-20T10:00:00Z",
+    })
+    # res_B observed only for cmt_wrong_B.
+    store.append_dict({
+        "type": RESULT_OBSERVATION_RECEIPT_TYPE,
+        "result_id": "res_B",
+        "episode_id": "ep",
+        "text": "B shipped",
+        "evidence_uri": "file:///t/e.log",
+        "policy_hash": "sha256:" + "c" * 64,
+        "references": [{"kind": "commitment", "id": "cmt_wrong_B"}],
+        "timestamp": "2026-04-20T11:00:00Z",
+    })
+    # Terminal tries to close cmt_wrong_A with res_B — wrong anchor edge.
+    store.append_dict({
+        "type": FULFILLMENT_COMMITMENT_KEPT_RECEIPT_TYPE,
+        "fulfillment_id": "ful_wrong_anchor",
+        "episode_id": "ep",
+        "commitment_id": "cmt_wrong_A",
+        "result_id": "res_B",
+        "evaluator": "qa",
+        "evaluator_version": "0.1",
+        "policy_hash": "sha256:" + "c" * 64,
+        "timestamp": "2026-04-20T12:00:00Z",
+    })
+
+    # --- BAD_DUE_AT: unparseable due_at (not overdue) -----------------------
+    store.append_dict({
+        "type": COMMITMENT_REGISTRATION_RECEIPT_TYPE,
+        "commitment_id": "cmt_bad_due",
+        "episode_id": "ep",
+        "actor_id": "alice",
+        "text": "bad_due",
+        "commitment_type": "delivery",
+        "policy_hash": "sha256:" + "c" * 64,
+        "due_at": "this-is-not-a-valid-iso-8601-timestamp",
+        "timestamp": "2026-04-20T10:00:00Z",
+    })
+
+    # --- PERPETUAL: open, no due_at -----------------------------------------
+    store.append_dict({
+        "type": COMMITMENT_REGISTRATION_RECEIPT_TYPE,
+        "commitment_id": "cmt_perpetual",
+        "episode_id": "ep",
+        "actor_id": "alice",
+        "text": "forever open",
+        "commitment_type": "delivery",
+        "policy_hash": "sha256:" + "c" * 64,
+        "timestamp": "2026-04-20T10:00:00Z",
+    })
+
+    return store
+
+
+def test_three_readers_agree_on_adversarial_corpus(tmp_path):
+    """Detector, explainer, and summarizer must agree on every commitment in
+    one adversarial corpus — same projection, same conclusions.
+
+    If the projector changes or a reader drifts off the projection, this
+    test surfaces the divergence.
+    """
+    store = _build_adversarial_corpus(tmp_path)
+
+    detector_result = detect_open_overdue_commitments(store)
+    summarizer_result = summarize_all_commitments(store)
+
+    # Header counts match.
+    assert detector_result.total_registered_found == len(summarizer_result.commitments)
+    assert detector_result.total_closed_found == sum(
+        1 for s in summarizer_result.commitments if s.state == "CLOSED"
+    )
+    summarizer_overdue_ids = {
+        s.commitment_id for s in summarizer_result.commitments if s.is_overdue
+    }
+    detector_overdue_ids = {
+        c.commitment_id for c in detector_result.open_commitments
+    }
+    assert detector_overdue_ids == summarizer_overdue_ids
+
+    # Expected overall state per commitment.
+    expected_state = {
+        "cmt_valid_closed": "CLOSED",
+        "cmt_invalid_terminal": "OPEN",
+        "cmt_retro": "OPEN",
+        "cmt_wrong_A": "OPEN",
+        "cmt_wrong_B": "OPEN",
+        "cmt_bad_due": "OPEN",
+        "cmt_perpetual": "OPEN",
+    }
+    summarizer_by_id = {s.commitment_id: s for s in summarizer_result.commitments}
+
+    for cmt_id, expected in expected_state.items():
+        summary = summarizer_by_id[cmt_id]
+        explanation = explain_commitment(store, cmt_id)
+
+        assert summary.state == expected, (
+            f"summarizer disagrees for {cmt_id!r}: got {summary.state!r}, "
+            f"expected {expected!r}"
+        )
+        assert explanation.state == expected, (
+            f"explainer disagrees for {cmt_id!r}: got {explanation.state!r}, "
+            f"expected {expected!r}"
+        )
+
+    # NOT_REGISTERED parity: a commitment that was never registered must
+    # surface as NOT_REGISTERED in the explainer and must not appear in
+    # the summarizer or detector output.
+    phantom = "cmt_never_registered"
+    assert explain_commitment(store, phantom).state == "NOT_REGISTERED"
+    assert phantom not in summarizer_by_id
+    assert phantom not in detector_overdue_ids
+
+
+def test_overdue_classification_agrees_on_adversarial_corpus(tmp_path):
+    """Overdue classification is the highest-leverage place for reader drift
+    (it depends on both closure state AND due_at parsing). Lock it tightly.
+
+    Expected per our corpus:
+        - cmt_valid_closed : NOT overdue (closed)
+        - cmt_invalid_terminal : overdue (registered past, never closed)
+        - cmt_retro : overdue (registered past, terminal invalid, never closed)
+        - cmt_wrong_A : overdue
+        - cmt_wrong_B : overdue (no terminal at all)
+        - cmt_bad_due : NOT overdue (unparseable due_at → perpetual)
+        - cmt_perpetual : NOT overdue (no due_at)
+    """
+    store = _build_adversarial_corpus(tmp_path)
+
+    expected_overdue = {
+        "cmt_invalid_terminal",
+        "cmt_retro",
+        "cmt_wrong_A",
+        "cmt_wrong_B",
+    }
+
+    detector_overdue = {
+        c.commitment_id for c in detect_open_overdue_commitments(store).open_commitments
+    }
+    summarizer_overdue = {
+        s.commitment_id
+        for s in summarize_all_commitments(store).commitments
+        if s.is_overdue
+    }
+
+    assert detector_overdue == expected_overdue, (
+        f"detector overdue set mismatch: "
+        f"got {detector_overdue!r}, expected {expected_overdue!r}"
+    )
+    assert summarizer_overdue == expected_overdue, (
+        f"summarizer overdue set mismatch: "
+        f"got {summarizer_overdue!r}, expected {expected_overdue!r}"
+    )
+
+
+def test_explainer_closed_anchor_seq_matches_projection(tmp_path):
+    """For a CLOSED commitment, the anchor seq cited in the explainer's
+    decision must match the ``anchor_observation_seq`` the projection
+    recorded. If the explainer re-derives the anchor from a different
+    source, the two can drift — this test locks the agreement.
+    """
+    from assay.commitment_projection import project_commitment_lifecycle
+
+    store = _build_adversarial_corpus(tmp_path)
+
+    projection = project_commitment_lifecycle(store)
+    closure = projection.closures["cmt_valid_closed"]
+    explanation = explain_commitment(store, "cmt_valid_closed")
+
+    assert explanation.state == "CLOSED"
+    # The explainer's closing ExplainLine seq must match the projection.
+    closing_lines = [
+        line for line in explanation.timeline
+        if line.note == "closes commitment"
+    ]
+    assert len(closing_lines) == 1
+    assert closing_lines[0].seq == closure.closing_terminal_seq
+    # Anchor seq appears in the decision string; the specific integer
+    # must match. Parsing minimally here is acceptable because the
+    # decision format is part of the explainer's stable contract.
+    anchor_token = f"anchor result.observed seq={closure.anchor_observation_seq} "
+    assert anchor_token in explanation.decision, (
+        f"expected {anchor_token!r} in decision, got: {explanation.decision!r}"
+    )

--- a/tests/assay/test_commitment_projection_parity.py
+++ b/tests/assay/test_commitment_projection_parity.py
@@ -351,3 +351,160 @@ def test_explainer_closed_anchor_seq_matches_projection(tmp_path):
     assert anchor_token in explanation.decision, (
         f"expected {anchor_token!r} in decision, got: {explanation.decision!r}"
     )
+
+
+def test_projection_stable_across_consumer_call_orders(tmp_path):
+    """Calling the three consumers in any order must produce identical
+    projection-derived state for the same underlying store.
+
+    Guards against hidden mutation / caching / side-effects crossing
+    consumer boundaries. The projection is pure-read by contract; this
+    test locks the contract so future changes that violate it fail
+    before they land.
+    """
+    store = _build_adversarial_corpus(tmp_path)
+
+    # Order A: detector → summarizer → explainer (one pass per cmt_id)
+    a_detector = detect_open_overdue_commitments(store)
+    a_summary = summarize_all_commitments(store)
+    a_explanations = {
+        s.commitment_id: explain_commitment(store, s.commitment_id)
+        for s in a_summary.commitments
+    }
+
+    # Order B: summarizer → explainer → detector
+    b_summary = summarize_all_commitments(store)
+    b_explanations = {
+        s.commitment_id: explain_commitment(store, s.commitment_id)
+        for s in b_summary.commitments
+    }
+    b_detector = detect_open_overdue_commitments(store)
+
+    # Order C: explainer for every commitment → detector → summarizer
+    ids_from_summary = [s.commitment_id for s in a_summary.commitments]
+    c_explanations = {
+        cmt_id: explain_commitment(store, cmt_id)
+        for cmt_id in ids_from_summary
+    }
+    c_detector = detect_open_overdue_commitments(store)
+    c_summary = summarize_all_commitments(store)
+
+    # Detector output stable.
+    assert (
+        {c.commitment_id for c in a_detector.open_commitments}
+        == {c.commitment_id for c in b_detector.open_commitments}
+        == {c.commitment_id for c in c_detector.open_commitments}
+    )
+    assert (
+        a_detector.total_registered_found
+        == b_detector.total_registered_found
+        == c_detector.total_registered_found
+    )
+    assert (
+        a_detector.total_closed_found
+        == b_detector.total_closed_found
+        == c_detector.total_closed_found
+    )
+
+    # Summarizer output stable (dict-of-dicts comparison ignores
+    # scanned_at, which is the wall-clock at call time and thus
+    # legitimately varies).
+    def _summary_facts(result):
+        return {
+            s.commitment_id: {
+                "state": s.state,
+                "is_overdue": s.is_overdue,
+                "closing_terminal_seq": s.closing_terminal_seq,
+                "closing_terminal_type": s.closing_terminal_type,
+                "registered_seq": s.registered_seq,
+            }
+            for s in result.commitments
+        }
+
+    assert _summary_facts(a_summary) == _summary_facts(b_summary) == _summary_facts(c_summary)
+
+    # Explainer output stable per commitment.
+    for cmt_id in a_explanations:
+        a_ex = a_explanations[cmt_id]
+        b_ex = b_explanations[cmt_id]
+        c_ex = c_explanations[cmt_id]
+
+        # State is deterministic.
+        assert a_ex.state == b_ex.state == c_ex.state, (
+            f"explainer state drift for {cmt_id!r}: "
+            f"{a_ex.state!r} vs {b_ex.state!r} vs {c_ex.state!r}"
+        )
+        # Timeline is deterministic by (seq, receipt_type, note, summary).
+        def _timeline_facts(ex):
+            return [
+                (line.seq, line.receipt_type, line.note, line.summary)
+                for line in ex.timeline
+            ]
+        assert _timeline_facts(a_ex) == _timeline_facts(b_ex) == _timeline_facts(c_ex), (
+            f"explainer timeline drift for {cmt_id!r}"
+        )
+        # Decision text is deterministic (no wall-clock in decisions).
+        assert a_ex.decision == b_ex.decision == c_ex.decision
+
+
+def test_all_consumers_fail_closed_on_same_corrupt_corpus(tmp_path):
+    """Locks the integrity contract across the three readers:
+
+        detector   → raises ReceiptStoreIntegrityError
+        explainer  → returns state="INVALID_STORE" with integrity_error set
+        summarizer → returns empty commitments with integrity_error set
+
+    Three different contracts (historical, each justified by caller
+    shape), but the same invariant: **corruption never silently
+    produces 'clean' output**. Empty + no error would be a silent
+    degradation; this test forbids it.
+
+    If a future change ever makes any consumer silently skip corrupt
+    data and return as if all was well, this test fails before it
+    ships.
+    """
+    from assay.store import ReceiptStoreIntegrityError
+
+    store = AssayStore(base_dir=tmp_path / "corrupt")
+    store.start_trace()
+    # Plant a legit receipt so the store has something to inspect.
+    store.append_dict({
+        "type": COMMITMENT_REGISTRATION_RECEIPT_TYPE,
+        "commitment_id": "cmt_corrupt_test",
+        "episode_id": "ep",
+        "actor_id": "alice",
+        "text": "will become corrupt",
+        "commitment_type": "delivery",
+        "policy_hash": "sha256:" + "c" * 64,
+        "due_at": "2020-01-01T00:00:00Z",
+        "timestamp": "2026-04-20T10:00:00Z",
+    })
+    # Corrupt the trace file by appending malformed JSON.
+    trace_files = sorted(store.base_dir.rglob("trace_*.jsonl"))
+    with open(trace_files[-1], "a") as f:
+        f.write("{this is not valid json\n")
+
+    # Detector: must raise.
+    with pytest.raises(ReceiptStoreIntegrityError):
+        detect_open_overdue_commitments(store)
+
+    # Summarizer: must have integrity_error set AND empty commitments.
+    summary = summarize_all_commitments(store)
+    assert summary.integrity_error is not None, (
+        "summarizer must surface corruption via integrity_error"
+    )
+    assert summary.commitments == [], (
+        "summarizer must not return partial facts on corruption"
+    )
+
+    # Explainer: must return INVALID_STORE state, NOT OPEN/CLOSED.
+    explanation = explain_commitment(store, "cmt_corrupt_test")
+    assert explanation.state == "INVALID_STORE", (
+        f"explainer must not downgrade corruption into OPEN/CLOSED; "
+        f"got state={explanation.state!r}"
+    )
+    assert explanation.integrity_error is not None
+    # Registration and timeline MUST be empty — no partial facts
+    # mixed with corruption evidence.
+    assert explanation.registration is None
+    assert explanation.timeline == []


### PR DESCRIPTION
## Summary

Consolidates three readers onto one projection path. Implements the architecture decision ratified in PR #86 (`docs/doctrine/COMMITMENT_ORDERING.md`): lifecycle semantics project per aggregate; `_store_seq` is immutable witnessed append order — a storage primitive, not a semantic global happens-before.

**Behavior-preserving.** No CLI change, no storage migration, no schema change. Every existing test passes unchanged.

## The architectural shift

```
Before:
    commitment_closure_detector.py  ──┐
    commitment_explain.py           ──┼─> each walks _iter_all_receipts
    commitment_summary.py           ──┘   and re-derives closure semantics

After:
    commitment_projection.py           ──> single walk; produces
                                           CommitmentLifecycleProjection

    commitment_closure_detector.py  ──┐
    commitment_explain.py           ──┼─> consume the projection;
    commitment_summary.py           ──┘   derive their specific outputs
```

Slice 1's reviews repeatedly caught invariant gaps where one reader encoded a closure rule slightly differently from another. The shared projection makes that drift structurally impossible: there is now one place the rule lives.

## What's in the PR

| File | Change |
|---|---|
| `src/assay/commitment_projection.py` | **New, 366 LOC.** `RegistrationFact` / `ObservationAnchorFact` / `TerminalFact` / `ClosureFact` / `CommitmentLifecycleProjection`; `project_commitment_lifecycle(store, *, now=None)`. Per-terminal validity + `invalid_reasons` recorded at the walk. `anchor_observation_seq` recorded in `ClosureFact` — no more "scan my own timeline to find the anchor seq". Integrity failures surface via `projection.integrity_error`. |
| `src/assay/commitment_summary.py` | Refactored: consumes projection; keeps `is_overdue` derivation (`now`-dependent) and `registered_seq` sort order. Dropped its private corpus walk. |
| `src/assay/commitment_closure_detector.py` | Refactored: consumes projection; keeps overdue filter + `due_at` parsing; preserves existing `ReceiptStoreIntegrityError` raise contract. |
| `src/assay/commitment_explain.py` | Refactored: consumes projection; builds per-commitment timeline by filtering projection facts and sorting by seq; derives decision strings from structured `ClosureFact` fields (no local closure recomputation). |
| `src/assay/commitment_fulfillment.py` | Docstring updated: `_iter_all_receipts` explicitly framed as a STORAGE primitive (witnessed append order), with pointer to the ordering memo. |
| `src/assay/store.py` | Docstring updated on the `._seq_file` comment block: names `_store_seq` as "witnessed append order", explicit non-semantic, memo pointer. |
| `tests/assay/test_commitment_projection_parity.py` | **New, 353 LOC, 3 tests.** |

## The parity test

One adversarial corpus, exercising every closure pathology Slice 1's reviews surfaced, simultaneously:

```
VALID_CLOSED      — register → observe+anchor → kept
INVALID_TERMINAL  — terminal before any observation
RETROACTIVE_OBS   — observation appended AFTER a terminal
WRONG_ANCHOR      — observation references a different commitment
BAD_DUE_AT        — malformed due_at (must not flag as overdue)
PERPETUAL         — no due_at (must never appear overdue)
NOT_REGISTERED    — never registered id
```

Three property assertions:

- `test_three_readers_agree_on_adversarial_corpus` — detector's `open_commitments`, summarizer's `is_overdue` set, and explainer's `state` all match the expected state map
- `test_overdue_classification_agrees_on_adversarial_corpus` — detector and summarizer produce the same overdue id set exactly
- `test_explainer_closed_anchor_seq_matches_projection` — the seq the explainer cites in its decision matches `projection.closures[cmt].anchor_observation_seq` structurally (not via prose grep)

If any future change causes one reader to drift off the projection, these tests fail before the drift ships.

## Test totals

| Slice | Tests | Pass |
|---|---:|---:|
| `test_commitment_projection_parity.py` (new) | 3 | 3 |
| `test_commitments_list_overdue.py` | 24 | 24 |
| `test_commitment_lifecycle.py` | 78 | 78 |
| `test_explain_commitment.py` | 17 | 17 |
| `test_commitment_terminal_invariant.py` | 3 | 3 |
| `test_contradiction_detector.py` | (adjacent) | all green |
| `test_doctor.py` | (adjacent) | all green |
| **Focused + adjacent** | **207** | **207** |

Zero failures.

## Code size

```
7 files changed, 929 insertions(+), 401 deletions(-)

Breakdown:
  src/assay/commitment_projection.py                    +366   (new)
  tests/assay/test_commitment_projection_parity.py      +353   (new)
  src/assay/commitment_closure_detector.py              -198   (shrunk)
  src/assay/commitment_explain.py                       -207   (shrunk)
  src/assay/commitment_summary.py                       -171   (shrunk)
  src/assay/commitment_fulfillment.py                   +10    (docstring)
  src/assay/store.py                                    +25    (docstring)
```

The three consumer modules shrank substantially. What moved out of them didn't disappear — it consolidated into the shared projection + parity tests.

## End-to-end smoke

Behavior identical on a real store:

```
$ assay commitments explain cmt_ship_widget --base-dir /tmp/explain-smoke
Commitment: cmt_ship_widget
State: CLOSED
Registration:
  seq=0 type=commitment.registered
  registered by actor_id='alice', due_at=2026-04-18T00:00:00Z
Timeline:
  seq=0 commitment.registered        ok
  seq=1 result.observed              anchor edge present
  seq=2 fulfillment.commitment_kept  closes commitment
Decision:
  CLOSED because terminal 'fulfillment.commitment_kept' seq=2 occurred with a valid anchor edge and anchor result.observed seq=1 explicitly references this commitment.
```

## Scope boundary (held)

- No new CLI behavior
- No storage migration
- No schema change (envelope field shape unchanged)
- Preserve all existing tests
- Add parity tests only
- Fail closed on corrupt/malformed stores exactly as current code does
- Adversarial closure-semantics tests from PR #85 intact
- No Slice 2 obligation work (still blocked on separate namespace adjudication)

## Test plan

- [ ] CI runs `tests/assay/test_commitment_projection_parity.py` (3 tests)
- [ ] CI runs the broader adjacent slice — zero regressions vs `origin/main`
- [ ] Spot-check `assay commitments {list,overdue,explain}` output format is byte-for-byte identical to pre-refactor

## Review state

Draft. Awaiting CI green, then Ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
