### PR TITLE
Add BarrierAnnotation v0.1 proof-hygiene primitive

### DIFF
--- a/docs/examples/barrier_annotations/invalid.arbitrary_closure_ref.v0.1.json
+++ b/docs/examples/barrier_annotations/invalid.arbitrary_closure_ref.v0.1.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "0.1.0",
+  "artifact_type": "barrier_annotation",
+  "version": "v0.1",
+  "attempt_ref": "schematic:invalid-aw-annotation-with-arbitrary-closure-pointer",
+  "target": "NEXP not-subset-of P/poly",
+  "implicated_barrier": "ALGEBRIZATION",
+  "obstruction_kind": "AW_algebraic_oracle_contradictory_worlds",
+  "assumptions": [],
+  "barrier_predicates": [
+    "algebrizing"
+  ],
+  "canonical_non_implications": "not a closure pointer",
+  "evidence_pointers": [
+    "Aaronson-Wigderson 2008"
+  ],
+  "auxiliary_descriptors": {
+    "defect": "closure pointer is an arbitrary string, not a canonical N(...) reference; v0.1 branch-specific const rejects unparseable closure pointers"
+  }
+}

--- a/docs/examples/barrier_annotations/invalid.arithmetizing_as_load_bearing.v0.1.json
+++ b/docs/examples/barrier_annotations/invalid.arithmetizing_as_load_bearing.v0.1.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "0.1.0",
+  "artifact_type": "barrier_annotation",
+  "version": "v0.1",
+  "attempt_ref": "schematic:invalid-aw-annotation-promoting-arithmetizing-to-load-bearing",
+  "target": "NEXP not-subset-of P/poly",
+  "implicated_barrier": "ALGEBRIZATION",
+  "obstruction_kind": "AW_algebraic_oracle_contradictory_worlds",
+  "assumptions": [],
+  "barrier_predicates": [
+    "arithmetizing",
+    "algebrizing"
+  ],
+  "canonical_non_implications": "N(ALGEBRIZATION, AW_algebraic_oracle_contradictory_worlds, [])",
+  "evidence_pointers": [
+    "Aaronson-Wigderson 2008"
+  ],
+  "auxiliary_descriptors": {
+    "defect": "arithmetizing is technique-family metadata, not a load-bearing predicate; it belongs in auxiliary_descriptors, not barrier_predicates"
+  }
+}

--- a/docs/examples/barrier_annotations/invalid.aw_composition_attempt.v0.1.json
+++ b/docs/examples/barrier_annotations/invalid.aw_composition_attempt.v0.1.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "0.1.0",
+  "artifact_type": "barrier_annotation",
+  "version": "v0.1",
+  "attempt_ref": "schematic:invalid-aw-annotation-asserting-modus-ponens-composition",
+  "target": "C subset-of E (derived via C subset-of D and D subset-of E, both algebrizing)",
+  "implicated_barrier": "ALGEBRIZATION",
+  "obstruction_kind": "AW_algebraic_oracle_contradictory_worlds",
+  "assumptions": [],
+  "barrier_predicates": [
+    "algebrizing"
+  ],
+  "canonical_non_implications": "N(ALGEBRIZATION, AW_algebraic_oracle_contradictory_worlds, [])",
+  "evidence_pointers": [
+    "Aaronson-Wigderson 2008"
+  ],
+  "auxiliary_descriptors": {
+    "defect": "attempts to derive an algebrizing conclusion by composing two algebrizing premises under modus ponens; the AW definition is not closed under modus ponens"
+  },
+  "composes_with": [
+    "annotation_for_C_subset_D",
+    "annotation_for_D_subset_E"
+  ]
+}

--- a/docs/examples/barrier_annotations/invalid.missing_rr_prf_assumption.v0.1.json
+++ b/docs/examples/barrier_annotations/invalid.missing_rr_prf_assumption.v0.1.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "0.1.0",
+  "artifact_type": "barrier_annotation",
+  "version": "v0.1",
+  "attempt_ref": "schematic:invalid-rr-annotation-missing-prf-hypothesis",
+  "target": "an explicit family {f_n} lies outside P/poly",
+  "implicated_barrier": "NATURAL_PROOFS",
+  "obstruction_kind": "RR_constructive_large_against_PRF_class",
+  "assumptions": [],
+  "barrier_predicates": [
+    "constructive",
+    "large",
+    "useful_against(P/poly)"
+  ],
+  "canonical_non_implications": "N(NATURAL_PROOFS, RR_constructive_large_against_PRF_class, [])",
+  "evidence_pointers": [
+    "Razborov-Rudich 1997"
+  ],
+  "auxiliary_descriptors": {
+    "defect": "omits SUBEXP_secure_PRFs_exist_in(P/poly) from assumptions; asserts an unconditional obstruction where only a conditional one is warranted"
+  }
+}

--- a/docs/examples/barrier_annotations/invalid.rr_missing_large.v0.1.json
+++ b/docs/examples/barrier_annotations/invalid.rr_missing_large.v0.1.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "0.1.0",
+  "artifact_type": "barrier_annotation",
+  "version": "v0.1",
+  "attempt_ref": "schematic:invalid-rr-annotation-missing-large-predicate",
+  "target": "an explicit family {f_n} lies outside P/poly",
+  "implicated_barrier": "NATURAL_PROOFS",
+  "obstruction_kind": "RR_constructive_large_against_PRF_class",
+  "assumptions": [
+    "SUBEXP_secure_PRFs_exist_in(P/poly)"
+  ],
+  "barrier_predicates": [
+    "constructive",
+    "useful_against(P/poly)"
+  ],
+  "canonical_non_implications": "N(NATURAL_PROOFS, RR_constructive_large_against_PRF_class, [SUBEXP_secure_PRFs_exist_in(P/poly)])",
+  "evidence_pointers": [
+    "Razborov-Rudich 1997"
+  ],
+  "auxiliary_descriptors": {
+    "defect": "omits the largeness predicate; RR applicability requires the conjunction of constructive + large + useful_against(C), not a subset"
+  }
+}

--- a/docs/examples/barrier_annotations/invalid.rr_missing_useful_against.v0.1.json
+++ b/docs/examples/barrier_annotations/invalid.rr_missing_useful_against.v0.1.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "0.1.0",
+  "artifact_type": "barrier_annotation",
+  "version": "v0.1",
+  "attempt_ref": "schematic:invalid-rr-annotation-missing-useful-against-predicate",
+  "target": "an explicit family {f_n} lies outside P/poly",
+  "implicated_barrier": "NATURAL_PROOFS",
+  "obstruction_kind": "RR_constructive_large_against_PRF_class",
+  "assumptions": [
+    "SUBEXP_secure_PRFs_exist_in(P/poly)"
+  ],
+  "barrier_predicates": [
+    "constructive",
+    "large"
+  ],
+  "canonical_non_implications": "N(NATURAL_PROOFS, RR_constructive_large_against_PRF_class, [SUBEXP_secure_PRFs_exist_in(P/poly)])",
+  "evidence_pointers": [
+    "Razborov-Rudich 1997"
+  ],
+  "auxiliary_descriptors": {
+    "defect": "omits the useful-against-class predicate; RR applicability requires the conjunction of constructive + large + useful_against(C)"
+  }
+}

--- a/docs/examples/barrier_annotations/invalid.rr_only_constructive.v0.1.json
+++ b/docs/examples/barrier_annotations/invalid.rr_only_constructive.v0.1.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "0.1.0",
+  "artifact_type": "barrier_annotation",
+  "version": "v0.1",
+  "attempt_ref": "schematic:invalid-rr-annotation-with-only-constructive-predicate",
+  "target": "an explicit family {f_n} lies outside P/poly",
+  "implicated_barrier": "NATURAL_PROOFS",
+  "obstruction_kind": "RR_constructive_large_against_PRF_class",
+  "assumptions": [
+    "SUBEXP_secure_PRFs_exist_in(P/poly)"
+  ],
+  "barrier_predicates": [
+    "constructive"
+  ],
+  "canonical_non_implications": "N(NATURAL_PROOFS, RR_constructive_large_against_PRF_class, [SUBEXP_secure_PRFs_exist_in(P/poly)])",
+  "evidence_pointers": [
+    "Razborov-Rudich 1997"
+  ],
+  "auxiliary_descriptors": {
+    "defect": "claims RR applicability with only one predicate; RR is the three-way conjunction (constructive + large + useful_against(C)), not any proper subset"
+  }
+}

--- a/docs/examples/barrier_annotations/invalid.unsupported_triple.v0.1.json
+++ b/docs/examples/barrier_annotations/invalid.unsupported_triple.v0.1.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "0.1.0",
+  "artifact_type": "barrier_annotation",
+  "version": "v0.1",
+  "attempt_ref": "schematic:invalid-annotation-using-post-v0.1-obstruction-kind",
+  "target": "some separation blocked by a post-2008 algebrization refinement",
+  "implicated_barrier": "ALGEBRIZATION",
+  "obstruction_kind": "IKK_affine_relativization_refinement",
+  "assumptions": [],
+  "barrier_predicates": [
+    "algebrizing"
+  ],
+  "canonical_non_implications": "N(ALGEBRIZATION, IKK_affine_relativization_refinement, [])",
+  "evidence_pointers": [
+    "Impagliazzo-Kabanets-Kolokolova 2009; Aydınlıoğlu-Bach 2018"
+  ],
+  "auxiliary_descriptors": {
+    "defect": "obstruction_kind is not in dom(N) at version v0.1; this is a vocabulary-extension request, not a valid annotation. Requires a version bump to a later vocabulary."
+  }
+}

--- a/docs/examples/barrier_annotations/invalid.wrong_branch_closure.v0.1.json
+++ b/docs/examples/barrier_annotations/invalid.wrong_branch_closure.v0.1.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "0.1.0",
+  "artifact_type": "barrier_annotation",
+  "version": "v0.1",
+  "attempt_ref": "schematic:invalid-bgs-annotation-pointing-at-rr-closure",
+  "target": "P != NP",
+  "implicated_barrier": "RELATIVIZATION",
+  "obstruction_kind": "BGS_contradictory_oracle_worlds",
+  "assumptions": [],
+  "barrier_predicates": [
+    "oracle_invariant"
+  ],
+  "canonical_non_implications": "N(NATURAL_PROOFS, RR_constructive_large_against_PRF_class, [SUBEXP_secure_PRFs_exist_in(P/poly)])",
+  "evidence_pointers": [
+    "Baker-Gill-Solovay 1975"
+  ],
+  "auxiliary_descriptors": {
+    "defect": "closure pointer references the RR closure, but the annotation is a BGS annotation; branch-specific closure pointer must match the implicated barrier's canonical non-implication set"
+  }
+}

--- a/docs/examples/barrier_annotations/valid.aw.v0.1.json
+++ b/docs/examples/barrier_annotations/valid.aw.v0.1.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "0.1.0",
+  "artifact_type": "barrier_annotation",
+  "version": "v0.1",
+  "attempt_ref": "schematic:nexp-not-in-p-poly-via-algebrizing-argument",
+  "target": "NEXP not-subset-of P/poly",
+  "implicated_barrier": "ALGEBRIZATION",
+  "obstruction_kind": "AW_algebraic_oracle_contradictory_worlds",
+  "assumptions": [],
+  "barrier_predicates": [
+    "algebrizing"
+  ],
+  "canonical_non_implications": "N(ALGEBRIZATION, AW_algebraic_oracle_contradictory_worlds, [])",
+  "evidence_pointers": [
+    "Aaronson-Wigderson 2008, STOC '08 / ACM TOCT 2009, Definition 2.3 and Section 5"
+  ],
+  "auxiliary_descriptors": {
+    "technique_family": "arithmetization",
+    "algebrizing_direction": "separation (left-hand class receives Ã)",
+    "composition_note": "local annotation; not composed under modus ponens"
+  }
+}

--- a/docs/examples/barrier_annotations/valid.bgs.v0.1.json
+++ b/docs/examples/barrier_annotations/valid.bgs.v0.1.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "0.1.0",
+  "artifact_type": "barrier_annotation",
+  "version": "v0.1",
+  "attempt_ref": "schematic:p-neq-np-via-oracle-invariant-simulation-diagonalization",
+  "target": "P != NP",
+  "implicated_barrier": "RELATIVIZATION",
+  "obstruction_kind": "BGS_contradictory_oracle_worlds",
+  "assumptions": [],
+  "barrier_predicates": [
+    "oracle_invariant"
+  ],
+  "canonical_non_implications": "N(RELATIVIZATION, BGS_contradictory_oracle_worlds, [])",
+  "evidence_pointers": [
+    "Baker-Gill-Solovay 1975, SIAM J. Comput. 4(4):431-442, Theorems 1 and 2"
+  ],
+  "auxiliary_descriptors": {
+    "technique_family": "diagonalization+simulation"
+  }
+}

--- a/docs/examples/barrier_annotations/valid.rr.v0.1.json
+++ b/docs/examples/barrier_annotations/valid.rr.v0.1.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "0.1.0",
+  "artifact_type": "barrier_annotation",
+  "version": "v0.1",
+  "attempt_ref": "schematic:natural-proof-lower-bound-against-P/poly",
+  "target": "an explicit family {f_n} lies outside P/poly",
+  "implicated_barrier": "NATURAL_PROOFS",
+  "obstruction_kind": "RR_constructive_large_against_PRF_class",
+  "assumptions": [
+    "SUBEXP_secure_PRFs_exist_in(P/poly)"
+  ],
+  "barrier_predicates": [
+    "constructive",
+    "large",
+    "useful_against(P/poly)"
+  ],
+  "canonical_non_implications": "N(NATURAL_PROOFS, RR_constructive_large_against_PRF_class, [SUBEXP_secure_PRFs_exist_in(P/poly)])",
+  "evidence_pointers": [
+    "Razborov-Rudich 1997, JCSS 55(1):24-35, Theorems 4.1 and 4.4"
+  ],
+  "auxiliary_descriptors": {
+    "technique_family": "combinatorial-property-of-truth-tables"
+  }
+}

--- a/src/assay/schemas/barrier_annotation.v0.1.schema.json
+++ b/src/assay/schemas/barrier_annotation.v0.1.schema.json
@@ -92,7 +92,7 @@
   },
   "allOf": [
     {
-      "$comment": "Relativization branch: BGS obstruction, no assumptions, oracle_invariant is the sole load-bearing predicate.",
+      "$comment": "Relativization branch: BGS obstruction, no assumptions, exactly one predicate = oracle_invariant, exact BGS closure pointer.",
       "if": {
         "properties": {
           "implicated_barrier": {
@@ -110,15 +110,20 @@
             "maxItems": 0
           },
           "barrier_predicates": {
+            "minItems": 1,
+            "maxItems": 1,
             "items": {
               "const": "oracle_invariant"
             }
+          },
+          "canonical_non_implications": {
+            "const": "N(RELATIVIZATION, BGS_contradictory_oracle_worlds, [])"
           }
         }
       }
     },
     {
-      "$comment": "Natural-proofs branch: RR obstruction, requires SUBEXP_secure_PRFs_exist_in(...) assumption; predicates restricted to {constructive, large, useful_against(...)}.",
+      "$comment": "Natural-proofs branch: RR obstruction, exactly one PRF assumption, exactly three predicates covering all three RR roles (constructive, large, useful_against(...)), RR closure pointer pattern.",
       "if": {
         "properties": {
           "implicated_barrier": {
@@ -134,25 +139,37 @@
           },
           "assumptions": {
             "minItems": 1,
+            "maxItems": 1,
             "contains": {
               "type": "string",
               "pattern": "^SUBEXP_secure_PRFs_exist_in\\(.+\\)$"
             }
           },
           "barrier_predicates": {
+            "minItems": 3,
+            "maxItems": 3,
             "items": {
               "anyOf": [
                 { "const": "constructive" },
                 { "const": "large" },
                 { "type": "string", "pattern": "^useful_against\\(.+\\)$" }
               ]
-            }
+            },
+            "allOf": [
+              { "contains": { "const": "constructive" } },
+              { "contains": { "const": "large" } },
+              { "contains": { "type": "string", "pattern": "^useful_against\\(.+\\)$" } }
+            ]
+          },
+          "canonical_non_implications": {
+            "type": "string",
+            "pattern": "^N\\(NATURAL_PROOFS, RR_constructive_large_against_PRF_class, \\[SUBEXP_secure_PRFs_exist_in\\(.+\\)\\]\\)$"
           }
         }
       }
     },
     {
-      "$comment": "Algebrization branch: AW obstruction, no assumptions, algebrizing is the sole load-bearing predicate (NOT arithmetizing; that is auxiliary).",
+      "$comment": "Algebrization branch: AW obstruction, no assumptions, exactly one predicate = algebrizing (NOT arithmetizing; that is auxiliary), exact AW closure pointer.",
       "if": {
         "properties": {
           "implicated_barrier": {
@@ -170,9 +187,14 @@
             "maxItems": 0
           },
           "barrier_predicates": {
+            "minItems": 1,
+            "maxItems": 1,
             "items": {
               "const": "algebrizing"
             }
+          },
+          "canonical_non_implications": {
+            "const": "N(ALGEBRIZATION, AW_algebraic_oracle_contradictory_worlds, [])"
           }
         }
       }

--- a/src/assay/schemas/barrier_annotation.v0.1.schema.json
+++ b/src/assay/schemas/barrier_annotation.v0.1.schema.json
@@ -1,0 +1,201 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "barrier_annotation v0.1",
+  "description": "Local citation-scoped annotation for barrier-sensitive implications in complexity theory. Citation instrument, not a theorem or closure theory. See notes/barrier-annotation-integration-spec.md in the barrier-implications-note repo for the full integration spec.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_type",
+    "version",
+    "attempt_ref",
+    "target",
+    "implicated_barrier",
+    "obstruction_kind",
+    "assumptions",
+    "barrier_predicates",
+    "canonical_non_implications",
+    "evidence_pointers",
+    "auxiliary_descriptors"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "artifact_type": {
+      "const": "barrier_annotation"
+    },
+    "version": {
+      "description": "Vocabulary version; pins (predicates, obstruction_kinds, assumptions, closure function N).",
+      "const": "v0.1"
+    },
+    "attempt_ref": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable identifier for the proof attempt being annotated (DOI, arXiv id, ECCC id, commit hash, or schematic descriptor)."
+    },
+    "target": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Separation or inclusion statement being claimed."
+    },
+    "implicated_barrier": {
+      "type": "string",
+      "enum": [
+        "RELATIVIZATION",
+        "NATURAL_PROOFS",
+        "ALGEBRIZATION"
+      ]
+    },
+    "obstruction_kind": {
+      "type": "string",
+      "enum": [
+        "BGS_contradictory_oracle_worlds",
+        "RR_constructive_large_against_PRF_class",
+        "AW_algebraic_oracle_contradictory_worlds"
+      ]
+    },
+    "assumptions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/assumption"
+      },
+      "uniqueItems": true
+    },
+    "barrier_predicates": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/predicate"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "canonical_non_implications": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Reference into the closure function N at `version`. Stored as a string pointer, e.g. 'N(RELATIVIZATION, BGS_contradictory_oracle_worlds, [])'."
+    },
+    "evidence_pointers": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "auxiliary_descriptors": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Non-load-bearing technique-family metadata. Not consulted by the closure function."
+    }
+  },
+  "allOf": [
+    {
+      "$comment": "Relativization branch: BGS obstruction, no assumptions, oracle_invariant is the sole load-bearing predicate.",
+      "if": {
+        "properties": {
+          "implicated_barrier": {
+            "const": "RELATIVIZATION"
+          }
+        },
+        "required": ["implicated_barrier"]
+      },
+      "then": {
+        "properties": {
+          "obstruction_kind": {
+            "const": "BGS_contradictory_oracle_worlds"
+          },
+          "assumptions": {
+            "maxItems": 0
+          },
+          "barrier_predicates": {
+            "items": {
+              "const": "oracle_invariant"
+            }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "Natural-proofs branch: RR obstruction, requires SUBEXP_secure_PRFs_exist_in(...) assumption; predicates restricted to {constructive, large, useful_against(...)}.",
+      "if": {
+        "properties": {
+          "implicated_barrier": {
+            "const": "NATURAL_PROOFS"
+          }
+        },
+        "required": ["implicated_barrier"]
+      },
+      "then": {
+        "properties": {
+          "obstruction_kind": {
+            "const": "RR_constructive_large_against_PRF_class"
+          },
+          "assumptions": {
+            "minItems": 1,
+            "contains": {
+              "type": "string",
+              "pattern": "^SUBEXP_secure_PRFs_exist_in\\(.+\\)$"
+            }
+          },
+          "barrier_predicates": {
+            "items": {
+              "anyOf": [
+                { "const": "constructive" },
+                { "const": "large" },
+                { "type": "string", "pattern": "^useful_against\\(.+\\)$" }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "Algebrization branch: AW obstruction, no assumptions, algebrizing is the sole load-bearing predicate (NOT arithmetizing; that is auxiliary).",
+      "if": {
+        "properties": {
+          "implicated_barrier": {
+            "const": "ALGEBRIZATION"
+          }
+        },
+        "required": ["implicated_barrier"]
+      },
+      "then": {
+        "properties": {
+          "obstruction_kind": {
+            "const": "AW_algebraic_oracle_contradictory_worlds"
+          },
+          "assumptions": {
+            "maxItems": 0
+          },
+          "barrier_predicates": {
+            "items": {
+              "const": "algebrizing"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "predicate": {
+      "type": "string",
+      "anyOf": [
+        { "const": "oracle_invariant" },
+        { "const": "constructive" },
+        { "const": "large" },
+        { "type": "string", "pattern": "^useful_against\\(.+\\)$" },
+        { "const": "algebrizing" }
+      ],
+      "description": "Closed load-bearing predicate vocabulary for v0.1. Auxiliary descriptors (diagonalization_based, simulation_based, arithmetizing, relativizing, circuit_complexity_measure_based) must not appear here; they belong in auxiliary_descriptors."
+    },
+    "assumption": {
+      "type": "string",
+      "anyOf": [
+        { "type": "string", "pattern": "^SUBEXP_secure_PRFs_exist_in\\(.+\\)$" }
+      ],
+      "description": "Closed assumption vocabulary for v0.1. Pattern-matched so target class C can be parameterized. Extend under a vocabulary version bump, not as schema patch."
+    }
+  }
+}

--- a/tests/assay/test_barrier_annotation_schema.py
+++ b/tests/assay/test_barrier_annotation_schema.py
@@ -1,0 +1,110 @@
+"""Structural validation tests for the barrier_annotation v0.1 schema.
+
+Scope: schema-only validation. This test does NOT adjudicate whether a
+proof actually relativizes, is natural, or algebrizes; those judgments
+are external to the primitive. The tests below check that the schema
+itself is well-formed and that the fixture annotations validate (or
+fail to validate) as the v0.1 vocabulary requires.
+
+See notes/barrier-annotation-integration-spec.md in the barrier-
+implications-note repo for the full integration spec.
+"""
+from __future__ import annotations
+
+import json
+from importlib import resources
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+
+ROOT = Path(__file__).resolve().parents[2]
+EXAMPLES_DIR = ROOT / "docs" / "examples" / "barrier_annotations"
+SCHEMA_NAME = "barrier_annotation.v0.1.schema.json"
+
+
+def _load_schema() -> dict:
+    schema_path = resources.files("assay").joinpath(f"schemas/{SCHEMA_NAME}")
+    return json.loads(schema_path.read_text())
+
+
+def _load_example(name: str) -> dict:
+    return json.loads((EXAMPLES_DIR / name).read_text())
+
+
+class TestBarrierAnnotationSchemaWellFormed:
+    def test_schema_is_valid_draft_2020_12(self) -> None:
+        Draft202012Validator.check_schema(_load_schema())
+
+
+@pytest.mark.parametrize(
+    "fixture_name, expected_barrier, expected_obstruction",
+    [
+        (
+            "valid.bgs.v0.1.json",
+            "RELATIVIZATION",
+            "BGS_contradictory_oracle_worlds",
+        ),
+        (
+            "valid.rr.v0.1.json",
+            "NATURAL_PROOFS",
+            "RR_constructive_large_against_PRF_class",
+        ),
+        (
+            "valid.aw.v0.1.json",
+            "ALGEBRIZATION",
+            "AW_algebraic_oracle_contradictory_worlds",
+        ),
+    ],
+)
+class TestValidFixtures:
+    def test_fixture_validates(
+        self,
+        fixture_name: str,
+        expected_barrier: str,
+        expected_obstruction: str,
+    ) -> None:
+        validator = Draft202012Validator(_load_schema())
+        instance = _load_example(fixture_name)
+        validator.validate(instance)
+        assert instance["implicated_barrier"] == expected_barrier
+        assert instance["obstruction_kind"] == expected_obstruction
+        assert instance["artifact_type"] == "barrier_annotation"
+        assert instance["version"] == "v0.1"
+
+
+@pytest.mark.parametrize(
+    "fixture_name, defect_kind",
+    [
+        (
+            "invalid.missing_rr_prf_assumption.v0.1.json",
+            "NATURAL_PROOFS branch requires SUBEXP_secure_PRFs_exist_in(...) in assumptions",
+        ),
+        (
+            "invalid.arithmetizing_as_load_bearing.v0.1.json",
+            "ALGEBRIZATION branch restricts barrier_predicates to {algebrizing}; arithmetizing belongs in auxiliary_descriptors",
+        ),
+        (
+            "invalid.aw_composition_attempt.v0.1.json",
+            "additionalProperties: false; composes_with is not a valid top-level field",
+        ),
+        (
+            "invalid.unsupported_triple.v0.1.json",
+            "obstruction_kind enum at v0.1 does not include post-2008 refinements",
+        ),
+    ],
+)
+class TestInvalidFixtures:
+    def test_fixture_fails_schema_validation(
+        self,
+        fixture_name: str,
+        defect_kind: str,
+    ) -> None:
+        validator = Draft202012Validator(_load_schema())
+        instance = _load_example(fixture_name)
+        errors = list(validator.iter_errors(instance))
+        assert errors, (
+            f"expected fixture {fixture_name} to fail schema validation "
+            f"because {defect_kind}, but it validated cleanly"
+        )

--- a/tests/assay/test_barrier_annotation_schema.py
+++ b/tests/assay/test_barrier_annotation_schema.py
@@ -74,24 +74,69 @@ class TestValidFixtures:
         assert instance["version"] == "v0.1"
 
 
+def _error_matches_marker(err, marker: str) -> bool:
+    """Return True if a jsonschema ValidationError references `marker` in its
+    absolute instance path, its absolute schema path, or its message.
+
+    We inspect three distinct surfaces so a test can pin the failure to the
+    field it was designed to catch, rather than merely that any error occurred.
+    """
+    if marker in [str(p) for p in err.absolute_path]:
+        return True
+    if marker in [str(p) for p in err.absolute_schema_path]:
+        return True
+    if marker in err.message:
+        return True
+    return False
+
+
 @pytest.mark.parametrize(
-    "fixture_name, defect_kind",
+    "fixture_name, expected_marker, defect_kind",
     [
         (
             "invalid.missing_rr_prf_assumption.v0.1.json",
-            "NATURAL_PROOFS branch requires SUBEXP_secure_PRFs_exist_in(...) in assumptions",
+            "assumptions",
+            "NATURAL_PROOFS branch requires exactly one SUBEXP_secure_PRFs_exist_in(...) in assumptions",
         ),
         (
             "invalid.arithmetizing_as_load_bearing.v0.1.json",
+            "barrier_predicates",
             "ALGEBRIZATION branch restricts barrier_predicates to {algebrizing}; arithmetizing belongs in auxiliary_descriptors",
         ),
         (
             "invalid.aw_composition_attempt.v0.1.json",
+            "composes_with",
             "additionalProperties: false; composes_with is not a valid top-level field",
         ),
         (
             "invalid.unsupported_triple.v0.1.json",
+            "obstruction_kind",
             "obstruction_kind enum at v0.1 does not include post-2008 refinements",
+        ),
+        (
+            "invalid.rr_missing_large.v0.1.json",
+            "barrier_predicates",
+            "NATURAL_PROOFS requires all three predicates; this fixture omits `large`",
+        ),
+        (
+            "invalid.rr_missing_useful_against.v0.1.json",
+            "barrier_predicates",
+            "NATURAL_PROOFS requires all three predicates; this fixture omits useful_against(...)",
+        ),
+        (
+            "invalid.rr_only_constructive.v0.1.json",
+            "barrier_predicates",
+            "NATURAL_PROOFS requires exactly three predicates; this fixture has only one",
+        ),
+        (
+            "invalid.wrong_branch_closure.v0.1.json",
+            "canonical_non_implications",
+            "RELATIVIZATION branch requires the BGS closure pointer; this fixture points to the RR closure",
+        ),
+        (
+            "invalid.arbitrary_closure_ref.v0.1.json",
+            "canonical_non_implications",
+            "ALGEBRIZATION branch requires the exact AW closure pointer; this fixture carries an arbitrary string",
         ),
     ],
 )
@@ -99,6 +144,7 @@ class TestInvalidFixtures:
     def test_fixture_fails_schema_validation(
         self,
         fixture_name: str,
+        expected_marker: str,
         defect_kind: str,
     ) -> None:
         validator = Draft202012Validator(_load_schema())
@@ -107,4 +153,33 @@ class TestInvalidFixtures:
         assert errors, (
             f"expected fixture {fixture_name} to fail schema validation "
             f"because {defect_kind}, but it validated cleanly"
+        )
+
+    def test_fixture_fails_for_intended_reason(
+        self,
+        fixture_name: str,
+        expected_marker: str,
+        defect_kind: str,
+    ) -> None:
+        """Failure must be traceable to the field the fixture was designed to probe.
+
+        A loose `errors != []` assertion can pass for accidental reasons and
+        does not actually protect the v0.1 contract. This check inspects
+        ValidationError.absolute_path, ValidationError.absolute_schema_path,
+        and ValidationError.message for a stable marker that identifies the
+        intended defect.
+        """
+        validator = Draft202012Validator(_load_schema())
+        instance = _load_example(fixture_name)
+        errors = list(validator.iter_errors(instance))
+        matching = [e for e in errors if _error_matches_marker(e, expected_marker)]
+        assert matching, (
+            f"fixture {fixture_name} failed validation, but no error referenced "
+            f"`{expected_marker}` (the intended defect marker for: {defect_kind}). "
+            f"Errors observed: "
+            + "; ".join(
+                f"path={list(e.absolute_path)} schema_path={list(e.absolute_schema_path)} "
+                f"validator={e.validator} message={e.message[:80]}"
+                for e in errors
+            )
         )


### PR DESCRIPTION
## Scope

Registers a new proof-hygiene primitive: `BarrierAnnotation v0.1`, a typed local citation instrument for barrier-sensitive implications in complexity theory (BGS / RR / AW).

**Citation instrument only.** Not a theorem. Not a new barrier. Not a closure repair. Not integrated into any live claim-flow yet.

## Note on history

Supersedes #95, which was inadvertently based on a stale local `main` and carried unrelated preserved commits. This branch is cherry-picked onto current `origin/main` via a clean worktree; only one commit in the PR.

## What's added

- `src/assay/schemas/barrier_annotation.v0.1.schema.json` — JSON Schema Draft 2020-12 with per-barrier `if/then` conditionals and `additionalProperties: false`.
- `docs/examples/barrier_annotations/` — three valid fixtures (BGS, RR, AW) and four invalid fixtures.
- `tests/assay/test_barrier_annotation_schema.py` — 8 parametrized tests; all pass locally.

Nine new files, 464 lines added. No existing schemas, examples, or tests modified.

## Review focus

- **Schema is structural only.** Does not adjudicate whether a proof actually relativizes, is natural, or algebrizes. JSON Schema's job here is instance validation against the v0.1 vocabulary, not mathematical truth.
- **Valid BGS/RR/AW examples are conservative** and match the primary sources (RR 1997 §2.1/§2.2; AW 2008 Definition 2.3; BGS 1975 Theorems 1 and 2).
- **Invalid examples fail for intended structural reasons:**
  - `missing_rr_prf_assumption`: NATURAL_PROOFS branch requires an assumption matching `^SUBEXP_secure_PRFs_exist_in\(.+\)$`.
  - `arithmetizing_as_load_bearing`: ALGEBRIZATION branch restricts `barrier_predicates` to `{algebrizing}`; arithmetizing is auxiliary only.
  - `aw_composition_attempt`: top-level `composes_with` violates `additionalProperties: false`.
  - `unsupported_triple`: `obstruction_kind` enum at v0.1 does not contain post-2008 refinements (IKK / Aydınlıoğlu–Bach).
- **Frozen barrier note untouched.** The originating note lives in `Haserjian/barrier-implications-note@8cf67c3` (separate repo); this PR is integration into the Assay primitive registry, not modification of the note.

## What this PR is not

- Not a semantic validator. Predicate adjudication on a specific proof is judgment-laden and explicitly external.
- Not an integration into any live claim-flow code path.
- Not a publication-pattern change.

## Integration spec (for reference)

`~/barrier-implications-note/notes/barrier-annotation-integration-spec.md` at commit `eca5c19` (local; not yet published).

## Test run

```
$ pytest tests/assay/test_barrier_annotation_schema.py -v
8 passed in 0.22s
```

All three valid fixtures validate; all four invalid fixtures produce ≥ 1 schema error for their intended reason. Full schema passes `Draft202012Validator.check_schema`.