### PR TITLE
chore(commitments): clean projection review nits

### DIFF
--- a/src/assay/commitment_closure_detector.py
+++ b/src/assay/commitment_closure_detector.py
@@ -119,12 +119,12 @@ def detect_open_overdue_commitments(
 
     # Integrity failure parity: the pre-extraction detector propagated
     # ``ReceiptStoreIntegrityError`` directly rather than returning a
-    # result with an error field. Preserve that contract so existing
-    # tests that expect a raised exception still work.
-    if projection.integrity_error is not None:
-        from assay.store import ReceiptStoreIntegrityError
-
-        raise ReceiptStoreIntegrityError(projection.integrity_error)
+    # result with an error field. Preserve that contract — and the
+    # original traceback for forensics — by re-raising the projection's
+    # captured exception directly instead of wrapping its message in a
+    # fresh instance.
+    if projection.integrity_exception is not None:
+        raise projection.integrity_exception
 
     open_commitments: List[OpenOverdueCommitment] = []
     for cmt_id, reg in projection.registrations.items():

--- a/src/assay/commitment_projection.py
+++ b/src/assay/commitment_projection.py
@@ -118,7 +118,10 @@ class TerminalFact:
     """
 
     seq: int  # _store_seq of the terminal receipt
-    receipt_type: str  # "fulfillment.commitment_kept" | "commitment_broken"
+    # Full dotted receipt-type name, one of:
+    #   "fulfillment.commitment_kept"
+    #   "fulfillment.commitment_broken"
+    receipt_type: str
     commitment_id: str
     result_id: str
     is_valid_closure: bool
@@ -172,9 +175,13 @@ class CommitmentLifecycleProjection:
     # ISO-8601 timestamp when the projection was computed
     scanned_at: str = ""
 
-    # Integrity failure from ``_iter_all_receipts`` surfaces here.
-    # On integrity failure, all other fields are empty.
+    # Integrity failure surfaces in TWO paired fields so consumers can
+    # both display a human-readable message (``integrity_error``) and
+    # re-raise or chain from the original exception
+    # (``integrity_exception``) for forensic context. On integrity
+    # failure, all other projection fields are empty.
     integrity_error: Optional[str] = None
+    integrity_exception: Optional[ReceiptStoreIntegrityError] = None
 
 
 # ---------------------------------------------------------------------------
@@ -209,14 +216,6 @@ def project_commitment_lifecycle(
     reference = now or datetime.now(timezone.utc)
     scanned_at = reference.isoformat()
 
-    try:
-        entries = list(_iter_all_receipts(store))
-    except ReceiptStoreIntegrityError as exc:
-        return CommitmentLifecycleProjection(
-            scanned_at=scanned_at,
-            integrity_error=str(exc),
-        )
-
     registrations: Dict[str, RegistrationFact] = {}
     observation_anchors: List[ObservationAnchorFact] = []
     terminals: List[TerminalFact] = []
@@ -229,115 +228,146 @@ def project_commitment_lifecycle(
     # observation; consulted on every terminal.
     anchor_seq_by_pair: Dict[Tuple[str, str], int] = {}
 
-    for entry in entries:
-        rt = _extract_receipt_type(entry)
-        seq = entry.get("_store_seq")
-        if not isinstance(seq, int) or isinstance(seq, bool):
-            # Defensive: _iter_all_receipts already enforces this.
-            continue
-
-        trace_id = str(entry.get("_trace_id") or "")
-        if trace_id:
-            trace_ids_seen.add(trace_id)
-
-        if rt == COMMITMENT_REGISTRATION_RECEIPT_TYPE:
-            cmt_id_raw = entry.get("commitment_id")
-            if not cmt_id_raw:
+    # Iterate the generator directly. ``_iter_all_receipts`` already
+    # materializes and sorts internally; wrapping it in ``list(...)``
+    # here would be a pointless second full copy. Integrity failures
+    # raise from the generator during iteration, so the try/except
+    # covers the whole walk.
+    try:
+        for entry in _iter_all_receipts(store):
+            rt = _extract_receipt_type(entry)
+            seq = entry.get("_store_seq")
+            if not isinstance(seq, int) or isinstance(seq, bool):
+                # Defensive: _iter_all_receipts already enforces this.
                 continue
-            cmt_id = str(cmt_id_raw)
-            if cmt_id in registrations:
-                # First-seen wins. Matches pre-extraction behavior.
-                continue
-            registrations[cmt_id] = RegistrationFact(
-                commitment_id=cmt_id,
-                seq=seq,
-                trace_id=trace_id,
-                episode_id=str(entry.get("episode_id") or ""),
-                actor_id=str(entry.get("actor_id") or ""),
-                text=str(entry.get("text") or ""),
-                commitment_type=str(entry.get("commitment_type") or ""),
-                due_at=_opt_str(entry.get("due_at")),
-                registered_at=_extract_timestamp(entry),
-            )
-            continue
 
-        if rt == RESULT_OBSERVATION_RECEIPT_TYPE:
-            result_id_raw = entry.get("result_id")
-            if not result_id_raw:
-                continue
-            result_id = str(result_id_raw)
-            referenced: List[str] = []
-            for ref in entry.get("references") or []:
-                if (
-                    isinstance(ref, dict)
-                    and ref.get("kind") == "commitment"
-                    and ref.get("id")
-                ):
-                    ref_cmt = str(ref["id"])
-                    referenced.append(ref_cmt)
-                    # Latest observation seq wins (still strictly < future
-                    # terminal seqs because we walk in _store_seq order).
-                    anchor_seq_by_pair[(result_id, ref_cmt)] = seq
+            trace_id = str(entry.get("_trace_id") or "")
+            if trace_id:
+                trace_ids_seen.add(trace_id)
 
-            if referenced:
-                observation_anchors.append(
-                    ObservationAnchorFact(
+            if rt == COMMITMENT_REGISTRATION_RECEIPT_TYPE:
+                cmt_id_raw = entry.get("commitment_id")
+                if not cmt_id_raw:
+                    continue
+                cmt_id = str(cmt_id_raw)
+                if cmt_id in registrations:
+                    # First-seen wins. Matches pre-extraction behavior.
+                    continue
+                registrations[cmt_id] = RegistrationFact(
+                    commitment_id=cmt_id,
+                    seq=seq,
+                    trace_id=trace_id,
+                    episode_id=str(entry.get("episode_id") or ""),
+                    actor_id=str(entry.get("actor_id") or ""),
+                    text=str(entry.get("text") or ""),
+                    commitment_type=str(entry.get("commitment_type") or ""),
+                    due_at=_opt_str(entry.get("due_at")),
+                    registered_at=_extract_timestamp(entry),
+                )
+                continue
+
+            if rt == RESULT_OBSERVATION_RECEIPT_TYPE:
+                result_id_raw = entry.get("result_id")
+                if not result_id_raw:
+                    continue
+                result_id = str(result_id_raw)
+                referenced: List[str] = []
+                for ref in entry.get("references") or []:
+                    if (
+                        isinstance(ref, dict)
+                        and ref.get("kind") == "commitment"
+                        and ref.get("id")
+                    ):
+                        ref_cmt = str(ref["id"])
+                        referenced.append(ref_cmt)
+                        # Latest observation seq wins (still strictly <
+                        # future terminal seqs because we walk in
+                        # _store_seq order).
+                        anchor_seq_by_pair[(result_id, ref_cmt)] = seq
+
+                if referenced:
+                    observation_anchors.append(
+                        ObservationAnchorFact(
+                            seq=seq,
+                            result_id=result_id,
+                            referenced_commitment_ids=tuple(referenced),
+                        )
+                    )
+                continue
+
+            if rt in TERMINAL_FULFILLMENT_TYPES:
+                cmt_id_raw = entry.get("commitment_id")
+                result_id_raw = entry.get("result_id")
+                if not cmt_id_raw or not result_id_raw:
+                    continue
+                cmt_id = str(cmt_id_raw)
+                result_id = str(result_id_raw)
+
+                has_registration = cmt_id in registrations
+                anchor_seq = anchor_seq_by_pair.get((result_id, cmt_id))
+                has_anchor = anchor_seq is not None
+                already_closed = cmt_id in closures
+
+                reasons: List[str] = []
+                if not has_registration:
+                    reasons.append(
+                        "no registration seen before this terminal"
+                    )
+                if not has_anchor:
+                    reasons.append(
+                        f"no anchor edge from result_id={result_id!r} "
+                        f"to commitment={cmt_id!r} at the terminal's "
+                        "encounter point"
+                    )
+                if already_closed:
+                    reasons.append(
+                        f"post-closure terminal (commitment already "
+                        f"closed by seq="
+                        f"{closures[cmt_id].closing_terminal_seq})"
+                    )
+
+                is_valid = not reasons
+
+                terminals.append(
+                    TerminalFact(
                         seq=seq,
+                        receipt_type=rt,
+                        commitment_id=cmt_id,
                         result_id=result_id,
-                        referenced_commitment_ids=tuple(referenced),
+                        is_valid_closure=is_valid,
+                        invalid_reasons=tuple(reasons),
                     )
                 )
-            continue
 
-        if rt in TERMINAL_FULFILLMENT_TYPES:
-            cmt_id_raw = entry.get("commitment_id")
-            result_id_raw = entry.get("result_id")
-            if not cmt_id_raw or not result_id_raw:
+                if is_valid:
+                    # Semantic invariant: is_valid implies not `reasons`,
+                    # which implies has_anchor is True, which implies
+                    # anchor_seq is an int. Assert the chain so the
+                    # type system (and future refactors) can rely on it
+                    # without a ``type: ignore``.
+                    assert anchor_seq is not None, (
+                        "is_valid closure without anchor_seq — invariant "
+                        "violated"
+                    )
+                    closures[cmt_id] = ClosureFact(
+                        commitment_id=cmt_id,
+                        closing_terminal_seq=seq,
+                        closing_terminal_type=rt,
+                        anchor_observation_seq=anchor_seq,
+                    )
                 continue
-            cmt_id = str(cmt_id_raw)
-            result_id = str(result_id_raw)
-
-            has_registration = cmt_id in registrations
-            anchor_seq = anchor_seq_by_pair.get((result_id, cmt_id))
-            has_anchor = anchor_seq is not None
-            already_closed = cmt_id in closures
-
-            reasons: List[str] = []
-            if not has_registration:
-                reasons.append("no registration seen before this terminal")
-            if not has_anchor:
-                reasons.append(
-                    f"no anchor edge from result_id={result_id!r} to "
-                    f"commitment={cmt_id!r} at the terminal's encounter point"
-                )
-            if already_closed:
-                reasons.append(
-                    f"post-closure terminal (commitment already closed "
-                    f"by seq={closures[cmt_id].closing_terminal_seq})"
-                )
-
-            is_valid = not reasons
-
-            terminals.append(
-                TerminalFact(
-                    seq=seq,
-                    receipt_type=rt,
-                    commitment_id=cmt_id,
-                    result_id=result_id,
-                    is_valid_closure=is_valid,
-                    invalid_reasons=tuple(reasons),
-                )
-            )
-
-            if is_valid:
-                # anchor_seq is not None here because has_anchor was True.
-                closures[cmt_id] = ClosureFact(
-                    commitment_id=cmt_id,
-                    closing_terminal_seq=seq,
-                    closing_terminal_type=rt,
-                    anchor_observation_seq=anchor_seq,  # type: ignore[arg-type]
-                )
-            continue
+    except ReceiptStoreIntegrityError as exc:
+        # Paired fields: human-readable message + original exception for
+        # forensic chain. On integrity failure, return an empty
+        # projection so consumers cannot accidentally act on partial
+        # facts — the contract is "corruption never produces clean
+        # semantic output", and empty+error is the shape that enforces
+        # it.
+        return CommitmentLifecycleProjection(
+            scanned_at=scanned_at,
+            integrity_error=str(exc),
+            integrity_exception=exc,
+        )
 
     return CommitmentLifecycleProjection(
         registrations=registrations,

--- a/tests/assay/test_commitment_projection_parity.py
+++ b/tests/assay/test_commitment_projection_parity.py
@@ -508,3 +508,65 @@ def test_all_consumers_fail_closed_on_same_corrupt_corpus(tmp_path):
     # mixed with corruption evidence.
     assert explanation.registration is None
     assert explanation.timeline == []
+
+
+def test_projection_preserves_original_integrity_exception(tmp_path):
+    """The projection surfaces BOTH a human-readable ``integrity_error``
+    string and the original ``integrity_exception`` object so callers
+    that need forensic chain (e.g. the detector) can re-raise with the
+    original traceback intact, while callers that only need a user-
+    facing message (CLI) can read the string.
+
+    This test locks the paired-field contract. A future refactor that
+    dropped ``integrity_exception`` would silently degrade
+    debuggability; this test makes that visible.
+    """
+    from assay.commitment_projection import project_commitment_lifecycle
+    from assay.store import ReceiptStoreIntegrityError
+
+    store = AssayStore(base_dir=tmp_path / "preserve_exc")
+    store.start_trace()
+    store.append_dict({
+        "type": COMMITMENT_REGISTRATION_RECEIPT_TYPE,
+        "commitment_id": "cmt_preserve",
+        "episode_id": "ep",
+        "actor_id": "alice",
+        "text": "test",
+        "commitment_type": "delivery",
+        "policy_hash": "sha256:" + "c" * 64,
+        "due_at": "2020-01-01T00:00:00Z",
+        "timestamp": "2026-04-20T10:00:00Z",
+    })
+    trace_files = sorted(store.base_dir.rglob("trace_*.jsonl"))
+    with open(trace_files[-1], "a") as f:
+        f.write("{corrupt\n")
+
+    projection = project_commitment_lifecycle(store)
+
+    # Both fields must be set in lockstep.
+    assert projection.integrity_error is not None, (
+        "projection must expose integrity_error for user-facing display"
+    )
+    assert projection.integrity_exception is not None, (
+        "projection must expose integrity_exception for forensic chain"
+    )
+    assert isinstance(projection.integrity_exception, ReceiptStoreIntegrityError)
+    # The string must come from the exception (not a different source).
+    assert str(projection.integrity_exception) == projection.integrity_error
+
+    # All other projection fields must be empty — the corruption
+    # contract. No partial authoritative facts alongside an integrity
+    # error.
+    assert projection.registrations == {}
+    assert projection.observation_anchors == []
+    assert projection.terminals == []
+    assert projection.closures == {}
+
+    # The detector re-raises an exception whose message matches the
+    # original. (We can't assert identity because the detector calls
+    # ``project_commitment_lifecycle`` which triggers a fresh walk
+    # and a fresh exception instance, but the message must be the
+    # same — proving the detector is not synthesizing its own text.)
+    with pytest.raises(ReceiptStoreIntegrityError) as exc_info:
+        detect_open_overdue_commitments(store)
+    assert str(exc_info.value) == projection.integrity_error


### PR DESCRIPTION
## Summary

Post-merge cleanup from PR #87's Copilot review. Four nits. No doctrine change, no behavior change, no Slice 2.

Copilot did not challenge projection architecture — it found type hygiene, memory hygiene, exception provenance, and one docstring typo. This PR closes all four.

## The four fixes

### 1. `# type: ignore[arg-type]` → explicit invariant assert

`src/assay/commitment_projection.py`

The code semantically depends on `is_valid` implying `anchor_seq is not None`. An explicit assert is both clearer to the reader and safer against future refactors than suppressing the type check:

```python
if is_valid:
    assert anchor_seq is not None, (
        "is_valid closure without anchor_seq — invariant violated"
    )
    closures[cmt_id] = ClosureFact(
        ...
        anchor_observation_seq=anchor_seq,  # type-safe, no ignore needed
    )
```

### 2. Drop pointless `list(_iter_all_receipts(store))` materialization

`src/assay/commitment_projection.py`

`_iter_all_receipts` already materializes and sorts internally before yielding (to produce `_store_seq` order). Wrapping the yielded generator in `list()` created a second full copy. Now iterates the generator directly inside the try/except that covers the walk.

### 3. Preserve original `ReceiptStoreIntegrityError` via paired field

`src/assay/commitment_projection.py`, `src/assay/commitment_closure_detector.py`

New field: `CommitmentLifecycleProjection.integrity_exception: Optional[ReceiptStoreIntegrityError]`

Lives alongside the existing `integrity_error: Optional[str]`:
- string stays for user-facing display (CLI, JSON output)
- exception object stays for forensic chain (preserves `__cause__` / `__context__`; re-raise may append the detector's raise site to the traceback, but provenance is no longer collapsed into text)

Detector's `integrity_exception is not None` branch now re-raises the captured exception directly:

```python
if projection.integrity_exception is not None:
    raise projection.integrity_exception
```

instead of wrapping its string in a fresh instance. Precise contract: **the projection preserves its original exception object; the detector re-raises the exception captured by its own projection pass.** (Not "same instance across two independent detector calls" — each `detect_open_overdue_commitments` call triggers its own projection walk and captures a fresh instance. The invariant is that within one call, the detector never synthesizes a fresh error from a string.)

### 4. Fix inline comment typo

`src/assay/commitment_projection.py`

```python
# Before:
receipt_type: str  # "fulfillment.commitment_kept" | "commitment_broken"

# After:
# Full dotted receipt-type name, one of:
#   "fulfillment.commitment_kept"
#   "fulfillment.commitment_broken"
receipt_type: str
```

## New test

`tests/assay/test_commitment_projection_parity.py::test_projection_preserves_original_integrity_exception`

Locks the paired-field contract so a future refactor can't silently drop `integrity_exception`:

- `integrity_error` (string) and `integrity_exception` (object) both set in lockstep on corruption
- `integrity_exception` is a `ReceiptStoreIntegrityError` instance
- Their string forms match — no synthesized message
- All other projection fields are empty on corruption (the "no partial facts" invariant from PR #87's parity test)
- Detector re-raises with the same message — proves no re-wrap

## Diffstat

```
 src/assay/commitment_projection.py               | 176 +++++++++++----------
 src/assay/commitment_closure_detector.py         |  12 +-
 tests/assay/test_commitment_projection_parity.py |  70 ++++++++
 3 files changed, 209 insertions(+), 117 deletions(-)
```

## Test totals

- `test_commitment_projection_parity.py` — **6 passing** (up from 5 on PR #87)
- Focused + adjacent — **210 passing**, 0 failing

## Scope boundary (held)

- No doctrine change
- No CLI behavior change
- No storage migration
- No schema change
- No new abstraction
- No Slice 2 obligation work
- No reopening of the commitment wedge

## Review state

Ready for review. Awaiting CI green + Copilot pass, then squash-merge if clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
