### PR TITLE
docs: align boundary maps with Threadwork naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,7 +717,7 @@ Restart your shell after installing. Tab completion works for all commands and o
 - [OpenClaw v1 Claim Sheet](docs/openclaw-v1-claim-sheet.md) -- tight public claim: proofs, non-proofs, trust assumptions, and required artifacts
 - [OpenClaw Support](docs/openclaw-support.md) -- current supported posture, proof boundary, and non-goals for OpenClaw integrations
 - [What Assay Does Today](docs/WHAT_ASSAY_DOES_TODAY.md) -- the plain-language founder memo
-- [Boundary Map](docs/BOUNDARY_MAP.md) -- Assay vs VendorQ vs AgentMesh vs Loom/CCIO
+- [Boundary Map](docs/BOUNDARY_MAP.md) -- Assay vs VendorQ vs Threadwork vs Loom/CCIO
 - [Full Picture](docs/FULL_PICTURE.md) -- architecture, trust tiers, repo boundaries, release history
 - [Quickstart](docs/README_quickstart.md) -- install, golden path, command reference
 - [For Compliance Teams](docs/for-compliance.md) -- what auditors see, evidence artifacts, framework alignment

--- a/docs/BOUNDARY_MAP.md
+++ b/docs/BOUNDARY_MAP.md
@@ -6,14 +6,18 @@ This is the working boundary for the current charter. If a sentence blurs these 
 |-----------|------------|----------|------------------|------------------|------------------------|
 | Assay | Public evidence compiler for AI execution: scan, patch, run, signed proof pack, offline verify | Developers, security reviewers, procurement reviewers | Public | Current | Public trust layer |
 | VendorQ | Reviewer workflow and packet compiler built on top of Assay evidence | Teams answering buyer or reviewer questions | Public-facing workflow, but wedge-specific | Current wedge hypothesis | Wedge |
-| AgentMesh | Provenance and execution-lineage helper used to support delivery and runtime evidence stories | Builders who need lineage between execution surfaces | Public | Current, but support-layer | Support for the trust story, not the whole product |
+| Threadwork | Provenance and execution-lineage helper used to support delivery and runtime evidence stories | Builders who need lineage between execution surfaces | Public | Current, but support-layer | Support for the trust story, not the whole product |
 | Loom / CCIO | Private constitutional runtime and consequence membrane: episodes, checkpoints, governance, lineage, settlement | Internal builder / operator surface | Private | Current privately, future strategic center | Organism |
 
 ## Working rules
 
 - Assay is the first public trust story.
 - VendorQ is a wedge hypothesis built on that trust layer.
-- AgentMesh is supporting provenance infrastructure.
+- Threadwork is supporting provenance infrastructure.
+- Compatibility note: implementation/runtime surfaces may still use `agentmesh` naming during migration.
+- Naming invariant during migration: `Threadwork` is the public name. `agentmesh`
+  may remain in repository, package, CLI, config, schema, state-path, and
+  trailer surfaces until an explicit compatibility plan lands.
 - Loom / CCIO is where the real load-bearing membrane is allowed to get weird and powerful.
 
 ## Anti-blur rules

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -13,7 +13,7 @@ how the Assay ecosystem fits together.
 | [Haserjian/assay-ledger](https://github.com/Haserjian/assay-ledger) | Public transparency ledger (GitHub Pages) | Append-only ledger entries via PR | Tim Bhaserjian |
 | [Haserjian/assay-scorecard](https://github.com/Haserjian/assay-scorecard) | Ecosystem readiness scoring | Public scorecard site | Tim Bhaserjian |
 | [Haserjian/assay-agent-demo](https://github.com/Haserjian/assay-agent-demo) | Demo packs and walkthroughs | Demo proof packs | Tim Bhaserjian |
-| [Haserjian/agentmesh](https://github.com/Haserjian/agentmesh) | Provenance and coordination engine | Claims, episodes, lineage, witness tooling | Tim Bhaserjian |
+| [Haserjian/agentmesh](https://github.com/Haserjian/agentmesh) | Threadwork coordination and provenance substrate (repo currently `agentmesh`) | Claims, episodes, lineage, witness tooling | Tim Bhaserjian |
 
 ## Private Repos
 
@@ -62,10 +62,12 @@ Public append-only ledger. Accepts submissions via PR workflow. Entries include:
 - `witness_level` (unwitnessed, hash_verified, signature_verified)
 - signer fingerprint and timestamp
 
-### Haserjian/agentmesh
+### Haserjian/agentmesh (Threadwork)
 
-Provenance and coordination system. It tracks claims, episodes, and lineage
-and can feed evidence into Assay.
+Threadwork is the provenance and coordination substrate. It tracks claims,
+episodes, and lineage and can feed evidence into Assay. The public name is
+moving to `Threadwork`; the repo/package/CLI still carry `agentmesh` naming
+during migration.
 
 ## Open vs Closed Product Boundary
 

--- a/docs/security/SECURITY_POSTURE_TODAY.md
+++ b/docs/security/SECURITY_POSTURE_TODAY.md
@@ -93,11 +93,15 @@ If stronger language is desired, that requires a protocol and workflow change ra
 
 Current operating decision: keep public ledger claims at manifest/attestation witness scope unless the protocol changes. See [`LEDGER_SCOPE_DECISION.md`](LEDGER_SCOPE_DECISION.md).
 
-## AgentMesh Integration Today
+## Threadwork Integration Today
 
 In the Assay-integrated reference workflow:
-- AgentMesh records lineage, coordination, and provenance
+- Threadwork records lineage, coordination, and provenance
 - Assay handles proof-pack verification and trust-artifact packaging
+
+Current compatibility note:
+- Threadwork is the canonical public name
+- runtime/package/CLI surfaces may still use `agentmesh` naming during migration
 
 Current honest CI language is:
 - `assay-gate` is the baseline evidence-readiness score


### PR DESCRIPTION
## Summary
- Introduce `Threadwork` as the canonical public/narrative name for the provenance substrate
- Retain `agentmesh` in repo, package, CLI, schema, state-path, and trailer surfaces during the migration window
- Update `BOUNDARY_MAP.md`, `REPO_MAP.md`, `README.md`, and `SECURITY_POSTURE_TODAY.md` to reflect naming
- Add explicit naming-invariant to `BOUNDARY_MAP.md` so future agents do not broaden the rename

## Scope
Docs-only. No CLI, package, schema, state-path, or trailer changes.

## Test plan
- [ ] Narrative consistency across BOUNDARY_MAP, REPO_MAP, README, SECURITY_POSTURE_TODAY
- [ ] No compatibility-surface references inadvertently renamed