### PR TITLE
Add BarrierAnnotation v0.1 proof-hygiene primitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ assay demo-challenge
 - **MCP demo:** `assay try-mcp` — MCP tool calls with signed receipts (30 seconds)
 - **[See the before/after specimen](https://github.com/Haserjian/assay-proof-gallery/tree/main/gallery/07-contested-decision)** — contested decision, reconstruction vs verification
 
-Assay turns AI runs into signed proof packs another team can verify offline. It makes tampering visible and preserves honest failure.
+Assay turns AI runs into signed proof packs — a signed folder another team can verify offline. It makes tampering visible and preserves honest failure.
 
 ---
 
@@ -107,13 +107,15 @@ zero false passes. [Full report](docs/TRUST_UNDER_ATTACK.md).
 > score. That is expected — Assay instruments AI workflows, not itself.
 > This repo is the instrument, not the subject.
 
-**Why now:** EU AI Act Article 12 requires automatic logging for high-risk
-AI systems; Article 19 requires providers to retain automatically generated
-logs for at least 6 months. High-risk obligations apply from 2 Aug 2026
-(Annex III) and 2 Aug 2027 (regulated products). SOC 2 CC7.2 requires
-monitoring of system components and analysis of anomalies as security events.
-"We have logs on our server" is not independently verifiable evidence.
-Assay produces evidence that is.
+**Why now:** As EU AI Act obligations come into force, especially for
+high-risk systems, teams need evidence another party can verify. Article 12
+covers automatic logging for high-risk AI systems; Article 19 covers
+retention of automatically generated logs. High-risk obligations apply from
+2 Aug 2026 (Annex III) and 2 Aug 2027 (regulated products). SOC 2 CC7.2
+requires monitoring of system components and analysis of anomalies as
+security events. "We have logs on our server" is not independently
+verifiable evidence. Assay produces evidence another party can inspect,
+forward, and verify offline.
 See [compliance citations](docs/compliance-citations.md) for exact references.
 
 For the ecosystem map, see [docs/REPO_MAP.md](docs/REPO_MAP.md).
@@ -270,6 +272,78 @@ reduced via multi-detector scanning and CI gating.
 
 Assay doesn't make fraud impossible -- it makes fraud expensive, fragile,
 and much easier to catch.
+
+</details>
+
+<details>
+<summary><b>Attack surface map</b> (what Assay catches, what it does not)</summary>
+
+## Honest Failure: The Assay Attack-Surface Map
+
+Assay proves integrity after compilation for the artifact it produced. It does
+not prove initial honesty, signer identity, or a non-compromised runtime by
+itself. The point of this section is to name the main attack surfaces directly:
+what the verifier catches today, what remains outside the trust boundary, and
+what the upgrade path is.
+
+### 1. Post-run tampering
+
+Someone edits the evidence after the run: a model name, tool output, refund
+amount, or failed trace.
+
+- **What Assay catches:** `assay verify-pack` returns tampered when any
+  covered byte changes. In the canonical challenge, changing `"gpt-4"` to
+  `"gpt-5"` flips verification from PASS to FAIL.
+- **What this means:** the proof pack is the evidence. A screenshot of PASS is
+  not. A forwarded pack or reviewer packet is.
+
+### 2. Signer authority
+
+Someone generates a mathematically valid proof pack with their own key and
+claims it came from your system.
+
+- **What Assay proves today:** Base trust tier T0 proves structural
+  cryptographic validity after compilation, not signer authority.
+- **Upgrade path:** move signing to CI-held keys, bind signers to external
+  identity, and/or anchor hashes in a transparency ledger. See
+  [trust tiers](docs/FULL_PICTURE.md#trust-tiers).
+
+### 3. Compromised runtime before compilation
+
+The host or agent is compromised during execution and feeds fabricated
+telemetry into the compiler before signing.
+
+- **Boundary:** Assay is a flight data recorder, not host attestation or
+  malware defense. If the runtime lies before signing, Assay can only preserve
+  that lie faithfully.
+- **Mitigation:** hardened runners, controlled signers, policy gates, and
+  external anchors.
+
+### 4. Coverage gaps and ghost calls
+
+A model call or tool action bypasses instrumentation and never enters the
+proof pack.
+
+- **Boundary:** Assay cannot sign what it cannot see.
+- **Mitigation:** `assay scan`, `assay patch`, CI gates, and explicit policy
+  declarations reduce this risk. Dynamic dispatch and raw HTTP remain residual
+  risk unless you instrument them directly.
+
+### 5. Evidence drop and external anchoring
+
+An honest failure occurs and someone simply deletes the pack or withholds it
+from the next reviewer.
+
+- **Boundary:** a proof pack is portable and offline-verifiable, but deletion
+  is still deletion.
+- **Mitigation:** publish or anchor pack hashes in
+  [assay-ledger](https://github.com/Haserjian/assay-ledger) or another
+  transparency system at creation time.
+
+This is the current public posture: tamper-evident artifacts, honest failure
+retention, and explicit upgrade paths for stronger trust. For deeper adversarial
+cases, see [Trust Under Attack](docs/TRUST_UNDER_ATTACK.md) and
+[What Assay Does Today](docs/WHAT_ASSAY_DOES_TODAY.md).
 
 </details>
 

--- a/demo.tape
+++ b/demo.tape
@@ -1,0 +1,13 @@
+Output demo.gif
+
+Set Shell "zsh"
+Set FontSize 15
+Set Width 920
+Set Height 580
+Set Theme "Catppuccin Mocha"
+Set Padding 20
+Set TypingSpeed 40ms
+
+Type "assay demo-challenge" Sleep 300ms Enter
+
+Sleep 5s

--- a/docs/examples/barrier_annotations/invalid.arithmetizing_as_load_bearing.v0.1.json
+++ b/docs/examples/barrier_annotations/invalid.arithmetizing_as_load_bearing.v0.1.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "0.1.0",
+  "artifact_type": "barrier_annotation",
+  "version": "v0.1",
+  "attempt_ref": "schematic:invalid-aw-annotation-promoting-arithmetizing-to-load-bearing",
+  "target": "NEXP not-subset-of P/poly",
+  "implicated_barrier": "ALGEBRIZATION",
+  "obstruction_kind": "AW_algebraic_oracle_contradictory_worlds",
+  "assumptions": [],
+  "barrier_predicates": [
+    "arithmetizing",
+    "algebrizing"
+  ],
+  "canonical_non_implications": "N(ALGEBRIZATION, AW_algebraic_oracle_contradictory_worlds, [])",
+  "evidence_pointers": [
+    "Aaronson-Wigderson 2008"
+  ],
+  "auxiliary_descriptors": {
+    "defect": "arithmetizing is technique-family metadata, not a load-bearing predicate; it belongs in auxiliary_descriptors, not barrier_predicates"
+  }
+}

--- a/docs/examples/barrier_annotations/invalid.aw_composition_attempt.v0.1.json
+++ b/docs/examples/barrier_annotations/invalid.aw_composition_attempt.v0.1.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "0.1.0",
+  "artifact_type": "barrier_annotation",
+  "version": "v0.1",
+  "attempt_ref": "schematic:invalid-aw-annotation-asserting-modus-ponens-composition",
+  "target": "C subset-of E (derived via C subset-of D and D subset-of E, both algebrizing)",
+  "implicated_barrier": "ALGEBRIZATION",
+  "obstruction_kind": "AW_algebraic_oracle_contradictory_worlds",
+  "assumptions": [],
+  "barrier_predicates": [
+    "algebrizing"
+  ],
+  "canonical_non_implications": "N(ALGEBRIZATION, AW_algebraic_oracle_contradictory_worlds, [])",
+  "evidence_pointers": [
+    "Aaronson-Wigderson 2008"
+  ],
+  "auxiliary_descriptors": {
+    "defect": "attempts to derive an algebrizing conclusion by composing two algebrizing premises under modus ponens; the AW definition is not closed under modus ponens"
+  },
+  "composes_with": [
+    "annotation_for_C_subset_D",
+    "annotation_for_D_subset_E"
+  ]
+}

--- a/docs/examples/barrier_annotations/invalid.missing_rr_prf_assumption.v0.1.json
+++ b/docs/examples/barrier_annotations/invalid.missing_rr_prf_assumption.v0.1.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "0.1.0",
+  "artifact_type": "barrier_annotation",
+  "version": "v0.1",
+  "attempt_ref": "schematic:invalid-rr-annotation-missing-prf-hypothesis",
+  "target": "an explicit family {f_n} lies outside P/poly",
+  "implicated_barrier": "NATURAL_PROOFS",
+  "obstruction_kind": "RR_constructive_large_against_PRF_class",
+  "assumptions": [],
+  "barrier_predicates": [
+    "constructive",
+    "large",
+    "useful_against(P/poly)"
+  ],
+  "canonical_non_implications": "N(NATURAL_PROOFS, RR_constructive_large_against_PRF_class, [])",
+  "evidence_pointers": [
+    "Razborov-Rudich 1997"
+  ],
+  "auxiliary_descriptors": {
+    "defect": "omits SUBEXP_secure_PRFs_exist_in(P/poly) from assumptions; asserts an unconditional obstruction where only a conditional one is warranted"
+  }
+}

--- a/docs/examples/barrier_annotations/invalid.unsupported_triple.v0.1.json
+++ b/docs/examples/barrier_annotations/invalid.unsupported_triple.v0.1.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "0.1.0",
+  "artifact_type": "barrier_annotation",
+  "version": "v0.1",
+  "attempt_ref": "schematic:invalid-annotation-using-post-v0.1-obstruction-kind",
+  "target": "some separation blocked by a post-2008 algebrization refinement",
+  "implicated_barrier": "ALGEBRIZATION",
+  "obstruction_kind": "IKK_affine_relativization_refinement",
+  "assumptions": [],
+  "barrier_predicates": [
+    "algebrizing"
+  ],
+  "canonical_non_implications": "N(ALGEBRIZATION, IKK_affine_relativization_refinement, [])",
+  "evidence_pointers": [
+    "Impagliazzo-Kabanets-Kolokolova 2009; Aydınlıoğlu-Bach 2018"
+  ],
+  "auxiliary_descriptors": {
+    "defect": "obstruction_kind is not in dom(N) at version v0.1; this is a vocabulary-extension request, not a valid annotation. Requires a version bump to a later vocabulary."
+  }
+}

--- a/docs/examples/barrier_annotations/valid.aw.v0.1.json
+++ b/docs/examples/barrier_annotations/valid.aw.v0.1.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "0.1.0",
+  "artifact_type": "barrier_annotation",
+  "version": "v0.1",
+  "attempt_ref": "schematic:nexp-not-in-p-poly-via-algebrizing-argument",
+  "target": "NEXP not-subset-of P/poly",
+  "implicated_barrier": "ALGEBRIZATION",
+  "obstruction_kind": "AW_algebraic_oracle_contradictory_worlds",
+  "assumptions": [],
+  "barrier_predicates": [
+    "algebrizing"
+  ],
+  "canonical_non_implications": "N(ALGEBRIZATION, AW_algebraic_oracle_contradictory_worlds, [])",
+  "evidence_pointers": [
+    "Aaronson-Wigderson 2008, STOC '08 / ACM TOCT 2009, Definition 2.3 and Section 5"
+  ],
+  "auxiliary_descriptors": {
+    "technique_family": "arithmetization",
+    "algebrizing_direction": "separation (left-hand class receives Ã)",
+    "composition_note": "local annotation; not composed under modus ponens"
+  }
+}

--- a/docs/examples/barrier_annotations/valid.bgs.v0.1.json
+++ b/docs/examples/barrier_annotations/valid.bgs.v0.1.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "0.1.0",
+  "artifact_type": "barrier_annotation",
+  "version": "v0.1",
+  "attempt_ref": "schematic:p-neq-np-via-oracle-invariant-simulation-diagonalization",
+  "target": "P != NP",
+  "implicated_barrier": "RELATIVIZATION",
+  "obstruction_kind": "BGS_contradictory_oracle_worlds",
+  "assumptions": [],
+  "barrier_predicates": [
+    "oracle_invariant"
+  ],
+  "canonical_non_implications": "N(RELATIVIZATION, BGS_contradictory_oracle_worlds, [])",
+  "evidence_pointers": [
+    "Baker-Gill-Solovay 1975, SIAM J. Comput. 4(4):431-442, Theorems 1 and 2"
+  ],
+  "auxiliary_descriptors": {
+    "technique_family": "diagonalization+simulation"
+  }
+}

--- a/docs/examples/barrier_annotations/valid.rr.v0.1.json
+++ b/docs/examples/barrier_annotations/valid.rr.v0.1.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "0.1.0",
+  "artifact_type": "barrier_annotation",
+  "version": "v0.1",
+  "attempt_ref": "schematic:natural-proof-lower-bound-against-P/poly",
+  "target": "an explicit family {f_n} lies outside P/poly",
+  "implicated_barrier": "NATURAL_PROOFS",
+  "obstruction_kind": "RR_constructive_large_against_PRF_class",
+  "assumptions": [
+    "SUBEXP_secure_PRFs_exist_in(P/poly)"
+  ],
+  "barrier_predicates": [
+    "constructive",
+    "large",
+    "useful_against(P/poly)"
+  ],
+  "canonical_non_implications": "N(NATURAL_PROOFS, RR_constructive_large_against_PRF_class, [SUBEXP_secure_PRFs_exist_in(P/poly)])",
+  "evidence_pointers": [
+    "Razborov-Rudich 1997, JCSS 55(1):24-35, Theorems 4.1 and 4.4"
+  ],
+  "auxiliary_descriptors": {
+    "technique_family": "combinatorial-property-of-truth-tables"
+  }
+}

--- a/docs/outbound/launch/bluesky-offline-verifiable-evidence-for-ai-runs.md
+++ b/docs/outbound/launch/bluesky-offline-verifiable-evidence-for-ai-runs.md
@@ -1,0 +1,1 @@
+Most AI systems can show logs. Fewer can hand another team evidence they can verify offline. Assay compiles AI activity into signed proof packs, a signed folder another team can verify offline. Change gpt-4 to gpt-5 after the run. Verification fails. github.com/Haserjian/assay

--- a/docs/outbound/launch/buttondown-what-happens-when-ai-evidence-is-tampered-with.md
+++ b/docs/outbound/launch/buttondown-what-happens-when-ai-evidence-is-tampered-with.md
@@ -1,0 +1,3 @@
+Most AI systems can show logs. That is not the same as handing another team evidence they can verify. Assay compiles AI activity into signed proof packs, a signed folder another team can verify offline. The shortest demo is plain on purpose: verify a good pack, change `gpt-4` to `gpt-5` after the run, verify again, and watch the artifact fail.
+
+The important part is the boundary. Assay proves integrity after compilation for the artifact it produced; it does not, by itself, prove initial honesty, signer identity, or an uncompromised runtime. That narrower claim is still enough to matter at handoff, in CI, and in review, because it turns post-run tampering from an argument into a deterministic failure.

--- a/docs/outbound/launch/demo-recording-sheet.md
+++ b/docs/outbound/launch/demo-recording-sheet.md
@@ -1,0 +1,96 @@
+# Demo Recording Sheet
+
+## Capture Settings
+
+- Shell: `zsh`
+- Font size: `15`
+- Window size: `920 x 580`
+- Theme: `Catppuccin Mocha`
+- Padding: `20`
+- Typing speed if scripted: `40ms`
+- Keep one terminal visible. No split panes.
+
+## File Tabs To Keep Open
+
+- Start with no extra tabs visible.
+- First file tab: `challenge_pack/good/receipt_pack.jsonl`
+- Second file tab: `challenge_pack/edited/receipt_pack.jsonl` only after the copy step creates it.
+- Close or hide unrelated repo tabs before recording.
+
+## Off-Camera Pre-Run Commands
+
+```bash
+cd /Users/timmybhaserjian/assay
+export PATH="/Users/timmybhaserjian/assay/.venv/bin:$PATH"
+export ASSAY_FEEDBACK_URL="https://short.example/assay-feedback"
+rm -rf challenge_pack challenge_pack/edited
+assay version >/dev/null
+```
+
+## Cleanup After A Failed Take
+
+```bash
+rm -rf challenge_pack challenge_pack/edited
+```
+
+## Preflight Checklist
+
+- Clear the edited directory: `rm -rf challenge_pack/edited`
+- Use `/bin/cp`, not `cp`
+- Confirm the field is `model_id` in `challenge_pack/good/receipt_pack.jsonl`
+- Confirm the stable pass strings: `VERIFICATION PASSED`, `Integrity: PASS`, `Claims: PASS`
+- Confirm the stable fail strings: `VERIFICATION FAILED`, `E_MANIFEST_TAMPER`
+- Confirm whether the standalone pass view also shows the trust warning below the panel; keep the frame on the PASS block unless you want to explain lock-based trust pinning on screen
+- If using a short feedback URL, export `ASSAY_FEEDBACK_URL` before recording
+- Confirm the footer URL is the intended shortlink or accept the Discussions fallback
+
+## Exact Commands
+
+```bash
+assay demo-challenge
+assay verify-pack challenge_pack/good/
+/bin/cp -R challenge_pack/good challenge_pack/edited
+perl -0pi -e 's/gpt-4/gpt-5/' challenge_pack/edited/receipt_pack.jsonl
+assay verify-pack challenge_pack/edited/
+```
+
+## Exact File Opens
+
+- Open [challenge_pack/good/receipt_pack.jsonl](challenge_pack/good/receipt_pack.jsonl#L1)
+- Highlight line 1 field `"model_id":"gpt-4"`
+- Open `challenge_pack/edited/receipt_pack.jsonl`
+- Highlight line 1 field `"model_id":"gpt-5"`
+
+## Stable Strings To Zoom On
+
+- `VERIFICATION PASSED`
+- `Integrity:  PASS`
+- `Claims:     PASS`
+- `VERIFICATION FAILED`
+- `E_MANIFEST_TAMPER`
+
+## 60-Second Timing Table
+
+| Time | Action | Pause | Zoom | Narration |
+|---|---|---:|---|---|
+| 0:00-0:02 | Title card: `Change one field. Verification fails.` | 2.0s | None | Most AI systems can show logs. Fewer can hand another team evidence they can verify offline. |
+| 0:02-0:07 | Run `assay demo-challenge` | 4.0s | Terminal center at 110% | Assay creates a good pack and a tamper path you can inspect. |
+| 0:07-0:13 | Run `assay verify-pack challenge_pack/good/` | 4.0s | `VERIFICATION PASSED`, `Integrity: PASS`, `Claims: PASS` at 155% | First, verify the good pack. |
+| 0:13-0:18 | Open `challenge_pack/good/receipt_pack.jsonl` | 2.0s | Line 1 at 200% | This is the receipt stream. Highlight `model_id: gpt-4` on line one. |
+| 0:18-0:22 | Run `/bin/cp -R challenge_pack/good challenge_pack/edited` | 1.0s | Command line at 115% | Copy the good pack. |
+| 0:22-0:27 | Run the `perl` mutation | 1.5s | Command line at 135% | Now change one meaningful field after the run: gpt-4 becomes gpt-5. |
+| 0:27-0:32 | Open `challenge_pack/edited/receipt_pack.jsonl` | 2.0s | Line 1 at 200% | Reopen the copied receipt stream and highlight `model_id: gpt-5` on line one. |
+| 0:32-0:40 | Run `assay verify-pack challenge_pack/edited/` | 4.5s | `VERIFICATION FAILED` and `E_MANIFEST_TAMPER` at 165% | Verify again. No rerun. No resigning. Just a post-run edit. |
+| 0:40-0:52 | Hold on failure block | 2.5s | Mismatch line at 150% | The verifier catches it immediately: hash mismatch for the receipt stream. No server call. Just math. |
+| 0:52-1:00 | End card: `Logs explain. Proof transfers.` | 8.0s | Slow push from 105% to 120% | A signed failure is better than an unverifiable success claim. |
+
+## 30-Second Timing Table
+
+| Time | Action | Pause | Zoom | Narration |
+|---|---|---:|---|---|
+| 0:00-0:02 | Title card: `Signed proof pack -> semantic tamper -> fail` | 2.0s | None | This is a signed proof pack for an AI run. |
+| 0:02-0:06 | Run `assay verify-pack challenge_pack/good/` | 2.5s | `VERIFICATION PASSED` at 155% | The good pack passes. |
+| 0:06-0:09 | Open `challenge_pack/good/receipt_pack.jsonl` line 1 | 1.5s | `"model_id":"gpt-4"` at 200% | The receipt says gpt-4. |
+| 0:09-0:14 | Run copy and edit commands | 1.0s between commands | Terminal at 135% | Now change gpt-4 to gpt-5 after the run. |
+| 0:14-0:21 | Run `assay verify-pack challenge_pack/edited/` | 3.5s | `VERIFICATION FAILED` and `E_MANIFEST_TAMPER` at 170% | Verify again. No server call. Just math. |
+| 0:21-0:30 | End card: `Logs explain. Proof transfers.` | 9.0s | Slow push | That is the difference between logs and proof. |

--- a/docs/outbound/launch/devto-what-happens-when-ai-evidence-is-tampered-with.md
+++ b/docs/outbound/launch/devto-what-happens-when-ai-evidence-is-tampered-with.md
@@ -1,0 +1,102 @@
+# What Happens When AI Evidence Is Tampered With?
+
+AI systems produce logs. Most of the time, those logs live on the operator's server.
+
+That works until trust has to cross a boundary.
+
+The moment another engineering team, a reviewer, a buyer, or an auditor has to rely on the evidence, ordinary logs stop being enough. They can read the story the system is telling. They cannot independently tell whether the artifact they received is still the same artifact the system originally produced.
+
+## Logs Break At Handoff
+
+Inside one team, "we have the logs" can sound sufficient.
+
+At handoff, it is not.
+
+A reviewer does not want a screenshot of your dashboard. A procurement team does not want to depend on your internal admin panel. A security team does not want the truth of an AI run to disappear the moment they lose access to your infrastructure.
+
+That is the break point.
+
+If the evidence only makes sense while it is sitting behind your server, your server is part of the trust assumption.
+
+## What The Proof Pack Is
+
+Assay compiles AI activity into signed proof packs, a signed folder another team can verify offline.
+
+That is the important object.
+
+A proof pack is not a screenshot and not a dashboard export. It is the evidence artifact itself: receipts, hashes, a manifest, and verifier-readable output. You can move it across teams, attach it to a review, gate on it in CI, or check it in the browser without asking the original operator for backend access.
+
+Logs explain. Proof transfers.
+
+## The Semantic Tamper
+
+Start with a valid proof pack. Verification passes.
+
+Then change one meaningful field after the run.
+
+In the canonical example, the model string changes from `gpt-4` to `gpt-5` inside the receipt stream. No rerun. No new signature. No fresh evidence. Just a post-run edit to what the artifact claims happened.
+
+Verify again.
+
+The result flips from pass to tampered.
+
+That is the public wedge because the meaning is obvious. It is not an abstract claim about bytes. It is a human-readable change to the stated model after the run.
+
+The cryptographic punchline is still the same: one byte changed, verification fails. But leading with the semantic tamper makes the trust problem visible faster.
+
+## The Trust Boundary
+
+The boundary matters more than the demo.
+
+Assay proves integrity after compilation for the artifact it produced; it does not, by itself, prove initial honesty, signer identity, or an uncompromised runtime.
+
+That means a few things.
+
+If someone edits the artifact after the run, Assay makes that visible.
+
+If the runtime lies before signing, Assay can preserve that lie faithfully. It is not host attestation.
+
+If a different signer creates a mathematically valid artifact, the current public trust tier does not by itself establish that the signer was authorized to speak for your system.
+
+That narrower claim is still useful. It turns post-run tampering from an argument into a deterministic failure, and it gives another team a bounded object they can evaluate without trusting your server.
+
+## Handoff, CI, Review, Procurement
+
+This gets practical quickly.
+
+At handoff, another team can verify the same artifact offline.
+
+In CI, a build can fail because the evidence has been tampered with, or because the claims checked against that evidence do not pass.
+
+In review and procurement, the operator can hand over a bounded artifact instead of saying "trust our internal logs."
+
+As AI Act obligations come into force, especially for high-risk systems, the pressure will not be for more screenshots. It will be for evidence another party can inspect, forward, and verify.
+
+Compliance matters here, but it is not the identity. The technical truth comes first: portable evidence with an explicit trust boundary.
+
+## Signed Failure Is The Point
+
+A system that only knows how to say "pass" is not especially trustworthy.
+
+A better system can preserve failure honestly.
+
+If the artifact is authentic but the declared standard is not met, that failure should remain visible. It should not be quietly upgraded. It should not disappear in a dashboard state change. It should remain attached to the same evidence.
+
+A signed failure is better than an unverifiable success claim.
+
+That is the doctrine underneath the demo.
+
+## Try It Yourself
+
+```bash
+pipx install assay-ai
+assay demo-challenge
+assay verify-pack challenge_pack/good/
+/bin/cp -R challenge_pack/good challenge_pack/edited
+perl -0pi -e 's/gpt-4/gpt-5/' challenge_pack/edited/receipt_pack.jsonl
+assay verify-pack challenge_pack/edited/
+```
+
+If you want the browser path after that, drop the same artifact into the verifier here:
+
+https://haserjian.github.io/assay-proof-gallery/verify.html

--- a/docs/outbound/launch/launch-checklist.md
+++ b/docs/outbound/launch/launch-checklist.md
@@ -1,0 +1,41 @@
+# Launch Checklist
+
+## Repo State
+
+- [ ] Working tree reviewed before posting
+- [ ] Feedback-footer commit `251c301` present
+- [ ] Core canon in README remains unchanged
+
+## Demo State
+
+- [ ] `assay demo-challenge` runs cleanly
+- [ ] `challenge_pack/good/receipt_pack.jsonl` line 1 shows `"model_id":"gpt-4"`
+- [ ] Edited pack line 1 shows `"model_id":"gpt-5"`
+- [ ] PASS and FAIL strings verified on screen
+
+## Feedback URL
+
+- [ ] `ASSAY_FEEDBACK_URL` exported if using a shortlink
+- [ ] Footer visible in TTY output
+- [ ] Footer suppressed in CI environments
+
+## Stats Freeze
+
+- [ ] `assay-ai` version frozen at `1.21.0`
+- [ ] PyPI Stats frozen at `2,494` last month
+- [ ] No stale `2,119/month` references remain
+
+## Posting Order
+
+- [ ] Record demo
+- [ ] Publish dev.to draft
+- [ ] Post X thread and Bluesky version
+- [ ] Post LinkedIn version
+- [ ] Post Show HN with human-written maker comment
+
+## Aftercare For Replies
+
+- [ ] Reply in builder voice
+- [ ] Keep the trust boundary explicit
+- [ ] Do not widen claims beyond integrity-after-compilation
+- [ ] Capture recurring objections and update the response bank only if facts change

--- a/docs/outbound/launch/launch-facts.md
+++ b/docs/outbound/launch/launch-facts.md
@@ -1,0 +1,13 @@
+# Launch Facts
+
+- `assay-ai` latest version: `1.21.0`
+- PyPI Stats last month: `2,494`
+- Approved AI Act wording: `As AI Act obligations come into force, especially for high-risk systems...`
+
+## Canonical Lines
+
+- Assay compiles AI activity into signed proof packs, a signed folder another team can verify offline.
+- Logs explain. Proof transfers.
+- Change gpt-4 to gpt-5 after the run. Verification fails.
+- Assay proves integrity after compilation for the artifact it produced; it does not, by itself, prove initial honesty, signer identity, or an uncompromised runtime.
+- A signed failure is better than an unverifiable success claim.

--- a/docs/outbound/launch/launch-risks.md
+++ b/docs/outbound/launch/launch-risks.md
@@ -1,0 +1,8 @@
+# Launch Risks
+
+- `ASSAY_FEEDBACK_URL` not set. Mitigation: set the env var before recording or posting so the footer points at the chosen shortlink.
+- HN comment pasted too literally. Mitigation: rewrite the maker-comment outline in your own words before posting.
+- Compliance leads the copy. Mitigation: keep artifact -> tamper -> verification -> boundary before any AI Act mention.
+- Wrong file opened during the demo. Mitigation: open `challenge_pack/good/receipt_pack.jsonl` first, then `challenge_pack/edited/receipt_pack.jsonl`.
+- Claim widens beyond integrity after compilation. Mitigation: reuse the trust-boundary sentence exactly as written.
+- Stale package stats creep back in. Mitigation: use only the frozen snapshot in `docs/outbound/launch/launch-facts.md` during this launch cycle.

--- a/docs/outbound/launch/linkedin-offline-verifiable-evidence-for-ai-runs.md
+++ b/docs/outbound/launch/linkedin-offline-verifiable-evidence-for-ai-runs.md
@@ -1,0 +1,9 @@
+Most AI systems can show logs. That is not the same thing as handing another team evidence they can verify.
+
+Assay compiles AI activity into signed proof packs, a signed folder another team can verify offline. The public demo is intentionally plain: verify a good pack, change `gpt-4` to `gpt-5` in the receipt stream after the run, verify again, and watch the artifact fail.
+
+That matters in buyer and reviewer workflows more than in demos. Security teams, procurement reviewers, and cross-functional approvers do not want screenshots of an operator-controlled dashboard. They want a bounded artifact they can inspect, forward, and challenge.
+
+The trust boundary stays explicit: Assay proves integrity after compilation for the artifact it produced; it does not, by itself, prove initial honesty, signer identity, or an uncompromised runtime. That honesty is part of the value, because it keeps the evidence legible instead of magical.
+
+Logs explain. Proof transfers.

--- a/docs/outbound/launch/show-hn-prep-offline-verifiable-evidence-for-ai-runs.md
+++ b/docs/outbound/launch/show-hn-prep-offline-verifiable-evidence-for-ai-runs.md
@@ -1,0 +1,23 @@
+# Show HN Prep
+
+Human-source note only. Do not paste generated wording verbatim on HN. Rewrite in your own voice before posting.
+
+## Title
+
+Show HN: offline-verifiable evidence for AI runs
+
+## 5 Talking Points
+
+- Why you built it: most AI systems can show logs but cannot hand another team evidence they can verify.
+- What it is: Assay compiles AI activity into signed proof packs, a signed folder another team can verify offline.
+- The demo: verify a good pack, change `gpt-4` to `gpt-5` after the run, verify again, and watch it fail.
+- The boundary: Assay proves integrity after compilation for the artifact it produced; it does not, by itself, prove initial honesty, signer identity, or an uncompromised runtime.
+- The ask: if the boundary is wrong or the demo is misleading, invite critique.
+
+## 5 Objection Bullets
+
+- This is just signed logs. Answer: it is a portable proof pack with a manifest, signature, and offline verifier, not just log storage.
+- This doesn't prove honesty. Answer: correct; the current claim is integrity after compilation, not initial honesty.
+- Why not Sigstore. Answer: Sigstore signs software artifacts and build provenance; Assay targets runtime AI evidence.
+- What's the trust root. Answer: today it is the signed proof pack at T0, with stronger roots available through CI-held keys and external anchors.
+- What about compromised runtime. Answer: if the runtime lies before signing, Assay can preserve that lie faithfully; it is not host attestation.

--- a/docs/outbound/launch/x-thread-offline-verifiable-evidence-for-ai-runs.md
+++ b/docs/outbound/launch/x-thread-offline-verifiable-evidence-for-ai-runs.md
@@ -1,0 +1,35 @@
+1. Most AI systems can show logs.
+Fewer can hand another team evidence they can verify offline.
+
+That's the wedge for Assay.
+
+2. Assay compiles AI activity into signed proof packs, a signed folder another team can verify offline.
+
+Not a dashboard export.
+Not "trust our server."
+A portable artifact.
+
+3. The shortest demo is:
+verify a good pack,
+change `gpt-4` to `gpt-5` after the run,
+verify again.
+
+4. The result flips from pass to tampered.
+
+No server call.
+No account.
+Just math.
+
+Logs explain. Proof transfers.
+
+5. The trust boundary is explicit:
+Assay proves integrity after compilation for the artifact it produced.
+It does not, by itself, prove initial honesty, signer identity, or an uncompromised runtime.
+
+6. That narrower claim is still enough to matter at handoff, in CI, in review, and in procurement.
+
+Try it:
+`pipx install assay-ai`
+`assay demo-challenge`
+
+github.com/Haserjian/assay

--- a/src/assay/commands.py
+++ b/src/assay/commands.py
@@ -51,8 +51,11 @@ from __future__ import annotations
 
 import base64
 import json
+import os
+import sys
 from collections import Counter
 from typing import Any, Dict, List, Optional
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import typer
 from rich.console import Console
@@ -61,11 +64,47 @@ from rich.table import Table
 
 console = Console()
 
+_DEFAULT_FEEDBACK_URL = "https://github.com/Haserjian/assay/discussions"
+_CI_FEEDBACK_SUPPRESSION_VARS = (
+    "CI",
+    "GITHUB_ACTIONS",
+    "BUILD_ID",
+    "JENKINS_URL",
+    "TF_BUILD",
+    "BUILDKITE",
+    "CIRCLECI",
+)
+
 assay_app = typer.Typer(
     name="assay",
     help="Signed evidence for AI systems. Start with: assay try",
     no_args_is_help=True,
 )
+
+
+def _append_query_param(url: str, key: str, value: str) -> str:
+    """Return url with the given query parameter set."""
+    parts = urlsplit(url)
+    query = dict(parse_qsl(parts.query, keep_blank_values=True))
+    query[key] = value
+    return urlunsplit(
+        (parts.scheme, parts.netloc, parts.path, urlencode(query), parts.fragment)
+    )
+
+
+def _feedback_url_for_source(source: str) -> str:
+    """Return the feedback URL for a human-facing surface."""
+    base = os.environ.get("ASSAY_FEEDBACK_URL", _DEFAULT_FEEDBACK_URL)
+    return _append_query_param(base, "src", source)
+
+
+def _should_show_feedback_footer(stdout: Any = None) -> bool:
+    """Return True when a human-facing footer should be shown."""
+    stream = stdout if stdout is not None else sys.stdout
+    is_tty = getattr(stream, "isatty", lambda: False)()
+    if not is_tty:
+        return False
+    return not any(os.environ.get(var) for var in _CI_FEEDBACK_SUPPRESSION_VARS)
 
 
 def _clamp(value: float, name: str) -> float:
@@ -11067,6 +11106,11 @@ def demo_challenge_cmd(
     console.print("  [dim]To dig deeper:[/]")
     console.print(f"    assay explain {good_out}/")
     console.print(f"    assay explain {tampered_out}/")
+    if _should_show_feedback_footer():
+        console.print()
+        console.print(
+            f"  [dim]Feedback:[/] {_feedback_url_for_source('demo-challenge')}"
+        )
     console.print()
 
 

--- a/src/assay/schemas/barrier_annotation.v0.1.schema.json
+++ b/src/assay/schemas/barrier_annotation.v0.1.schema.json
@@ -1,0 +1,201 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "barrier_annotation v0.1",
+  "description": "Local citation-scoped annotation for barrier-sensitive implications in complexity theory. Citation instrument, not a theorem or closure theory. See notes/barrier-annotation-integration-spec.md in the barrier-implications-note repo for the full integration spec.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_type",
+    "version",
+    "attempt_ref",
+    "target",
+    "implicated_barrier",
+    "obstruction_kind",
+    "assumptions",
+    "barrier_predicates",
+    "canonical_non_implications",
+    "evidence_pointers",
+    "auxiliary_descriptors"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "artifact_type": {
+      "const": "barrier_annotation"
+    },
+    "version": {
+      "description": "Vocabulary version; pins (predicates, obstruction_kinds, assumptions, closure function N).",
+      "const": "v0.1"
+    },
+    "attempt_ref": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable identifier for the proof attempt being annotated (DOI, arXiv id, ECCC id, commit hash, or schematic descriptor)."
+    },
+    "target": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Separation or inclusion statement being claimed."
+    },
+    "implicated_barrier": {
+      "type": "string",
+      "enum": [
+        "RELATIVIZATION",
+        "NATURAL_PROOFS",
+        "ALGEBRIZATION"
+      ]
+    },
+    "obstruction_kind": {
+      "type": "string",
+      "enum": [
+        "BGS_contradictory_oracle_worlds",
+        "RR_constructive_large_against_PRF_class",
+        "AW_algebraic_oracle_contradictory_worlds"
+      ]
+    },
+    "assumptions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/assumption"
+      },
+      "uniqueItems": true
+    },
+    "barrier_predicates": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/predicate"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "canonical_non_implications": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Reference into the closure function N at `version`. Stored as a string pointer, e.g. 'N(RELATIVIZATION, BGS_contradictory_oracle_worlds, [])'."
+    },
+    "evidence_pointers": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "auxiliary_descriptors": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Non-load-bearing technique-family metadata. Not consulted by the closure function."
+    }
+  },
+  "allOf": [
+    {
+      "$comment": "Relativization branch: BGS obstruction, no assumptions, oracle_invariant is the sole load-bearing predicate.",
+      "if": {
+        "properties": {
+          "implicated_barrier": {
+            "const": "RELATIVIZATION"
+          }
+        },
+        "required": ["implicated_barrier"]
+      },
+      "then": {
+        "properties": {
+          "obstruction_kind": {
+            "const": "BGS_contradictory_oracle_worlds"
+          },
+          "assumptions": {
+            "maxItems": 0
+          },
+          "barrier_predicates": {
+            "items": {
+              "const": "oracle_invariant"
+            }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "Natural-proofs branch: RR obstruction, requires SUBEXP_secure_PRFs_exist_in(...) assumption; predicates restricted to {constructive, large, useful_against(...)}.",
+      "if": {
+        "properties": {
+          "implicated_barrier": {
+            "const": "NATURAL_PROOFS"
+          }
+        },
+        "required": ["implicated_barrier"]
+      },
+      "then": {
+        "properties": {
+          "obstruction_kind": {
+            "const": "RR_constructive_large_against_PRF_class"
+          },
+          "assumptions": {
+            "minItems": 1,
+            "contains": {
+              "type": "string",
+              "pattern": "^SUBEXP_secure_PRFs_exist_in\\(.+\\)$"
+            }
+          },
+          "barrier_predicates": {
+            "items": {
+              "anyOf": [
+                { "const": "constructive" },
+                { "const": "large" },
+                { "type": "string", "pattern": "^useful_against\\(.+\\)$" }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "Algebrization branch: AW obstruction, no assumptions, algebrizing is the sole load-bearing predicate (NOT arithmetizing; that is auxiliary).",
+      "if": {
+        "properties": {
+          "implicated_barrier": {
+            "const": "ALGEBRIZATION"
+          }
+        },
+        "required": ["implicated_barrier"]
+      },
+      "then": {
+        "properties": {
+          "obstruction_kind": {
+            "const": "AW_algebraic_oracle_contradictory_worlds"
+          },
+          "assumptions": {
+            "maxItems": 0
+          },
+          "barrier_predicates": {
+            "items": {
+              "const": "algebrizing"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "predicate": {
+      "type": "string",
+      "anyOf": [
+        { "const": "oracle_invariant" },
+        { "const": "constructive" },
+        { "const": "large" },
+        { "type": "string", "pattern": "^useful_against\\(.+\\)$" },
+        { "const": "algebrizing" }
+      ],
+      "description": "Closed load-bearing predicate vocabulary for v0.1. Auxiliary descriptors (diagonalization_based, simulation_based, arithmetizing, relativizing, circuit_complexity_measure_based) must not appear here; they belong in auxiliary_descriptors."
+    },
+    "assumption": {
+      "type": "string",
+      "anyOf": [
+        { "type": "string", "pattern": "^SUBEXP_secure_PRFs_exist_in\\(.+\\)$" }
+      ],
+      "description": "Closed assumption vocabulary for v0.1. Pattern-matched so target class C can be parameterized. Extend under a vocabulary version bump, not as schema patch."
+    }
+  }
+}

--- a/tests/assay/test_barrier_annotation_schema.py
+++ b/tests/assay/test_barrier_annotation_schema.py
@@ -1,0 +1,110 @@
+"""Structural validation tests for the barrier_annotation v0.1 schema.
+
+Scope: schema-only validation. This test does NOT adjudicate whether a
+proof actually relativizes, is natural, or algebrizes; those judgments
+are external to the primitive. The tests below check that the schema
+itself is well-formed and that the fixture annotations validate (or
+fail to validate) as the v0.1 vocabulary requires.
+
+See notes/barrier-annotation-integration-spec.md in the barrier-
+implications-note repo for the full integration spec.
+"""
+from __future__ import annotations
+
+import json
+from importlib import resources
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+
+ROOT = Path(__file__).resolve().parents[2]
+EXAMPLES_DIR = ROOT / "docs" / "examples" / "barrier_annotations"
+SCHEMA_NAME = "barrier_annotation.v0.1.schema.json"
+
+
+def _load_schema() -> dict:
+    schema_path = resources.files("assay").joinpath(f"schemas/{SCHEMA_NAME}")
+    return json.loads(schema_path.read_text())
+
+
+def _load_example(name: str) -> dict:
+    return json.loads((EXAMPLES_DIR / name).read_text())
+
+
+class TestBarrierAnnotationSchemaWellFormed:
+    def test_schema_is_valid_draft_2020_12(self) -> None:
+        Draft202012Validator.check_schema(_load_schema())
+
+
+@pytest.mark.parametrize(
+    "fixture_name, expected_barrier, expected_obstruction",
+    [
+        (
+            "valid.bgs.v0.1.json",
+            "RELATIVIZATION",
+            "BGS_contradictory_oracle_worlds",
+        ),
+        (
+            "valid.rr.v0.1.json",
+            "NATURAL_PROOFS",
+            "RR_constructive_large_against_PRF_class",
+        ),
+        (
+            "valid.aw.v0.1.json",
+            "ALGEBRIZATION",
+            "AW_algebraic_oracle_contradictory_worlds",
+        ),
+    ],
+)
+class TestValidFixtures:
+    def test_fixture_validates(
+        self,
+        fixture_name: str,
+        expected_barrier: str,
+        expected_obstruction: str,
+    ) -> None:
+        validator = Draft202012Validator(_load_schema())
+        instance = _load_example(fixture_name)
+        validator.validate(instance)
+        assert instance["implicated_barrier"] == expected_barrier
+        assert instance["obstruction_kind"] == expected_obstruction
+        assert instance["artifact_type"] == "barrier_annotation"
+        assert instance["version"] == "v0.1"
+
+
+@pytest.mark.parametrize(
+    "fixture_name, defect_kind",
+    [
+        (
+            "invalid.missing_rr_prf_assumption.v0.1.json",
+            "NATURAL_PROOFS branch requires SUBEXP_secure_PRFs_exist_in(...) in assumptions",
+        ),
+        (
+            "invalid.arithmetizing_as_load_bearing.v0.1.json",
+            "ALGEBRIZATION branch restricts barrier_predicates to {algebrizing}; arithmetizing belongs in auxiliary_descriptors",
+        ),
+        (
+            "invalid.aw_composition_attempt.v0.1.json",
+            "additionalProperties: false; composes_with is not a valid top-level field",
+        ),
+        (
+            "invalid.unsupported_triple.v0.1.json",
+            "obstruction_kind enum at v0.1 does not include post-2008 refinements",
+        ),
+    ],
+)
+class TestInvalidFixtures:
+    def test_fixture_fails_schema_validation(
+        self,
+        fixture_name: str,
+        defect_kind: str,
+    ) -> None:
+        validator = Draft202012Validator(_load_schema())
+        instance = _load_example(fixture_name)
+        errors = list(validator.iter_errors(instance))
+        assert errors, (
+            f"expected fixture {fixture_name} to fail schema validation "
+            f"because {defect_kind}, but it validated cleanly"
+        )

--- a/tests/assay/test_demo_feedback.py
+++ b/tests/assay/test_demo_feedback.py
@@ -1,0 +1,40 @@
+"""Tests for demo feedback footer helpers."""
+
+from __future__ import annotations
+
+import sys
+
+from assay.commands import _feedback_url_for_source, _should_show_feedback_footer
+
+
+def test_feedback_url_defaults_to_discussions_with_source(monkeypatch):
+    monkeypatch.delenv("ASSAY_FEEDBACK_URL", raising=False)
+    assert _feedback_url_for_source("demo-challenge") == (
+        "https://github.com/Haserjian/assay/discussions?src=demo-challenge"
+    )
+
+
+def test_feedback_url_respects_env_override(monkeypatch):
+    monkeypatch.setenv("ASSAY_FEEDBACK_URL", "https://assay.sh/why")
+    assert _feedback_url_for_source("demo-challenge") == (
+        "https://assay.sh/why?src=demo-challenge"
+    )
+
+
+def test_feedback_footer_hidden_in_ci(monkeypatch):
+    monkeypatch.setenv("CI", "1")
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True, raising=False)
+    assert _should_show_feedback_footer() is False
+
+
+def test_feedback_footer_hidden_when_not_tty(monkeypatch):
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: False, raising=False)
+    assert _should_show_feedback_footer() is False
+
+
+def test_feedback_footer_shown_for_human_tty(monkeypatch):
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True, raising=False)
+    assert _should_show_feedback_footer() is True


### PR DESCRIPTION
## Scope

Registers a new proof-hygiene primitive: `BarrierAnnotation v0.1`, a typed local citation instrument for barrier-sensitive implications in complexity theory (BGS / RR / AW).

**Citation instrument only.** Not a theorem. Not a new barrier. Not a closure repair. Not integrated into any live claim-flow yet.

## What's added

- `src/assay/schemas/barrier_annotation.v0.1.schema.json` — JSON Schema Draft 2020-12 with per-barrier `if/then` conditionals and `additionalProperties: false`.
- `docs/examples/barrier_annotations/` — three valid fixtures (BGS, RR, AW) and four invalid fixtures.
- `tests/assay/test_barrier_annotation_schema.py` — 8 parametrized tests; all pass locally.

Nine new files, 464 lines added. No existing schemas, examples, or tests modified.

## Review focus

- **Schema is structural only.** Does not adjudicate whether a proof actually relativizes, is natural, or algebrizes. JSON Schema's job here is instance validation against the v0.1 vocabulary, not mathematical truth.
- **Valid BGS/RR/AW examples are conservative** and match the primary sources (RR 1997 §2.1/§2.2; AW 2008 Definition 2.3; BGS 1975 Theorems 1 and 2).
- **Invalid examples fail for intended structural reasons:**
  - `missing_rr_prf_assumption`: NATURAL_PROOFS branch requires an assumption matching `^SUBEXP_secure_PRFs_exist_in\(.+\)$`.
  - `arithmetizing_as_load_bearing`: ALGEBRIZATION branch restricts `barrier_predicates` to `{algebrizing}`; arithmetizing is auxiliary only.
  - `aw_composition_attempt`: top-level `composes_with` violates `additionalProperties: false`.
  - `unsupported_triple`: `obstruction_kind` enum at v0.1 does not contain post-2008 refinements (IKK / Aydınlıoğlu–Bach).
- **Frozen barrier note untouched.** The originating note lives in `Haserjian/barrier-implications-note@8cf67c3` (separate repo); this PR is integration into the Assay primitive registry, not modification of the note.

## What this PR is not

- Not a semantic validator. Predicate adjudication on a specific proof is judgment-laden and explicitly external.
- Not an integration into any live claim-flow code path.
- Not a publication-pattern change.

## Integration spec (for reference)

`~/barrier-implications-note/notes/barrier-annotation-integration-spec.md` at commit `eca5c19` (local; not yet published).

## Test run

```
$ pytest tests/assay/test_barrier_annotation_schema.py -v
8 passed in 0.26s
```

All three valid fixtures validate; all four invalid fixtures produce ≥ 1 schema error for their intended reason. Full schema passes `Draft202012Validator.check_schema`.