### PR TITLE
feat(commitments): implement terminal-state membrane

### DIFF
--- a/docs/doctrine/COMMITMENT_TERMINAL_MEMBRANE.md
+++ b/docs/doctrine/COMMITMENT_TERMINAL_MEMBRANE.md
@@ -1,0 +1,244 @@
+# Commitment Terminal-State Membrane
+
+**Status:** decided (paper + code landed together for the membrane surface)
+**Scope:** commitment-lifecycle reader/writer code paths
+**Supersedes:** the prose-only handling of revocation/amendment/supersession
+implicit in Slice 1
+
+---
+
+## Doctrine sentence
+
+> Kept, broken, revoked, amended, and superseded may all end a
+> commitment's active life, but only kept/broken are fulfillment
+> outcomes.
+
+## Implementation invariant
+
+> If it changes list or overdue, it must be state, not commentary.
+
+---
+
+## What this surface is
+
+Before this membrane, `list` and `overdue` only knew two ways a
+commitment could end its active life:
+
+- `fulfillment.commitment_kept` — the commitment was kept.
+- `fulfillment.commitment_broken` — the commitment was broken.
+
+Every other ending — revocation, amendment, supersession — lived only
+as prose (operator comments, audit notes, slack threads). A revoked
+commitment still appeared in `list` as OPEN; still showed up in
+`overdue`; still fired the constitutional-violation path. That made
+`list` and `overdue` lie: a commitment that *the operator had ended*
+still read as active.
+
+The terminal-state membrane fixes that. It introduces one new event,
+`commitment.terminated`, covering **only non-fulfillment terminal
+endings** (revoked | superseded | amended), plus the projection /
+summary / detector updates that make those endings machine-visible
+state — not prose notes.
+
+## Non-fulfillment terminal endings are state, not notes
+
+A `commitment.terminated` event ends a commitment's active life with
+one of three `terminal_reason` values:
+
+- `revoked` — the commitment is withdrawn; no fulfillment, no
+  replacement.
+- `superseded` — the commitment is replaced by a different, newly
+  registered commitment (via `replacement_commitment_id`).
+- `amended` — the commitment is replaced by a revised version of
+  itself. The old commitment is NOT edited in place; instead a new
+  commitment is registered with `supersedes_commitment_id` pointing
+  at the original, and the original receives a
+  `commitment.terminated` with `terminal_reason=amended` and
+  `amended_field` naming what changed.
+
+None of these are fulfillment. The grammar is strict:
+
+- **CLOSED** = closed by `fulfillment.commitment_kept` or
+  `fulfillment.commitment_broken`. Fulfillment outcome.
+- **TERMINATED** = closed by `commitment.terminated`. NOT a
+  fulfillment outcome. The commitment ended its active life without a
+  kept/broken judgement.
+- **OPEN** = registered, no terminal event yet.
+
+`commitment.terminated` does NOT absorb kept/broken. The existing
+event types `fulfillment.commitment_kept` and
+`fulfillment.commitment_broken` are untouched by this PR. No
+`verified` / `breached` vocabulary has been introduced.
+
+## Amendment terminates the original only by registering a replacement
+
+Amendment is never an in-place mutation. The membrane refuses to
+pretend a commitment can be edited after the fact. The shape is
+always:
+
+1. Original commitment receives:
+   - `commitment.terminated`
+   - `terminal_reason: amended`
+   - `replacement_commitment_id: <new id>`
+   - `amended_field: due_at | scope | owner | acceptance_terms`
+
+2. A replacement commitment is registered separately with:
+   - `commitment.registered`
+   - `supersedes_commitment_id: <old id>`
+   - optional `lineage_root_commitment_id` for convenience
+
+The replacement is a new aggregate. It has its own registration seq,
+its own lifecycle, its own terminal events. The original is
+TERMINATED; the replacement starts OPEN. Until the replacement itself
+closes or is terminated, it stays in the active list.
+
+## Lineage is stored as immediate edges
+
+Supersession forms a chain (A → B → C → ...). The membrane stores
+ONLY immediate edges:
+
+- The registration receipt for the successor may carry
+  `supersedes_commitment_id` naming its direct predecessor.
+- The termination receipt for the predecessor may carry
+  `replacement_commitment_id` naming its direct successor.
+
+Either edge is sufficient. If both are present they refer to the same
+edge and the projection deduplicates. Chains are NEVER duplicated onto
+each event. `lineage_root_commitment_id` is allowed as a convenience —
+when the emitter knows the chain's root, it can record it — but
+consumers must be able to reconstruct chains by walking edges. The
+projection's `supersession_edges` list is the operator's view of the
+lineage graph.
+
+## First terminal wins
+
+A commitment has at most ONE terminal event across all three types:
+
+- `fulfillment.commitment_kept`
+- `fulfillment.commitment_broken`
+- `commitment.terminated`
+
+The emit path enforces this. If a terminal event already exists for a
+commitment_id, a second terminal event is refused:
+
+- **Same `idempotency_key` on `commitment.terminated`** — treated as a
+  replay. NO event is written; the emitter returns a no-op signal. Same
+  key = same operation.
+- **Different `idempotency_key`, or different terminal type** —
+  `TerminalFulfillmentError` is raised at emission time. NO event is
+  written. The first terminal keeps the commitment.
+
+This rule is symmetric: kept cannot replace terminated, terminated
+cannot replace broken, etc.
+
+## Runtime authority
+
+Four `authority_mode` values are schema-reserved:
+
+- `self` — the author is terminating their own commitment. **Only this
+  is accepted in the current probe.**
+- `owner`, `policy`, `external` — reserved for future delegation work.
+  The schema permits them; the emit path rejects them with
+  `AuthorityModeUnsupportedError`. No event is written.
+
+Values outside the enum fail schema validation before reaching the
+emit-path runtime check. No event is written on schema failure.
+
+## Identity and idempotency
+
+The membrane distinguishes `commitment_id` (aggregate identity) from
+`idempotency_key` (operation identity). They are stable on both sides
+but derived independently.
+
+**commitment_id** — prefer an emitter-authored stable id when
+available. Otherwise derive:
+
+```text
+sha256(emitter_namespace || "\0" || actor || "\0" ||
+       plan_slot_key || "\0" || normalized_first_authored_text)
+```
+
+**idempotency_key** — derive:
+
+```text
+sha256(emitter_namespace || "\0" || operation_id || "\0" ||
+       commitment_id || "\0" || event_type)
+```
+
+Conflict rules:
+
+- Same `idempotency_key` = no-op.
+- Same `commitment_id` with materially different text = **conflict**,
+  not silent replacement. The emitter must detect this and either
+  allocate a new id or refuse.
+
+### Normalization of `normalized_first_authored_text`
+
+- Unicode NFC normalization.
+- Trim leading and trailing whitespace.
+- Collapse internal whitespace runs to a single space (any whitespace
+  character collapses to one ASCII space).
+- **No case folding.** "Ship the report" and "ship the report" are
+  different commitments.
+
+The normalization is applied ONLY to the id-derivation input. The
+stored `text` field round-trips as authored.
+
+## Projection / list / overdue behavior
+
+The shared lifecycle projection
+(`src/assay/commitment_projection.py`) now carries:
+
+- `closures` — fulfillment closures (kept | broken), keyed by
+  commitment_id.
+- `terminations` — `commitment.terminated` events, keyed by
+  commitment_id (first-wins).
+- `supersession_edges` — immediate predecessor→successor edges across
+  both registered-side and terminated-side declarations, deduplicated.
+
+`list` summaries carry three states: OPEN, CLOSED, TERMINATED.
+TERMINATED summaries also expose `terminal_reason`, `termination_seq`,
+and `replacement_commitment_id`. `is_overdue` is always False for
+TERMINATED (same rule as CLOSED — ended commitments are never
+overdue).
+
+`overdue` excludes TERMINATED commitments. The detector's filter is:
+
+```text
+registered AND not-closed AND not-terminated AND due_at < now
+```
+
+## Storage convention
+
+`commitment.terminated` and the extended `commitment.registered`
+fields write through the same `_store_seq` allocator and storage
+envelope used by existing commitment events. There is no parallel
+write path. Schema files live next to the existing commitment schemas
+at `src/assay/schemas/`.
+
+## Probe scope meta-receipt
+
+`probe.scoped` is a meta-receipt that declares a probe's boundary.
+Required fields: `probe_name`, `scope`, `owner_equals_author`,
+`delegation_allowed`, `external_ingestion_allowed`,
+`allowed_event_types`, `membrane_version`, `code_commit`,
+`emitted_at`.
+
+This PR does NOT wire the full claude-organism self-authored emitter;
+it only makes the membrane + projection + probe schema real and
+testable. Wiring the actual emitter is a next slice.
+
+## What this membrane does NOT do
+
+- No delegation. `authority_mode` values other than `self` are
+  rejected until delegation work lands.
+- No Jira/Linear ingestion.
+- No manager assignment flows.
+- No renaming of existing `commitment.registered` /
+  `fulfillment.commitment_kept` / `fulfillment.commitment_broken`
+  vocabulary.
+- No full supersession-chain duplication — immediate edges only.
+- No in-place mutation of a live commitment.
+- No treating revocation as fulfillment.
+- No buyer-demo copy change (`docs/demo/commitments_slice1_demo.md` is
+  untouched).

--- a/src/assay/commitment_closure_detector.py
+++ b/src/assay/commitment_closure_detector.py
@@ -129,7 +129,9 @@ def detect_open_overdue_commitments(
     open_commitments: List[OpenOverdueCommitment] = []
     for cmt_id, reg in projection.registrations.items():
         if cmt_id in projection.closures:
-            continue  # closed — not overdue
+            continue  # closed by fulfillment — not overdue
+        if cmt_id in projection.terminations:
+            continue  # terminated (revoked | superseded | amended) — not overdue
         if not reg.due_at:
             continue  # perpetual
         due_dt = _parse_iso(reg.due_at)

--- a/src/assay/commitment_explain.py
+++ b/src/assay/commitment_explain.py
@@ -79,10 +79,19 @@ class ExplainLine:
 
 @dataclass(frozen=True)
 class ExplainResult:
-    """The full explanation record for a single commitment."""
+    """The full explanation record for a single commitment.
+
+    States:
+        CLOSED         — ended by fulfillment (kept | broken).
+        TERMINATED     — ended by commitment.terminated (revoked |
+                         superseded | amended). Non-fulfillment ending.
+        OPEN           — registered, no terminal event yet.
+        NOT_REGISTERED — no registration receipt found.
+        INVALID_STORE  — the receipt corpus failed integrity validation.
+    """
 
     commitment_id: str
-    state: str  # CLOSED | OPEN | NOT_REGISTERED | INVALID_STORE
+    state: str  # CLOSED | TERMINATED | OPEN | NOT_REGISTERED | INVALID_STORE
     registration: Optional[ExplainLine]
     timeline: List[ExplainLine]
     decision: str
@@ -133,6 +142,7 @@ def explain_commitment(store: AssayStore, commitment_id: str) -> ExplainResult:
 
     reg_fact = projection.registrations.get(commitment_id)
     closure_fact = projection.closures.get(commitment_id)
+    termination_fact = projection.terminations.get(commitment_id)
 
     # Build the per-commitment timeline. The projection already has
     # everything we need; we just filter and translate facts into the
@@ -187,6 +197,30 @@ def explain_commitment(store: AssayStore, commitment_id: str) -> ExplainResult:
             )
         terminal_lines_for_cmt.append(line)
 
+    # Termination line (commitment.terminated, if any).
+    termination_line: Optional[ExplainLine] = None
+    if termination_fact is not None:
+        replacement_hint = (
+            f", replacement={termination_fact.replacement_commitment_id!r}"
+            if termination_fact.replacement_commitment_id
+            else ""
+        )
+        amended_hint = (
+            f", amended_field={termination_fact.amended_field!r}"
+            if termination_fact.amended_field
+            and termination_fact.amended_field != "none"
+            else ""
+        )
+        termination_line = ExplainLine(
+            seq=termination_fact.seq,
+            receipt_type="commitment.terminated",
+            summary=(
+                f"terminated (reason={termination_fact.terminal_reason}"
+                f"{amended_hint}{replacement_hint})"
+            ),
+            note="terminates commitment",
+        )
+
     # Compose the timeline in seq order. The projection guarantees seq
     # is the authoritative causal key for this per-aggregate view.
     timeline: List[ExplainLine] = []
@@ -194,6 +228,8 @@ def explain_commitment(store: AssayStore, commitment_id: str) -> ExplainResult:
         timeline.append(registration)
     timeline.extend(observation_lines)
     timeline.extend(terminal_lines_for_cmt)
+    if termination_line is not None:
+        timeline.append(termination_line)
     timeline.sort(key=lambda line: line.seq)
 
     # ----- Decision -----
@@ -223,6 +259,28 @@ def explain_commitment(store: AssayStore, commitment_id: str) -> ExplainResult:
         return ExplainResult(
             commitment_id=commitment_id,
             state="CLOSED",
+            registration=registration,
+            timeline=timeline,
+            decision=decision,
+        )
+
+    if termination_fact is not None:
+        replacement_hint = (
+            f" replacement_commitment_id="
+            f"{termination_fact.replacement_commitment_id!r}."
+            if termination_fact.replacement_commitment_id
+            else ""
+        )
+        decision = (
+            f"TERMINATED because commitment.terminated "
+            f"seq={termination_fact.seq} ended the commitment "
+            f"with terminal_reason={termination_fact.terminal_reason!r}. "
+            "This is a non-fulfillment ending — not a kept/broken "
+            "outcome." + (f" {replacement_hint}" if replacement_hint else "")
+        )
+        return ExplainResult(
+            commitment_id=commitment_id,
+            state="TERMINATED",
             registration=registration,
             timeline=timeline,
             decision=decision,
@@ -353,11 +411,20 @@ def _format_summary_line(s: CommitmentSummary) -> str:
     structured fields from ``--json``, not this prose format.
     """
     overdue_marker = " [OVERDUE]" if s.is_overdue else ""
-    closing = (
-        f" via seq={s.closing_terminal_seq} ({s.closing_terminal_type})"
-        if s.closing_terminal_seq is not None
-        else ""
-    )
+    if s.closing_terminal_seq is not None:
+        closing = f" via seq={s.closing_terminal_seq} ({s.closing_terminal_type})"
+    elif s.termination_seq is not None:
+        replacement = (
+            f" replacement={s.replacement_commitment_id}"
+            if s.replacement_commitment_id
+            else ""
+        )
+        closing = (
+            f" via seq={s.termination_seq} "
+            f"(commitment.terminated:{s.terminal_reason}){replacement}"
+        )
+    else:
+        closing = ""
     return (
         f"{s.commitment_id}  {s.state}{overdue_marker}  "
         f"registered_seq={s.registered_seq}  "

--- a/src/assay/commitment_fulfillment.py
+++ b/src/assay/commitment_fulfillment.py
@@ -1,14 +1,23 @@
-"""Commitment → Result → Fulfillment wedge — Slice 1.
+"""Commitment → Result → Fulfillment wedge — Slice 1 + terminal membrane.
 
 Doctrine source: loom-staging docs/architecture/authority_nouns.md
 (commit 9c5921d5, frozen).
 
 Event lifecycle:
-    commitment.registered      — a declared forward-looking commitment.
-    result.observed            — a non-adjudicating observation referencing
-                                 zero or more commitments. Never closes.
-    fulfillment.commitment_kept    — terminal: commitment was kept.
-    fulfillment.commitment_broken  — terminal: commitment was broken.
+    commitment.registered            — a declared forward-looking commitment.
+    result.observed                  — a non-adjudicating observation.
+    fulfillment.commitment_kept      — terminal: commitment was kept.
+    fulfillment.commitment_broken    — terminal: commitment was broken.
+    commitment.terminated            — terminal: non-fulfillment ending
+                                       (revoked | superseded | amended).
+
+Doctrine sentence:
+    "Kept, broken, revoked, amended, and superseded may all end a
+    commitment's active life, but only kept/broken are fulfillment
+    outcomes."
+
+Implementation invariant:
+    "If it changes list or overdue, it must be state, not commentary."
 
 Invariants:
     1. Every commitment.registered must have a resolvable policy_hash. The
@@ -17,9 +26,13 @@ Invariants:
     2. result.observed is non-adjudicating. It MUST NOT contain ``fulfills``
        or ``closes`` fields. References are typed ({"kind": "commitment",
        "id": ...}) and do not, by themselves, close anything.
-    3. A commitment has zero or one terminal fulfillment. Emission of a
-       second terminal for the same commitment_id raises
-       ``TerminalFulfillmentError``.
+    3. A commitment has AT MOST ONE terminal event (kept | broken |
+       terminated). Emission of a second terminal event for the same
+       commitment_id raises ``TerminalFulfillmentError`` — with one
+       exception: replaying an identical ``commitment.terminated`` with
+       the same ``idempotency_key`` is a no-op (storage primitive).
+    4. ``commitment.terminated`` covers only non-fulfillment terminal
+       endings. It MUST NOT absorb kept/broken.
 
 This module does NOT adjudicate the obligation namespace collision with
 ``src/assay/obligation.py`` (override-debt semantics). Slice 2 must resolve
@@ -27,7 +40,9 @@ that before adding the obligation side of the wedge.
 """
 from __future__ import annotations
 
+import hashlib
 import json
+import unicodedata
 from dataclasses import asdict, dataclass, field
 from importlib import resources
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
@@ -50,8 +65,38 @@ COMMITMENT_REGISTRATION_RECEIPT_TYPE = "commitment.registered"
 RESULT_OBSERVATION_RECEIPT_TYPE = "result.observed"
 FULFILLMENT_COMMITMENT_KEPT_RECEIPT_TYPE = "fulfillment.commitment_kept"
 FULFILLMENT_COMMITMENT_BROKEN_RECEIPT_TYPE = "fulfillment.commitment_broken"
+COMMITMENT_TERMINATED_RECEIPT_TYPE = "commitment.terminated"
+PROBE_SCOPED_RECEIPT_TYPE = "probe.scoped"
 
 TERMINAL_FULFILLMENT_TYPES = frozenset({
+    FULFILLMENT_COMMITMENT_KEPT_RECEIPT_TYPE,
+    FULFILLMENT_COMMITMENT_BROKEN_RECEIPT_TYPE,
+})
+
+# All receipt types that end a commitment's active life. Includes the
+# fulfillment outcomes AND ``commitment.terminated``. "All terminal" is a
+# strictly wider set than "fulfillment terminal": kept is fulfillment,
+# terminated is not. The projection/emission guards check this set when
+# enforcing the zero-or-one terminal invariant across every ending.
+TERMINAL_RECEIPT_TYPES = frozenset(
+    TERMINAL_FULFILLMENT_TYPES | {COMMITMENT_TERMINATED_RECEIPT_TYPE}
+)
+
+# Enums — doctrine-exact. Do not rename without explicit authorization.
+TERMINAL_REASONS = frozenset({"revoked", "superseded", "amended"})
+AMENDED_FIELDS = frozenset({"none", "due_at", "scope", "owner", "acceptance_terms"})
+AUTHORITY_MODES = frozenset({"self", "owner", "policy", "external"})
+
+# Runtime rule for this PR: only authority_mode=self is accepted.
+# Other values are schema-reserved but rejected at emission until
+# delegation work exists.
+ACCEPTED_AUTHORITY_MODES = frozenset({"self"})
+
+# Current self-authored probe membrane: probe.scoped must declare exactly
+# this event surface, no more and no less.
+PROBE_SCOPED_ALLOWED_EVENT_TYPES = frozenset({
+    COMMITMENT_REGISTRATION_RECEIPT_TYPE,
+    COMMITMENT_TERMINATED_RECEIPT_TYPE,
     FULFILLMENT_COMMITMENT_KEPT_RECEIPT_TYPE,
     FULFILLMENT_COMMITMENT_BROKEN_RECEIPT_TYPE,
 })
@@ -86,6 +131,18 @@ class UnanchoredFulfillmentError(ValueError):
     """
 
 
+class AuthorityModeUnsupportedError(ValueError):
+    """Raised when a commitment.terminated emission carries an authority_mode
+    that is valid per the schema but not supported in the current probe.
+
+    The schema reserves {"self", "owner", "policy", "external"}. This PR
+    only accepts ``self``. Emitting with another value is rejected at
+    validation time with an explicit "not supported in current probe"
+    diagnostic — no event is written. Support for the remaining modes
+    lands with delegation work.
+    """
+
+
 # ``ReceiptStoreIntegrityError`` is defined in ``assay.store`` (its home is
 # the storage substrate, not the commitment wedge). We re-export it here
 # for backwards-compat with tests/consumers that imported it from this
@@ -116,7 +173,14 @@ def _get_validator(schema_name: str) -> Draft202012Validator:
 
 @dataclass
 class CommitmentRegistrationArtifact:
-    """A declared forward-looking commitment."""
+    """A declared forward-looking commitment.
+
+    The optional ``supersedes_commitment_id`` and
+    ``lineage_root_commitment_id`` fields are how a replacement
+    commitment declares its lineage when registered after a prior
+    commitment was amended. See the membrane doctrine note
+    ``docs/doctrine/COMMITMENT_TERMINAL_MEMBRANE.md``.
+    """
 
     commitment_id: str
     timestamp: str
@@ -128,6 +192,8 @@ class CommitmentRegistrationArtifact:
     policy_resolver: Dict[str, Any]
     due_at: Optional[str] = None
     evidence_uri: Optional[str] = None
+    supersedes_commitment_id: Optional[str] = None
+    lineage_root_commitment_id: Optional[str] = None
     schema_version: str = SCHEMA_VERSION
     artifact_type: str = "commitment_registration"
 
@@ -221,6 +287,138 @@ class FulfillmentBrokenArtifact:
         _get_validator("fulfillment_commitment_broken.v0.1.schema.json").validate(
             self.to_dict()
         )
+
+
+@dataclass
+class CommitmentTerminatedArtifact:
+    """Non-fulfillment terminal ending: revoked | superseded | amended.
+
+    Separate receipt type from fulfillment outcomes: kept/broken remain
+    fulfillment terminals. ``commitment.terminated`` is for endings that
+    are NOT fulfillment.
+    """
+
+    commitment_id: str
+    timestamp: str
+    terminated_at: str
+    terminated_by_actor: str
+    terminal_reason: str  # revoked | superseded | amended
+    authority_mode: str   # self | owner | policy | external (only self accepted)
+    idempotency_key: str
+    amended_field: Optional[str] = None  # none | due_at | scope | owner | acceptance_terms
+    replacement_commitment_id: Optional[str] = None
+    supersedes_commitment_id: Optional[str] = None
+    lineage_root_commitment_id: Optional[str] = None
+    schema_version: str = SCHEMA_VERSION
+    artifact_type: str = "commitment_terminated"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {k: v for k, v in asdict(self).items() if v is not None}
+
+    def validate(self) -> None:
+        _get_validator("commitment_terminated.v0.1.schema.json").validate(
+            self.to_dict()
+        )
+
+
+@dataclass
+class ProbeScopedArtifact:
+    """Meta-receipt declaring a probe's boundary (scope + allowed events).
+
+    This PR does not wire the full claude-organism self-authored emitter.
+    It only makes the membrane real and testable. The artifact records
+    the probe's scope so downstream verifiers can check emitted receipts
+    against the declared boundary.
+    """
+
+    probe_name: str
+    scope: str
+    owner_equals_author: bool
+    delegation_allowed: bool
+    external_ingestion_allowed: bool
+    allowed_event_types: List[str]
+    membrane_version: str
+    code_commit: str
+    emitted_at: str
+    schema_version: str = SCHEMA_VERSION
+    artifact_type: str = "probe_scoped"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    def validate(self) -> None:
+        _get_validator("probe_scoped.v0.1.schema.json").validate(self.to_dict())
+
+
+# ---------------------------------------------------------------------------
+# Identity / idempotency derivation
+# ---------------------------------------------------------------------------
+
+
+def normalize_first_authored_text(text: str) -> str:
+    """Canonicalize commitment text for identity derivation.
+
+    Rule (documented in the membrane note):
+        - Unicode NFC.
+        - Trim leading and trailing whitespace.
+        - Collapse internal whitespace runs to a single space.
+        - No case folding.
+
+    This normalization is ONLY for commitment_id derivation. It is not
+    applied to the stored ``text`` field, which must round-trip as
+    authored.
+    """
+    nfc = unicodedata.normalize("NFC", text)
+    stripped = nfc.strip()
+    # ``split()`` without args splits on any whitespace run AND drops
+    # leading/trailing empties — exactly the collapse rule we want.
+    collapsed = " ".join(stripped.split())
+    return collapsed
+
+
+def derive_commitment_id(
+    *,
+    emitter_namespace: str,
+    actor: str,
+    plan_slot_key: str,
+    first_authored_text: str,
+) -> str:
+    """Derive a stable commitment_id from emitter-side identity material.
+
+    Used ONLY when the emitter does not have a pre-existing stable id.
+    Prefer an emitter-authored id when available.
+
+    Shape:
+        sha256(emitter_namespace || "\\0" || actor || "\\0" ||
+               plan_slot_key || "\\0" || normalized_first_authored_text)
+    """
+    normalized = normalize_first_authored_text(first_authored_text)
+    joined = "\0".join([emitter_namespace, actor, plan_slot_key, normalized])
+    digest = hashlib.sha256(joined.encode("utf-8")).hexdigest()
+    return f"cmt_{digest}"
+
+
+def derive_idempotency_key(
+    *,
+    emitter_namespace: str,
+    operation_id: str,
+    commitment_id: str,
+    event_type: str,
+) -> str:
+    """Derive a stable idempotency_key for a commitment event.
+
+    Shape:
+        sha256(emitter_namespace || "\\0" || operation_id || "\\0" ||
+               commitment_id || "\\0" || event_type)
+
+    Same idempotency_key replaying the same operation is a no-op.
+    A different idempotency_key attempting to terminate an
+    already-terminal commitment_id is a conflict (raises
+    ``TerminalFulfillmentError``).
+    """
+    joined = "\0".join([emitter_namespace, operation_id, commitment_id, event_type])
+    digest = hashlib.sha256(joined.encode("utf-8")).hexdigest()
+    return f"idem_{digest}"
 
 
 # ---------------------------------------------------------------------------
@@ -391,22 +589,50 @@ def _assert_result_anchors_commitment(
 
 
 def _assert_no_existing_terminal(store: AssayStore, commitment_id: str) -> None:
-    """Scan the entire store for a prior terminal fulfillment of this commitment.
+    """Scan the entire store for a prior terminal event of this commitment.
+
+    "Terminal" here is the WIDE set: fulfillment.commitment_kept,
+    fulfillment.commitment_broken, and commitment.terminated. A commitment
+    has AT MOST ONE terminal event across all three types — the first one
+    wins.
 
     Full-store scan, no cap. Raises TerminalFulfillmentError if one is found.
     """
     for entry in _iter_all_receipts(store):
         entry_type = _extract_receipt_type(entry)
-        if entry_type not in TERMINAL_FULFILLMENT_TYPES:
+        if entry_type not in TERMINAL_RECEIPT_TYPES:
             continue
         if entry.get("commitment_id") != commitment_id:
             continue
         raise TerminalFulfillmentError(
-            f"Commitment {commitment_id!r} already has a terminal fulfillment: "
-            f"type={entry_type!r} "
-            f"fulfillment_id={entry.get('fulfillment_id')!r}. "
-            "A commitment has zero or one terminal fulfillment."
+            f"Commitment {commitment_id!r} already has a terminal event: "
+            f"type={entry_type!r}. "
+            "A commitment has zero or one terminal event "
+            "(kept | broken | terminated); first event wins."
         )
+
+
+def _find_existing_terminated_by_idempotency(
+    store: AssayStore,
+    *,
+    commitment_id: str,
+    idempotency_key: str,
+) -> Optional[Dict[str, Any]]:
+    """Return a prior commitment.terminated receipt for this commitment with
+    the same idempotency_key, or ``None``.
+
+    Used by ``emit_commitment_terminated`` to implement the replay no-op
+    rule: same idempotency_key + same commitment_id = no-op.
+    """
+    for entry in _iter_all_receipts(store):
+        if _extract_receipt_type(entry) != COMMITMENT_TERMINATED_RECEIPT_TYPE:
+            continue
+        if entry.get("commitment_id") != commitment_id:
+            continue
+        if entry.get("idempotency_key") != idempotency_key:
+            continue
+        return entry
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -596,22 +822,173 @@ def emit_fulfillment_broken(
     return artifact
 
 
+def emit_commitment_terminated(
+    episode: Episode,
+    termination: Union[CommitmentTerminatedArtifact, Dict[str, Any]],
+    *,
+    parent_receipt_id: Optional[str] = None,
+) -> Tuple[CommitmentTerminatedArtifact, bool]:
+    """Emit a commitment.terminated receipt (revoked | superseded | amended).
+
+    Covers only non-fulfillment terminal endings. Does NOT absorb kept
+    or broken. Those remain ``fulfillment.commitment_kept`` and
+    ``fulfillment.commitment_broken`` respectively.
+
+    Guards (all before emission; no event is written on failure):
+        1. Schema validation (covers enum membership for terminal_reason,
+           authority_mode, amended_field).
+        2. Runtime authority_mode rule: only ``self`` is accepted in
+           this PR. Other values are schema-reserved but rejected with
+           ``AuthorityModeUnsupportedError`` until delegation work exists.
+          3. Amendment shape: terminal_reason=amended requires a non-None
+              ``amended_field`` (other than "none") and a
+              ``replacement_commitment_id``. These are structural
+           correctness checks, not schema checks.
+        4. Idempotency: if a prior ``commitment.terminated`` exists for
+           the same commitment_id with the SAME ``idempotency_key``, the
+           call is a NO-OP and returns ``(artifact, False)``. If a prior
+           terminal event exists for the same commitment_id with a
+           DIFFERENT idempotency_key (or of a different type),
+           ``TerminalFulfillmentError`` is raised.
+
+    Returns:
+        (artifact, wrote_event) — ``wrote_event`` is ``False`` for a
+        replayed idempotent no-op, ``True`` otherwise.
+
+    Raises:
+        AuthorityModeUnsupportedError: on a schema-valid authority_mode
+            that is not supported in the current probe.
+        TerminalFulfillmentError: on conflicting prior terminal event.
+        jsonschema.ValidationError: on schema failure.
+    """
+    artifact = (
+        termination
+        if isinstance(termination, CommitmentTerminatedArtifact)
+        else CommitmentTerminatedArtifact(**termination)
+    )
+
+    # Schema first — rejects invalid enum values, missing required fields.
+    artifact.validate()
+
+    # Runtime authority rule: only ``self`` accepted in this PR.
+    if artifact.authority_mode not in ACCEPTED_AUTHORITY_MODES:
+        raise AuthorityModeUnsupportedError(
+            f"authority_mode={artifact.authority_mode!r} is not supported "
+            "in the current probe. Only authority_mode='self' is accepted "
+            "until delegation work lands. No event written."
+        )
+
+    store = episode._store
+
+    # Termination must target an existing registered commitment.
+    _assert_commitment_exists(store, artifact.commitment_id)
+
+    # Amendment shape check.
+    if artifact.terminal_reason == "amended":
+        amended = artifact.amended_field
+        if amended is None or amended == "none":
+            raise ValueError(
+                "commitment.terminated with terminal_reason='amended' "
+                "requires a non-'none' amended_field "
+                "(due_at | scope | owner | acceptance_terms). "
+                "No event written."
+            )
+        if not artifact.replacement_commitment_id:
+            raise ValueError(
+                "commitment.terminated with terminal_reason='amended' "
+                "requires replacement_commitment_id. Amendment terminates "
+                "the original only by registering a replacement. "
+                "No event written."
+            )
+
+    # Idempotency: same key + same commitment_id → no-op.
+    existing = _find_existing_terminated_by_idempotency(
+        store,
+        commitment_id=artifact.commitment_id,
+        idempotency_key=artifact.idempotency_key,
+    )
+    if existing is not None:
+        # No-op: do not emit a second event. Same key = same operation.
+        return artifact, False
+
+    # Different key (or different terminal type) on an already-terminated
+    # commitment is a conflict. First terminal wins.
+    _assert_no_existing_terminal(store, artifact.commitment_id)
+
+    episode.emit(
+        COMMITMENT_TERMINATED_RECEIPT_TYPE,
+        artifact.to_dict(),
+        parent_receipt_id=parent_receipt_id,
+    )
+    return artifact, True
+
+
+def emit_probe_scoped(
+    episode: Episode,
+    probe: Union[ProbeScopedArtifact, Dict[str, Any]],
+    *,
+    parent_receipt_id: Optional[str] = None,
+) -> ProbeScopedArtifact:
+    """Emit a probe.scoped meta-receipt.
+
+    Declares a probe's boundary so downstream verifiers can check its
+    emitted receipts against the declared scope. This PR does NOT wire
+    the full claude-organism self-authored emitter; it only makes the
+    membrane real and testable.
+    """
+    artifact = (
+        probe
+        if isinstance(probe, ProbeScopedArtifact)
+        else ProbeScopedArtifact(**probe)
+    )
+    artifact.validate()
+    if set(artifact.allowed_event_types) != PROBE_SCOPED_ALLOWED_EVENT_TYPES:
+        raise ValueError(
+            "probe.scoped allowed_event_types must exactly equal the "
+            "current self-authored probe membrane whitelist. "
+            f"expected={sorted(PROBE_SCOPED_ALLOWED_EVENT_TYPES)!r} "
+            f"got={sorted(set(artifact.allowed_event_types))!r}."
+        )
+    episode.emit(
+        PROBE_SCOPED_RECEIPT_TYPE,
+        artifact.to_dict(),
+        parent_receipt_id=parent_receipt_id,
+    )
+    return artifact
+
+
 __all__ = [
     "SCHEMA_VERSION",
     "COMMITMENT_REGISTRATION_RECEIPT_TYPE",
     "RESULT_OBSERVATION_RECEIPT_TYPE",
     "FULFILLMENT_COMMITMENT_KEPT_RECEIPT_TYPE",
     "FULFILLMENT_COMMITMENT_BROKEN_RECEIPT_TYPE",
+    "COMMITMENT_TERMINATED_RECEIPT_TYPE",
+    "PROBE_SCOPED_RECEIPT_TYPE",
     "TERMINAL_FULFILLMENT_TYPES",
+    "TERMINAL_RECEIPT_TYPES",
+    "TERMINAL_REASONS",
+    "AMENDED_FIELDS",
+    "AUTHORITY_MODES",
+    "ACCEPTED_AUTHORITY_MODES",
+    "PROBE_SCOPED_ALLOWED_EVENT_TYPES",
     "TerminalFulfillmentError",
     "UnanchoredFulfillmentError",
+    "AuthorityModeUnsupportedError",
     "ReceiptStoreIntegrityError",
     "CommitmentRegistrationArtifact",
     "ResultObservationArtifact",
     "FulfillmentKeptArtifact",
     "FulfillmentBrokenArtifact",
+    "CommitmentTerminatedArtifact",
+    "ProbeScopedArtifact",
+    "normalize_first_authored_text",
+    "derive_commitment_id",
+    "derive_idempotency_key",
     "emit_commitment_registration",
     "emit_result_observation",
     "emit_fulfillment_kept",
     "emit_fulfillment_broken",
+    "emit_commitment_terminated",
+    "emit_probe_scoped",
 ]

--- a/src/assay/commitment_projection.py
+++ b/src/assay/commitment_projection.py
@@ -62,6 +62,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 from assay.commitment_fulfillment import (
     COMMITMENT_REGISTRATION_RECEIPT_TYPE,
+    COMMITMENT_TERMINATED_RECEIPT_TYPE,
     RESULT_OBSERVATION_RECEIPT_TYPE,
     TERMINAL_FULFILLMENT_TYPES,
     _iter_all_receipts,
@@ -145,6 +146,48 @@ class ClosureFact:
 
 
 @dataclass(frozen=True)
+class TerminationFact:
+    """Derived: the ``commitment.terminated`` event that ended a commitment
+    (non-fulfillment ending).
+
+    First-terminal-wins: if a commitment already has a fulfillment closure
+    (kept | broken) or a prior termination, subsequent terminated events
+    do NOT replace it and are NOT recorded here. They are also refused at
+    emission time; this field reflects the first accepted terminal event.
+
+    ``commitment.terminated`` covers only non-fulfillment endings
+    (revoked | superseded | amended). Kept/broken remain ``ClosureFact``.
+    """
+
+    commitment_id: str
+    seq: int
+    terminal_reason: str  # revoked | superseded | amended
+    amended_field: Optional[str]
+    authority_mode: str
+    idempotency_key: str
+    replacement_commitment_id: Optional[str]
+    supersedes_commitment_id: Optional[str]
+    lineage_root_commitment_id: Optional[str]
+
+
+@dataclass(frozen=True)
+class SupersessionEdge:
+    """Immediate supersession edge between two commitments.
+
+    Captures only the direct predecessor/successor relationship. Chain
+    reconstruction (if ever needed) walks edges; chains are NOT stored
+    per-event. ``lineage_root_commitment_id`` may be present as a
+    convenience when the emitter already knows the chain's root.
+    """
+
+    predecessor_commitment_id: str
+    successor_commitment_id: str
+    lineage_root_commitment_id: Optional[str]
+    source_seq: int  # _store_seq of the receipt that declared this edge
+    source_receipt_type: str  # "commitment.registered" or "commitment.terminated"
+
+
+@dataclass(frozen=True)
 class CommitmentLifecycleProjection:
     """Ground-truth projection of the commitment lifecycle as recorded in
     the store's receipt corpus, in ``_store_seq`` order.
@@ -168,6 +211,17 @@ class CommitmentLifecycleProjection:
     # Derived: commitment_id -> ClosureFact for commitments that have a
     # valid closing terminal.
     closures: Dict[str, ClosureFact] = field(default_factory=dict)
+
+    # Derived: commitment_id -> TerminationFact for commitments ended by a
+    # ``commitment.terminated`` event (revoked | superseded | amended).
+    # Fulfillment closures (kept | broken) remain in ``closures``; this
+    # map is strictly for non-fulfillment terminal endings. First-wins.
+    terminations: Dict[str, TerminationFact] = field(default_factory=dict)
+
+    # Immediate supersession edges (predecessor -> successor). Chains are
+    # NOT stored per-event; consumers reconstruct chains from edges when
+    # needed.
+    supersession_edges: List[SupersessionEdge] = field(default_factory=list)
 
     # For detector's total_traces_scanned
     total_traces_scanned: int = 0
@@ -220,7 +274,54 @@ def project_commitment_lifecycle(
     observation_anchors: List[ObservationAnchorFact] = []
     terminals: List[TerminalFact] = []
     closures: Dict[str, ClosureFact] = {}
+    terminations: Dict[str, TerminationFact] = {}
+    supersession_edges: List[SupersessionEdge] = []
+    # Dedup supersession edges by (predecessor, successor) so two
+    # receipts declaring the same edge (e.g. an amendment's terminated
+    # receipt carries replacement_commitment_id, and the replacement's
+    # registered receipt carries supersedes_commitment_id) do not
+    # double-count. When a later receipt declares the same edge with a
+    # ``lineage_root_commitment_id`` that the first did not carry, the
+    # edge is upgraded in-place so the root is reachable even if the
+    # earlier receipt omitted it.
+    edge_index_by_pair: Dict[Tuple[str, str], int] = {}
     trace_ids_seen: Set[str] = set()
+
+    def _record_edge(
+        predecessor: str,
+        successor: str,
+        lineage_root: Optional[str],
+        source_seq: int,
+        source_receipt_type: str,
+    ) -> None:
+        key = (predecessor, successor)
+        if key in edge_index_by_pair:
+            idx = edge_index_by_pair[key]
+            existing = supersession_edges[idx]
+            # Upgrade in-place if this receipt carries a lineage_root
+            # the earlier one did not.
+            if (
+                existing.lineage_root_commitment_id is None
+                and lineage_root is not None
+            ):
+                supersession_edges[idx] = SupersessionEdge(
+                    predecessor_commitment_id=existing.predecessor_commitment_id,
+                    successor_commitment_id=existing.successor_commitment_id,
+                    lineage_root_commitment_id=lineage_root,
+                    source_seq=existing.source_seq,
+                    source_receipt_type=existing.source_receipt_type,
+                )
+            return
+        edge_index_by_pair[key] = len(supersession_edges)
+        supersession_edges.append(
+            SupersessionEdge(
+                predecessor_commitment_id=predecessor,
+                successor_commitment_id=successor,
+                lineage_root_commitment_id=lineage_root,
+                source_seq=source_seq,
+                source_receipt_type=source_receipt_type,
+            )
+        )
 
     # Rolling state used to decide terminal validity at encounter time.
     # Keyed by (result_id, commitment_id); value is the most recent
@@ -250,6 +351,23 @@ def project_commitment_lifecycle(
                 if not cmt_id_raw:
                     continue
                 cmt_id = str(cmt_id_raw)
+
+                # Capture supersession edge from the registration side
+                # (the replacement declaring its predecessor), even if
+                # this is a second registration of the same id. The
+                # edge is independent of first-seen-wins.
+                supersedes_raw = entry.get("supersedes_commitment_id")
+                if supersedes_raw:
+                    _record_edge(
+                        predecessor=str(supersedes_raw),
+                        successor=cmt_id,
+                        lineage_root=_opt_str(
+                            entry.get("lineage_root_commitment_id")
+                        ),
+                        source_seq=seq,
+                        source_receipt_type=rt,
+                    )
+
                 if cmt_id in registrations:
                     # First-seen wins. Matches pre-extraction behavior.
                     continue
@@ -307,6 +425,7 @@ def project_commitment_lifecycle(
                 anchor_seq = anchor_seq_by_pair.get((result_id, cmt_id))
                 has_anchor = anchor_seq is not None
                 already_closed = cmt_id in closures
+                already_terminated = cmt_id in terminations
 
                 reasons: List[str] = []
                 if not has_registration:
@@ -324,6 +443,12 @@ def project_commitment_lifecycle(
                         f"post-closure terminal (commitment already "
                         f"closed by seq="
                         f"{closures[cmt_id].closing_terminal_seq})"
+                    )
+                if already_terminated:
+                    reasons.append(
+                        f"post-termination terminal (commitment already "
+                        f"terminated at seq="
+                        f"{terminations[cmt_id].seq})"
                     )
 
                 is_valid = not reasons
@@ -356,6 +481,52 @@ def project_commitment_lifecycle(
                         anchor_observation_seq=anchor_seq,
                     )
                 continue
+
+            if rt == COMMITMENT_TERMINATED_RECEIPT_TYPE:
+                cmt_id_raw = entry.get("commitment_id")
+                reason_raw = entry.get("terminal_reason")
+                idem_raw = entry.get("idempotency_key")
+                authority_raw = entry.get("authority_mode")
+                if not cmt_id_raw or not reason_raw or not idem_raw:
+                    continue
+                cmt_id = str(cmt_id_raw)
+
+                # First-terminal-wins across BOTH closures and
+                # terminations. Subsequent terminated receipts for the
+                # same commitment_id are ignored (the emit path refuses
+                # them; this is defensive parity for direct writes).
+                if cmt_id in closures or cmt_id in terminations:
+                    continue
+
+                replacement_raw = entry.get("replacement_commitment_id")
+                if replacement_raw:
+                    # Supersession edge from the termination side.
+                    _record_edge(
+                        predecessor=cmt_id,
+                        successor=str(replacement_raw),
+                        lineage_root=_opt_str(
+                            entry.get("lineage_root_commitment_id")
+                        ),
+                        source_seq=seq,
+                        source_receipt_type=rt,
+                    )
+
+                terminations[cmt_id] = TerminationFact(
+                    commitment_id=cmt_id,
+                    seq=seq,
+                    terminal_reason=str(reason_raw),
+                    amended_field=_opt_str(entry.get("amended_field")),
+                    authority_mode=str(authority_raw or ""),
+                    idempotency_key=str(idem_raw),
+                    replacement_commitment_id=_opt_str(replacement_raw),
+                    supersedes_commitment_id=_opt_str(
+                        entry.get("supersedes_commitment_id")
+                    ),
+                    lineage_root_commitment_id=_opt_str(
+                        entry.get("lineage_root_commitment_id")
+                    ),
+                )
+                continue
     except ReceiptStoreIntegrityError as exc:
         # Paired fields: human-readable message + original exception for
         # forensic chain. On integrity failure, return an empty
@@ -374,6 +545,8 @@ def project_commitment_lifecycle(
         observation_anchors=observation_anchors,
         terminals=terminals,
         closures=closures,
+        terminations=terminations,
+        supersession_edges=supersession_edges,
         total_traces_scanned=len(trace_ids_seen),
         scanned_at=scanned_at,
     )
@@ -404,6 +577,8 @@ __all__ = [
     "ObservationAnchorFact",
     "TerminalFact",
     "ClosureFact",
+    "TerminationFact",
+    "SupersessionEdge",
     "CommitmentLifecycleProjection",
     "project_commitment_lifecycle",
 ]

--- a/src/assay/commitment_summary.py
+++ b/src/assay/commitment_summary.py
@@ -41,9 +41,10 @@ class CommitmentSummary:
                      outcome; see membrane doctrine note.
 
     Doctrine: "Kept, broken, revoked, amended, and superseded may all
-    end a commitment's active life, but only kept is fulfillment." Only
-    OPEN is active. Both CLOSED and TERMINATED are ended, but they are
-    distinct terminal states and MUST NOT be conflated.
+    end a commitment's active life, but only kept/broken are
+    fulfillment outcomes." Only OPEN is active. Both CLOSED and
+    TERMINATED are ended, but they are distinct terminal states and
+    MUST NOT be conflated.
     """
 
     commitment_id: str

--- a/src/assay/commitment_summary.py
+++ b/src/assay/commitment_summary.py
@@ -30,10 +30,24 @@ from assay.store import AssayStore
 
 @dataclass(frozen=True)
 class CommitmentSummary:
-    """Compact per-commitment state for list/overdue views."""
+    """Compact per-commitment state for list/overdue views.
+
+    States:
+        OPEN       — registered, not yet closed or terminated.
+        CLOSED     — ended by fulfillment.commitment_kept or
+                     fulfillment.commitment_broken (fulfillment outcomes).
+        TERMINATED — ended by commitment.terminated
+                     (revoked | superseded | amended). NOT a fulfillment
+                     outcome; see membrane doctrine note.
+
+    Doctrine: "Kept, broken, revoked, amended, and superseded may all
+    end a commitment's active life, but only kept is fulfillment." Only
+    OPEN is active. Both CLOSED and TERMINATED are ended, but they are
+    distinct terminal states and MUST NOT be conflated.
+    """
 
     commitment_id: str
-    state: str  # OPEN | CLOSED
+    state: str  # OPEN | CLOSED | TERMINATED
     actor_id: str
     text: str
     commitment_type: str
@@ -42,6 +56,10 @@ class CommitmentSummary:
     closing_terminal_seq: Optional[int]
     closing_terminal_type: Optional[str]
     is_overdue: bool
+    # Populated when state == TERMINATED; None otherwise.
+    terminal_reason: Optional[str] = None  # revoked | superseded | amended
+    termination_seq: Optional[int] = None
+    replacement_commitment_id: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -55,6 +73,9 @@ class CommitmentSummary:
             "closing_terminal_seq": self.closing_terminal_seq,
             "closing_terminal_type": self.closing_terminal_type,
             "is_overdue": self.is_overdue,
+            "terminal_reason": self.terminal_reason,
+            "termination_seq": self.termination_seq,
+            "replacement_commitment_id": self.replacement_commitment_id,
         }
 
 
@@ -108,10 +129,43 @@ def summarize_all_commitments(
         projection.registrations.values(), key=lambda r: r.seq
     ):
         closure = projection.closures.get(reg.commitment_id)
-        state = "CLOSED" if closure else "OPEN"
-        closing_seq = closure.closing_terminal_seq if closure else None
-        closing_type = closure.closing_terminal_type if closure else None
+        termination = projection.terminations.get(reg.commitment_id)
 
+        # First-terminal-wins across closures and terminations. The
+        # projector already enforces this: a commitment that entered
+        # ``closures`` cannot subsequently enter ``terminations``, and
+        # vice-versa. Defensive tie-break if both ever appeared: whichever
+        # has the smaller seq wins.
+        if closure and termination:
+            if closure.closing_terminal_seq <= termination.seq:
+                termination = None
+            else:
+                closure = None
+
+        if closure:
+            state = "CLOSED"
+            closing_seq = closure.closing_terminal_seq
+            closing_type = closure.closing_terminal_type
+            terminal_reason = None
+            termination_seq = None
+            replacement_commitment_id = None
+        elif termination:
+            state = "TERMINATED"
+            closing_seq = None
+            closing_type = None
+            terminal_reason = termination.terminal_reason
+            termination_seq = termination.seq
+            replacement_commitment_id = termination.replacement_commitment_id
+        else:
+            state = "OPEN"
+            closing_seq = None
+            closing_type = None
+            terminal_reason = None
+            termination_seq = None
+            replacement_commitment_id = None
+
+        # is_overdue only applies to OPEN commitments. TERMINATED and
+        # CLOSED have ended their active life and are never overdue.
         is_overdue = False
         if state == "OPEN" and reg.due_at:
             parsed = _parse_iso(reg.due_at)
@@ -130,6 +184,9 @@ def summarize_all_commitments(
                 closing_terminal_seq=closing_seq,
                 closing_terminal_type=closing_type,
                 is_overdue=is_overdue,
+                terminal_reason=terminal_reason,
+                termination_seq=termination_seq,
+                replacement_commitment_id=replacement_commitment_id,
             )
         )
 

--- a/src/assay/schemas/commitment_registration.v0.1.schema.json
+++ b/src/assay/schemas/commitment_registration.v0.1.schema.json
@@ -25,6 +25,8 @@
     "commitment_type": {"type": "string", "minLength": 1},
     "due_at": {"type": "string", "format": "date-time"},
     "evidence_uri": {"type": "string"},
+    "supersedes_commitment_id": {"type": "string", "minLength": 1},
+    "lineage_root_commitment_id": {"type": "string", "minLength": 1},
     "policy_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
     "policy_resolver": {
       "type": "object",

--- a/src/assay/schemas/commitment_terminated.v0.1.schema.json
+++ b/src/assay/schemas/commitment_terminated.v0.1.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://assay.ai/schemas/commitment_terminated.v0.1.schema.json",
+  "title": "Commitment Terminated (v0.1)",
+  "description": "Non-fulfillment terminal ending of a commitment (revoked | superseded | amended). Fulfillment outcomes (kept | broken) are separate receipt types and are NOT absorbed here.",
+  "type": "object",
+  "required": [
+    "commitment_id",
+    "timestamp",
+    "terminated_at",
+    "terminated_by_actor",
+    "terminal_reason",
+    "authority_mode",
+    "idempotency_key",
+    "schema_version",
+    "artifact_type"
+  ],
+  "properties": {
+    "commitment_id": {"type": "string", "minLength": 1},
+    "timestamp": {"type": "string", "format": "date-time"},
+    "terminated_at": {"type": "string", "format": "date-time"},
+    "terminated_by_actor": {"type": "string", "minLength": 1},
+    "terminal_reason": {
+      "type": "string",
+      "enum": ["revoked", "superseded", "amended"]
+    },
+    "amended_field": {
+      "type": "string",
+      "enum": ["none", "due_at", "scope", "owner", "acceptance_terms"]
+    },
+    "authority_mode": {
+      "type": "string",
+      "enum": ["self", "owner", "policy", "external"]
+    },
+    "idempotency_key": {"type": "string", "minLength": 1},
+    "replacement_commitment_id": {"type": "string", "minLength": 1},
+    "supersedes_commitment_id": {"type": "string", "minLength": 1},
+    "lineage_root_commitment_id": {"type": "string", "minLength": 1},
+    "schema_version": {"type": "string"},
+    "artifact_type": {"type": "string", "const": "commitment_terminated"}
+  },
+  "additionalProperties": true
+}

--- a/src/assay/schemas/probe_scoped.v0.1.schema.json
+++ b/src/assay/schemas/probe_scoped.v0.1.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://assay.ai/schemas/probe_scoped.v0.1.schema.json",
+  "title": "Probe Scoped Receipt (v0.1)",
+  "description": "Meta-receipt declaring the scope and allowed event types of a probe. Records a probe's boundary (what it is and is not allowed to emit) so downstream verifiers can check its receipts against its declared scope. This PR does not wire a full emitter; it only makes the membrane real and testable.",
+  "type": "object",
+  "required": [
+    "probe_name",
+    "scope",
+    "owner_equals_author",
+    "delegation_allowed",
+    "external_ingestion_allowed",
+    "allowed_event_types",
+    "membrane_version",
+    "code_commit",
+    "emitted_at",
+    "schema_version",
+    "artifact_type"
+  ],
+  "properties": {
+    "probe_name": {"type": "string", "minLength": 1},
+    "scope": {
+      "type": "string",
+      "enum": ["self-authored-only"]
+    },
+    "owner_equals_author": {"type": "boolean"},
+    "delegation_allowed": {"type": "boolean"},
+    "external_ingestion_allowed": {"type": "boolean"},
+    "allowed_event_types": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 4,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "commitment.registered",
+          "commitment.terminated",
+          "fulfillment.commitment_kept",
+          "fulfillment.commitment_broken"
+        ]
+      }
+    },
+    "membrane_version": {"type": "string", "minLength": 1},
+    "code_commit": {"type": "string", "minLength": 1},
+    "emitted_at": {"type": "string", "format": "date-time"},
+    "schema_version": {"type": "string"},
+    "artifact_type": {"type": "string", "const": "probe_scoped"}
+  },
+  "additionalProperties": true
+}

--- a/tests/assay/test_commitment_terminal_membrane.py
+++ b/tests/assay/test_commitment_terminal_membrane.py
@@ -1,0 +1,842 @@
+"""Commitment terminal-state membrane tests.
+
+Makes revoked, amended, and superseded commitments machine-visible
+terminal state, not prose notes, so ``list`` and ``overdue`` remain
+honest.
+
+Doctrine sentence:
+    "Kept, broken, revoked, amended, and superseded may all end a
+    commitment's active life, but only kept/broken are fulfillment
+    outcomes."
+
+Implementation invariant:
+    "If it changes list or overdue, it must be state, not commentary."
+
+Grammar preservation note:
+    This module keeps the existing commitment/fulfillment vocabulary
+    exactly: ``fulfillment.commitment_kept`` and
+    ``fulfillment.commitment_broken`` remain unchanged. A new
+    ``commitment.terminated`` event covers non-fulfillment endings
+    (revoked | superseded | amended). No "verified" or "breached"
+    vocabulary is introduced.
+"""
+from __future__ import annotations
+
+import json
+import pytest
+
+from assay.commitment_closure_detector import detect_open_overdue_commitments
+from assay.commitment_fulfillment import (
+    ACCEPTED_AUTHORITY_MODES,
+    AUTHORITY_MODES,
+    AuthorityModeUnsupportedError,
+    COMMITMENT_REGISTRATION_RECEIPT_TYPE,
+    COMMITMENT_TERMINATED_RECEIPT_TYPE,
+    CommitmentTerminatedArtifact,
+    FULFILLMENT_COMMITMENT_BROKEN_RECEIPT_TYPE,
+    FULFILLMENT_COMMITMENT_KEPT_RECEIPT_TYPE,
+    PROBE_SCOPED_ALLOWED_EVENT_TYPES,
+    PROBE_SCOPED_RECEIPT_TYPE,
+    ProbeScopedArtifact,
+    RESULT_OBSERVATION_RECEIPT_TYPE,
+    TerminalFulfillmentError,
+    UnanchoredFulfillmentError,
+    derive_commitment_id,
+    derive_idempotency_key,
+    emit_commitment_terminated,
+    emit_probe_scoped,
+    normalize_first_authored_text,
+)
+from assay.commitment_projection import project_commitment_lifecycle
+from assay.commitment_summary import summarize_all_commitments
+from assay.episode import Episode
+from assay.store import AssayStore
+
+
+POLICY_HASH = "sha256:" + "c" * 64
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_store(tmp_path):
+    store = AssayStore(base_dir=tmp_path / "store")
+    store.start_trace()
+    return store
+
+
+def _write_registered(
+    store,
+    commitment_id,
+    *,
+    actor_id="alice",
+    due_at="2020-01-01T00:00:00Z",
+    text=None,
+    supersedes_commitment_id=None,
+    lineage_root_commitment_id=None,
+):
+    """Register a commitment via direct append.
+
+    Uses a deep-past due_at by default so overdue-filter tests work.
+    """
+    data = {
+        "type": COMMITMENT_REGISTRATION_RECEIPT_TYPE,
+        "commitment_id": commitment_id,
+        "episode_id": "ep_test",
+        "actor_id": actor_id,
+        "text": text or f"Commitment {commitment_id}.",
+        "commitment_type": "delivery",
+        "policy_hash": POLICY_HASH,
+        "timestamp": "2026-04-20T10:00:00.000Z",
+    }
+    if due_at is not None:
+        data["due_at"] = due_at
+    if supersedes_commitment_id is not None:
+        data["supersedes_commitment_id"] = supersedes_commitment_id
+    if lineage_root_commitment_id is not None:
+        data["lineage_root_commitment_id"] = lineage_root_commitment_id
+    store.append_dict(data)
+
+
+def _write_result(store, result_id, references=None):
+    store.append_dict({
+        "type": RESULT_OBSERVATION_RECEIPT_TYPE,
+        "result_id": result_id,
+        "episode_id": "ep_test",
+        "text": f"Observed {result_id}.",
+        "evidence_uri": "file:///tmp/evidence.log",
+        "policy_hash": POLICY_HASH,
+        "references": references or [],
+        "timestamp": "2026-04-20T11:00:00.000Z",
+    })
+
+
+def _write_kept(store, commitment_id, result_id):
+    store.append_dict({
+        "type": FULFILLMENT_COMMITMENT_KEPT_RECEIPT_TYPE,
+        "fulfillment_id": f"ful_kept_{commitment_id}",
+        "episode_id": "ep_test",
+        "commitment_id": commitment_id,
+        "result_id": result_id,
+        "evaluator": "test",
+        "evaluator_version": "0.1",
+        "policy_hash": POLICY_HASH,
+        "timestamp": "2026-04-20T12:00:00.000Z",
+    })
+
+
+def _write_broken(store, commitment_id, result_id, reason="violated"):
+    store.append_dict({
+        "type": FULFILLMENT_COMMITMENT_BROKEN_RECEIPT_TYPE,
+        "fulfillment_id": f"ful_broken_{commitment_id}",
+        "episode_id": "ep_test",
+        "commitment_id": commitment_id,
+        "result_id": result_id,
+        "evaluator": "test",
+        "evaluator_version": "0.1",
+        "policy_hash": POLICY_HASH,
+        "violation_reason": reason,
+        "timestamp": "2026-04-20T12:00:00.000Z",
+    })
+
+
+def _make_terminated_artifact(
+    commitment_id,
+    *,
+    terminal_reason="revoked",
+    amended_field=None,
+    authority_mode="self",
+    idempotency_key=None,
+    replacement_commitment_id=None,
+    supersedes_commitment_id=None,
+    lineage_root_commitment_id=None,
+    terminated_by_actor="alice",
+):
+    return CommitmentTerminatedArtifact(
+        commitment_id=commitment_id,
+        timestamp="2026-04-20T13:00:00.000Z",
+        terminated_at="2026-04-20T13:00:00.000Z",
+        terminated_by_actor=terminated_by_actor,
+        terminal_reason=terminal_reason,
+        amended_field=amended_field,
+        authority_mode=authority_mode,
+        idempotency_key=idempotency_key or f"idem_{commitment_id}_{terminal_reason}",
+        replacement_commitment_id=replacement_commitment_id,
+        supersedes_commitment_id=supersedes_commitment_id,
+        lineage_root_commitment_id=lineage_root_commitment_id,
+    )
+
+
+def _write_terminated(
+    store,
+    commitment_id,
+    *,
+    terminal_reason="revoked",
+    amended_field=None,
+    authority_mode="self",
+    idempotency_key=None,
+    replacement_commitment_id=None,
+    supersedes_commitment_id=None,
+    lineage_root_commitment_id=None,
+):
+    """Direct write of a commitment.terminated receipt (bypasses emit guards).
+
+    Use sparingly — ``emit_commitment_terminated`` is the authorized path.
+    """
+    data = {
+        "type": COMMITMENT_TERMINATED_RECEIPT_TYPE,
+        "commitment_id": commitment_id,
+        "episode_id": "ep_test",
+        "timestamp": "2026-04-20T13:00:00.000Z",
+        "terminated_at": "2026-04-20T13:00:00.000Z",
+        "terminated_by_actor": "alice",
+        "terminal_reason": terminal_reason,
+        "authority_mode": authority_mode,
+        "idempotency_key": (
+            idempotency_key or f"idem_{commitment_id}_{terminal_reason}"
+        ),
+    }
+    if amended_field is not None:
+        data["amended_field"] = amended_field
+    if replacement_commitment_id is not None:
+        data["replacement_commitment_id"] = replacement_commitment_id
+    if supersedes_commitment_id is not None:
+        data["supersedes_commitment_id"] = supersedes_commitment_id
+    if lineage_root_commitment_id is not None:
+        data["lineage_root_commitment_id"] = lineage_root_commitment_id
+    store.append_dict(data)
+
+
+# ---------------------------------------------------------------------------
+# Tests 1–8: the projection-level membrane invariants
+# ---------------------------------------------------------------------------
+
+
+def test_01_revoked_disappears_from_active_list(tmp_store):
+    """Test 1: Revoked commitment disappears from active list.
+
+    The active subset is state == OPEN; a revoked commitment must show
+    state == TERMINATED with terminal_reason == "revoked", and MUST NOT
+    appear in the OPEN subset.
+    """
+    _write_registered(tmp_store, "cmt_rev")
+    _write_terminated(tmp_store, "cmt_rev", terminal_reason="revoked")
+
+    result = summarize_all_commitments(tmp_store)
+    assert len(result.commitments) == 1
+    s = result.commitments[0]
+
+    assert s.commitment_id == "cmt_rev"
+    assert s.state == "TERMINATED"
+    assert s.terminal_reason == "revoked"
+    # Active list = OPEN subset. Revoked must be excluded.
+    active = [c for c in result.commitments if c.state == "OPEN"]
+    assert active == []
+
+
+def test_02_revoked_not_overdue(tmp_store):
+    """Test 2: Revoked commitment does not appear as overdue."""
+    _write_registered(tmp_store, "cmt_rev", due_at="2020-01-01T00:00:00Z")
+    _write_terminated(tmp_store, "cmt_rev", terminal_reason="revoked")
+
+    detector = detect_open_overdue_commitments(tmp_store)
+    assert detector.total_open_found == 0
+    assert detector.clean
+    assert all(c.commitment_id != "cmt_rev" for c in detector.open_commitments)
+
+    # Summary path parity: is_overdue is False for TERMINATED.
+    summary = summarize_all_commitments(tmp_store)
+    assert summary.commitments[0].is_overdue is False
+
+
+def test_03_superseded_disappears_from_active_list(tmp_store):
+    """Test 3: Superseded commitment disappears from active list.
+
+    The replacement is registered separately and remains active; the
+    original enters TERMINATED state with terminal_reason == "superseded".
+    """
+    _write_registered(tmp_store, "cmt_old")
+    _write_terminated(
+        tmp_store,
+        "cmt_old",
+        terminal_reason="superseded",
+        replacement_commitment_id="cmt_new",
+    )
+    _write_registered(
+        tmp_store,
+        "cmt_new",
+        supersedes_commitment_id="cmt_old",
+    )
+
+    result = summarize_all_commitments(tmp_store)
+    by_id = {c.commitment_id: c for c in result.commitments}
+
+    assert by_id["cmt_old"].state == "TERMINATED"
+    assert by_id["cmt_old"].terminal_reason == "superseded"
+    assert by_id["cmt_new"].state == "OPEN"
+
+    # Active list excludes cmt_old.
+    active_ids = {c.commitment_id for c in result.commitments if c.state == "OPEN"}
+    assert active_ids == {"cmt_new"}
+
+
+def test_04_replacement_remains_active_if_not_terminal(tmp_store):
+    """Test 4: Replacement commitment remains active if not terminal."""
+    _write_registered(tmp_store, "cmt_old")
+    _write_terminated(
+        tmp_store,
+        "cmt_old",
+        terminal_reason="amended",
+        amended_field="due_at",
+        replacement_commitment_id="cmt_new",
+    )
+    _write_registered(
+        tmp_store,
+        "cmt_new",
+        supersedes_commitment_id="cmt_old",
+    )
+
+    result = summarize_all_commitments(tmp_store)
+    by_id = {c.commitment_id: c for c in result.commitments}
+
+    # cmt_new is not terminal — neither closed nor terminated — so OPEN.
+    assert by_id["cmt_new"].state == "OPEN"
+    # The replacement is not itself terminal; termination_seq is None.
+    assert by_id["cmt_new"].termination_seq is None
+    assert by_id["cmt_new"].closing_terminal_seq is None
+
+
+def test_05_amended_original_disappears_from_active_list(tmp_store):
+    """Test 5: Amended original disappears from active list."""
+    _write_registered(tmp_store, "cmt_orig", due_at="2020-01-01T00:00:00Z")
+    _write_terminated(
+        tmp_store,
+        "cmt_orig",
+        terminal_reason="amended",
+        amended_field="due_at",
+        replacement_commitment_id="cmt_orig_v2",
+    )
+    _write_registered(
+        tmp_store,
+        "cmt_orig_v2",
+        due_at="2099-01-01T00:00:00Z",
+        supersedes_commitment_id="cmt_orig",
+    )
+
+    result = summarize_all_commitments(tmp_store)
+    by_id = {c.commitment_id: c for c in result.commitments}
+
+    # Original is terminated (amended), not active.
+    assert by_id["cmt_orig"].state == "TERMINATED"
+    assert by_id["cmt_orig"].terminal_reason == "amended"
+    # Original is NOT overdue despite its past due_at, because TERMINATED.
+    assert by_id["cmt_orig"].is_overdue is False
+    # Replacement is active.
+    assert by_id["cmt_orig_v2"].state == "OPEN"
+
+    active_ids = {c.commitment_id for c in result.commitments if c.state == "OPEN"}
+    assert active_ids == {"cmt_orig_v2"}
+
+
+def test_06_amended_replacement_carries_supersedes_commitment_id(tmp_store):
+    """Test 6: Amended replacement carries supersedes_commitment_id.
+
+    The projection exposes the supersession edge; the replacement's
+    registered receipt declares it.
+    """
+    _write_registered(tmp_store, "cmt_orig")
+    _write_terminated(
+        tmp_store,
+        "cmt_orig",
+        terminal_reason="amended",
+        amended_field="scope",
+        replacement_commitment_id="cmt_orig_v2",
+    )
+    _write_registered(
+        tmp_store,
+        "cmt_orig_v2",
+        supersedes_commitment_id="cmt_orig",
+        lineage_root_commitment_id="cmt_orig",
+    )
+
+    projection = project_commitment_lifecycle(tmp_store)
+    edges = projection.supersession_edges
+    assert len(edges) >= 1
+
+    edge = next(e for e in edges if e.predecessor_commitment_id == "cmt_orig")
+    assert edge.successor_commitment_id == "cmt_orig_v2"
+    # Either the registration or the termination may have declared the
+    # edge; lineage_root appears on at least one side. Assert the root
+    # is reachable somewhere in the projection's edge set.
+    roots = {e.lineage_root_commitment_id for e in edges}
+    assert "cmt_orig" in roots
+
+
+def test_07_kept_remains_fulfillment_not_terminated(tmp_store):
+    """Test 7: Kept / fulfillment.commitment_kept remains fulfillment, not
+    commitment.terminated.
+
+    Grammar preservation: kept is a fulfillment outcome, NOT a
+    termination. State is CLOSED, closing_terminal_type is
+    ``fulfillment.commitment_kept``, and the commitment does NOT show up
+    in projection.terminations.
+    """
+    _write_registered(tmp_store, "cmt_k")
+    _write_result(
+        tmp_store,
+        "res_k",
+        references=[{"kind": "commitment", "id": "cmt_k"}],
+    )
+    _write_kept(tmp_store, "cmt_k", "res_k")
+
+    result = summarize_all_commitments(tmp_store)
+    s = result.commitments[0]
+    assert s.state == "CLOSED"
+    assert s.closing_terminal_type == FULFILLMENT_COMMITMENT_KEPT_RECEIPT_TYPE
+    assert s.terminal_reason is None
+    assert s.termination_seq is None
+
+    projection = project_commitment_lifecycle(tmp_store)
+    assert "cmt_k" in projection.closures
+    assert "cmt_k" not in projection.terminations
+
+
+def test_08_broken_remains_fulfillment_not_terminated(tmp_store):
+    """Test 8: Broken / fulfillment.commitment_broken remains fulfillment
+    outcome, not commitment.terminated.
+
+    Same grammar invariant as kept: broken is a fulfillment outcome, not
+    a termination. State is CLOSED with closing_terminal_type =
+    ``fulfillment.commitment_broken``.
+    """
+    _write_registered(tmp_store, "cmt_b")
+    _write_result(
+        tmp_store,
+        "res_b",
+        references=[{"kind": "commitment", "id": "cmt_b"}],
+    )
+    _write_broken(tmp_store, "cmt_b", "res_b")
+
+    result = summarize_all_commitments(tmp_store)
+    s = result.commitments[0]
+    assert s.state == "CLOSED"
+    assert s.closing_terminal_type == FULFILLMENT_COMMITMENT_BROKEN_RECEIPT_TYPE
+    assert s.terminal_reason is None
+    assert s.termination_seq is None
+
+    projection = project_commitment_lifecycle(tmp_store)
+    assert "cmt_b" in projection.closures
+    assert "cmt_b" not in projection.terminations
+
+
+# ---------------------------------------------------------------------------
+# Tests 9–11: the emit-path guards
+# ---------------------------------------------------------------------------
+
+
+def test_09_replay_same_idempotency_key_is_noop(tmp_store):
+    """Test 9: Replaying same idempotency_key is a no-op.
+
+    Two calls to ``emit_commitment_terminated`` with the same
+    commitment_id AND same idempotency_key produce exactly one on-disk
+    event. The second call returns ``(artifact, wrote_event=False)``.
+    """
+    _write_registered(tmp_store, "cmt_idem")
+    episode = Episode(store=tmp_store, episode_id="ep_idem")
+
+    artifact = _make_terminated_artifact(
+        "cmt_idem",
+        terminal_reason="revoked",
+        idempotency_key="idem_once",
+    )
+
+    _, wrote1 = emit_commitment_terminated(episode, artifact)
+    assert wrote1 is True
+
+    # Replay with the same idempotency_key.
+    _, wrote2 = emit_commitment_terminated(episode, artifact)
+    assert wrote2 is False
+
+    # Exactly one on-disk terminated event for this commitment.
+    projection = project_commitment_lifecycle(tmp_store)
+    termination_events = [
+        t for t in projection.terminations.values()
+        if t.commitment_id == "cmt_idem"
+    ]
+    assert len(termination_events) == 1
+
+    raw_events = [
+        e for e in _iter_terminated_events(tmp_store)
+        if e["commitment_id"] == "cmt_idem"
+    ]
+    assert len(raw_events) == 1
+
+
+def test_10_different_idempotency_key_on_terminated_raises(tmp_store):
+    """Test 10: Different idempotency_key attempting to terminate an
+    already-terminal commitment_id raises validation error at emission;
+    no event is written.
+    """
+    _write_registered(tmp_store, "cmt_conflict")
+    episode = Episode(store=tmp_store, episode_id="ep_conflict")
+
+    first = _make_terminated_artifact(
+        "cmt_conflict",
+        terminal_reason="revoked",
+        idempotency_key="idem_first",
+    )
+    emit_commitment_terminated(episode, first)
+
+    # Count events before the conflicting call.
+    before = [
+        e for e in _iter_terminated_events(tmp_store)
+        if e["commitment_id"] == "cmt_conflict"
+    ]
+    assert len(before) == 1
+
+    conflict = _make_terminated_artifact(
+        "cmt_conflict",
+        terminal_reason="superseded",
+        idempotency_key="idem_second",
+        replacement_commitment_id="cmt_replace",
+    )
+    with pytest.raises(TerminalFulfillmentError):
+        emit_commitment_terminated(episode, conflict)
+
+    # No new event written.
+    after = [
+        e for e in _iter_terminated_events(tmp_store)
+        if e["commitment_id"] == "cmt_conflict"
+    ]
+    assert len(after) == 1
+    # First event is still the one on disk.
+    assert after[0]["idempotency_key"] == "idem_first"
+    assert after[0]["terminal_reason"] == "revoked"
+
+
+def test_10b_terminate_unregistered_commitment_rejected_no_event(tmp_store):
+    """Unregistered commitments cannot be terminated."""
+    episode = Episode(store=tmp_store, episode_id="ep_missing")
+    artifact = _make_terminated_artifact(
+        "cmt_missing",
+        terminal_reason="revoked",
+        idempotency_key="idem_missing",
+    )
+
+    with pytest.raises(UnanchoredFulfillmentError):
+        emit_commitment_terminated(episode, artifact)
+
+    assert list(_iter_terminated_events(tmp_store)) == []
+
+
+def test_10c_amended_requires_replacement_commitment_id(tmp_store):
+    """Amendment must terminate only via replacement registration."""
+    _write_registered(tmp_store, "cmt_amend")
+    episode = Episode(store=tmp_store, episode_id="ep_amend")
+    artifact = _make_terminated_artifact(
+        "cmt_amend",
+        terminal_reason="amended",
+        amended_field="due_at",
+        idempotency_key="idem_amend",
+        replacement_commitment_id=None,
+    )
+
+    with pytest.raises(ValueError, match="replacement_commitment_id"):
+        emit_commitment_terminated(episode, artifact)
+
+    assert list(_iter_terminated_events(tmp_store)) == []
+
+
+def test_11_non_self_authority_mode_rejected_no_event(tmp_store):
+    """Test 11: authority_mode values other than ``self`` are rejected at
+    validation time with explicit "not supported in current probe"
+    diagnostic; no event is written.
+    """
+    _write_registered(tmp_store, "cmt_auth")
+    episode = Episode(store=tmp_store, episode_id="ep_auth")
+
+    # Every non-``self`` value is schema-valid but rejected at emission.
+    non_self_modes = AUTHORITY_MODES - ACCEPTED_AUTHORITY_MODES
+    assert non_self_modes == {"owner", "policy", "external"}
+
+    for mode in non_self_modes:
+        artifact = _make_terminated_artifact(
+            "cmt_auth",
+            terminal_reason="revoked",
+            authority_mode=mode,
+            idempotency_key=f"idem_{mode}",
+        )
+        with pytest.raises(AuthorityModeUnsupportedError) as exc_info:
+            emit_commitment_terminated(episode, artifact)
+        assert "not supported in the current probe" in str(exc_info.value)
+
+    # Invalid (non-enum) authority_mode fails schema validation BEFORE
+    # emission; nothing is written.
+    from jsonschema import ValidationError as _SchemaValidationError
+
+    bad_artifact = _make_terminated_artifact(
+        "cmt_auth",
+        terminal_reason="revoked",
+        authority_mode="god_mode",  # not in the schema enum
+        idempotency_key="idem_bad",
+    )
+    with pytest.raises(_SchemaValidationError):
+        emit_commitment_terminated(episode, bad_artifact)
+
+    # No commitment.terminated for this commitment on disk.
+    events = [
+        e for e in _iter_terminated_events(tmp_store)
+        if e["commitment_id"] == "cmt_auth"
+    ]
+    assert events == []
+
+
+# ---------------------------------------------------------------------------
+# Tests 12–13: supersession edges + probe.scoped
+# ---------------------------------------------------------------------------
+
+
+def test_12_projection_exposes_immediate_supersession_edge(tmp_store):
+    """Test 12: Projection reconstructs or exposes immediate supersession
+    edge without requiring full-chain duplication.
+
+    Three-step chain A -> B -> C. Each edge is stored only as an
+    immediate edge; the projection does NOT duplicate the full chain
+    onto each event. Consumers reconstruct chains from edges when
+    needed.
+    """
+    _write_registered(tmp_store, "cmt_A")
+    _write_terminated(
+        tmp_store,
+        "cmt_A",
+        terminal_reason="amended",
+        amended_field="scope",
+        replacement_commitment_id="cmt_B",
+    )
+    _write_registered(
+        tmp_store,
+        "cmt_B",
+        supersedes_commitment_id="cmt_A",
+        lineage_root_commitment_id="cmt_A",
+    )
+    _write_terminated(
+        tmp_store,
+        "cmt_B",
+        terminal_reason="amended",
+        amended_field="scope",
+        replacement_commitment_id="cmt_C",
+    )
+    _write_registered(
+        tmp_store,
+        "cmt_C",
+        supersedes_commitment_id="cmt_B",
+        lineage_root_commitment_id="cmt_A",
+    )
+
+    projection = project_commitment_lifecycle(tmp_store)
+
+    # Every stored edge is a single predecessor->successor hop. No edge
+    # stores the full chain on its body.
+    predecessors = {e.predecessor_commitment_id for e in projection.supersession_edges}
+    successors = {e.successor_commitment_id for e in projection.supersession_edges}
+    assert {"cmt_A", "cmt_B"} <= predecessors
+    assert {"cmt_B", "cmt_C"} <= successors
+
+    # Chain reconstruction from the edge set (no full-chain duplication
+    # on any single event).
+    pred_to_succ = {
+        e.predecessor_commitment_id: e.successor_commitment_id
+        for e in projection.supersession_edges
+    }
+    chain = ["cmt_A"]
+    node = "cmt_A"
+    while node in pred_to_succ:
+        node = pred_to_succ[node]
+        chain.append(node)
+        if len(chain) > 10:
+            break  # guard against cycles
+    assert chain == ["cmt_A", "cmt_B", "cmt_C"]
+
+    # Each termination records at most its immediate replacement.
+    for cmt in ("cmt_A", "cmt_B"):
+        term = projection.terminations[cmt]
+        assert term.replacement_commitment_id in {"cmt_B", "cmt_C"}
+        # No chain fields like "successor_chain" or "lineage_chain".
+        assert not hasattr(term, "successor_chain")
+        assert not hasattr(term, "lineage_chain")
+
+
+def test_13_probe_scoped_validates_allowed_events_and_scope(tmp_store):
+    """Test 13: probe.scoped receipt validates allowed event types and scope.
+
+    Emit a probe.scoped receipt and confirm its shape.
+    """
+    episode = Episode(store=tmp_store, episode_id="ep_probe")
+    artifact = ProbeScopedArtifact(
+        probe_name="claude-organism-second-emitter",
+        scope="self-authored-only",
+        owner_equals_author=True,
+        delegation_allowed=False,
+        external_ingestion_allowed=False,
+        allowed_event_types=[
+            COMMITMENT_REGISTRATION_RECEIPT_TYPE,
+            COMMITMENT_TERMINATED_RECEIPT_TYPE,
+            FULFILLMENT_COMMITMENT_KEPT_RECEIPT_TYPE,
+            FULFILLMENT_COMMITMENT_BROKEN_RECEIPT_TYPE,
+        ],
+        membrane_version="0.1.0",
+        code_commit="cb06d0f9c3d04d29fbc3cdb7326f1424c0b82d87",
+        emitted_at="2026-04-20T13:30:00.000Z",
+    )
+
+    emit_probe_scoped(episode, artifact)
+
+    # Read the probe.scoped event back from the store and assert its
+    # fields match. Scope is the declared boundary; allowed_event_types
+    # is the whitelist the probe promises not to exceed.
+    events = [
+        e for e in _iter_all_events(tmp_store)
+        if e.get("type") == PROBE_SCOPED_RECEIPT_TYPE
+    ]
+    assert len(events) == 1
+    event = events[0]
+
+    assert event["probe_name"] == "claude-organism-second-emitter"
+    assert event["scope"] == "self-authored-only"
+    assert event["owner_equals_author"] is True
+    assert event["delegation_allowed"] is False
+    assert event["external_ingestion_allowed"] is False
+    assert set(event["allowed_event_types"]) == PROBE_SCOPED_ALLOWED_EVENT_TYPES
+
+    # The probe does NOT claim result.observed in its allowed types.
+    # That is intentional — this membrane PR does not wire result
+    # emission through the claude-organism probe.
+    assert RESULT_OBSERVATION_RECEIPT_TYPE not in event["allowed_event_types"]
+
+    # Schema-invalid probe.scoped is rejected (empty allowed_event_types
+    # is a schema violation).
+    from jsonschema import ValidationError as _SchemaValidationError
+
+    bad = ProbeScopedArtifact(
+        probe_name="bad",
+        scope="self-authored-only",
+        owner_equals_author=True,
+        delegation_allowed=False,
+        external_ingestion_allowed=False,
+        allowed_event_types=[],  # violates minItems=1
+        membrane_version="0.1.0",
+        code_commit="cb06d0f",
+        emitted_at="2026-04-20T13:30:00.000Z",
+    )
+    with pytest.raises(_SchemaValidationError):
+        bad.validate()
+
+    wrong_allowed = ProbeScopedArtifact(
+        probe_name="wrong-allowed",
+        scope="self-authored-only",
+        owner_equals_author=True,
+        delegation_allowed=False,
+        external_ingestion_allowed=False,
+        allowed_event_types=[
+            COMMITMENT_REGISTRATION_RECEIPT_TYPE,
+            COMMITMENT_TERMINATED_RECEIPT_TYPE,
+            FULFILLMENT_COMMITMENT_KEPT_RECEIPT_TYPE,
+            RESULT_OBSERVATION_RECEIPT_TYPE,
+        ],
+        membrane_version="0.1.0",
+        code_commit="cb06d0f",
+        emitted_at="2026-04-20T13:30:00.000Z",
+    )
+    with pytest.raises(_SchemaValidationError):
+        wrong_allowed.validate()
+
+
+# ---------------------------------------------------------------------------
+# Secondary coverage: identity derivation + normalization
+# ---------------------------------------------------------------------------
+
+
+class TestIdentityDerivation:
+    """Normalization rule + derivations (membrane note contract)."""
+
+    def test_normalize_nfc(self):
+        # é as decomposed vs composed; NFC collapses to composed.
+        decomposed = "café"
+        composed = "café"
+        assert decomposed != composed
+        assert normalize_first_authored_text(decomposed) == composed
+
+    def test_normalize_trim_and_collapse_whitespace(self):
+        raw = "   hello    world \t\n there   "
+        assert normalize_first_authored_text(raw) == "hello world there"
+
+    def test_normalize_preserves_case(self):
+        assert normalize_first_authored_text("Foo Bar") == "Foo Bar"
+        assert normalize_first_authored_text("FOO") != "foo"
+
+    def test_derive_commitment_id_is_stable_and_depends_on_all_fields(self):
+        base = dict(
+            emitter_namespace="claude-organism",
+            actor="alice",
+            plan_slot_key="slot_A",
+            first_authored_text="Ship the report by Friday.",
+        )
+        id1 = derive_commitment_id(**base)
+        id2 = derive_commitment_id(**base)
+        assert id1 == id2
+        assert id1.startswith("cmt_")
+        # Whitespace-different text normalizes to the same id.
+        id_w = derive_commitment_id(
+            **{**base, "first_authored_text": "  Ship   the report by Friday.  "}
+        )
+        assert id_w == id1
+        # Case-different text → different id (case is preserved).
+        id_c = derive_commitment_id(
+            **{**base, "first_authored_text": "ship the report by friday."}
+        )
+        assert id_c != id1
+        # Different actor → different id.
+        id_a = derive_commitment_id(**{**base, "actor": "bob"})
+        assert id_a != id1
+
+    def test_derive_idempotency_key_stable(self):
+        base = dict(
+            emitter_namespace="claude-organism",
+            operation_id="op_42",
+            commitment_id="cmt_abc",
+            event_type=COMMITMENT_TERMINATED_RECEIPT_TYPE,
+        )
+        k1 = derive_idempotency_key(**base)
+        k2 = derive_idempotency_key(**base)
+        assert k1 == k2
+        assert k1.startswith("idem_")
+        k3 = derive_idempotency_key(**{**base, "operation_id": "op_43"})
+        assert k3 != k1
+
+
+# ---------------------------------------------------------------------------
+# Small iteration helpers (kept local — do not export)
+# ---------------------------------------------------------------------------
+
+
+def _iter_all_events(store):
+    """Iterate every receipt on disk (across all trace files)."""
+    for trace_file in sorted(store.base_dir.rglob("trace_*.jsonl")):
+        if not trace_file.is_file():
+            continue
+        with open(trace_file) as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                yield json.loads(line)
+
+
+def _iter_terminated_events(store):
+    """Iterate commitment.terminated events from disk."""
+    for entry in _iter_all_events(store):
+        if entry.get("type") == COMMITMENT_TERMINATED_RECEIPT_TYPE:
+            yield entry

--- a/tests/assay/test_commitment_terminal_membrane.py
+++ b/tests/assay/test_commitment_terminal_membrane.py
@@ -669,6 +669,39 @@ def test_12_projection_exposes_immediate_supersession_edge(tmp_store):
         assert not hasattr(term, "lineage_chain")
 
 
+def test_12b_duplicate_post_terminal_receipt_does_not_create_edge(tmp_store):
+    """Strict lineage: only the first accepted terminal shapes lineage.
+
+    If a direct-write corpus contains a second post-terminal
+    commitment.terminated receipt carrying replacement_commitment_id,
+    the projection ignores it. Invalid duplicate terminals do not shape
+    lineage edges.
+    """
+    _write_registered(tmp_store, "cmt_A")
+    _write_terminated(
+        tmp_store,
+        "cmt_A",
+        terminal_reason="revoked",
+        idempotency_key="idem_first",
+    )
+    _write_terminated(
+        tmp_store,
+        "cmt_A",
+        terminal_reason="superseded",
+        idempotency_key="idem_second",
+        replacement_commitment_id="cmt_B",
+    )
+
+    projection = project_commitment_lifecycle(tmp_store)
+
+    # First terminal wins, and the duplicate later receipt does not
+    # create lineage.
+    term = projection.terminations["cmt_A"]
+    assert term.terminal_reason == "revoked"
+    assert term.replacement_commitment_id is None
+    assert projection.supersession_edges == []
+
+
 def test_13_probe_scoped_validates_allowed_events_and_scope(tmp_store):
     """Test 13: probe.scoped receipt validates allowed event types and scope.
 


### PR DESCRIPTION
## Summary

Implements the commitment terminal-state membrane for non-fulfillment endings:

- adds `commitment.terminated` for `revoked`, `superseded`, and `amended`
- keeps `kept` / `broken` as fulfillment outcomes only
- projects `TERMINATED` separately from `CLOSED`
- excludes terminated commitments from overdue detection
- records immediate supersession edges without duplicating full chains
- enforces first-terminal-wins across fulfillment closures and terminations
- adds `probe.scoped` schema support for the self-authored probe boundary

## Doctrine

Kept, broken, revoked, amended, and superseded may all end a commitment's active life, but only kept/broken are fulfillment outcomes.

Non-fulfillment endings are now machine-visible lifecycle state, not prose notes.

## Validation

```bash
PYTHONPATH=$PWD/src /Users/timmymacbookpro/assay-toolkit/.venv/bin/python -m pytest \
  tests/assay/test_commitment_projection_parity.py \
  tests/assay/test_commitment_terminal_invariant.py \
  tests/assay/test_commitment_terminal_membrane.py \
  tests/assay/test_commitments_list_overdue.py -q
```

Result:

- `54 passed`
- only pre-existing pytest config warnings

## Deferred

This PR does not wire the claude-organism emitter hooks. That should land as a separate organism-only slice after this membrane merges.