### PR TITLE
test(proof_pack): lock AgentMesh namespaced receipt conformance

### DIFF
--- a/tests/assay/test_proof_pack.py
+++ b/tests/assay/test_proof_pack.py
@@ -680,6 +680,38 @@ class TestProofPackBuilder:
         result = verify_proof_pack(manifest, out, tmp_keys)
         assert result.passed, f"Errors: {[e.to_dict() for e in result.errors]}"
 
+    def test_agentmesh_namespaced_receipt_types_build_and_verify(
+        self, tmp_path, tmp_keys
+    ):
+        # Conformance gate for the AgentMesh alias_bug fix (2026-04-24):
+        # AgentMesh emits agentmesh.weave/v1 and agentmesh.witness/v1; both must
+        # round-trip through build() and verify_proof_pack() without allowlist
+        # expansion, relying only on the existing namespaced-token regex.
+        receipts = [
+            _make_receipt(
+                receipt_id="r_type_001",
+                run_id="agentmesh-namespaced-types",
+                seq=0,
+                type="agentmesh.weave/v1",
+            ),
+            _make_receipt(
+                receipt_id="r_type_002",
+                run_id="agentmesh-namespaced-types",
+                seq=1,
+                type="agentmesh.witness/v1",
+            ),
+        ]
+        pack = ProofPack(
+            run_id="agentmesh-namespaced-types",
+            entries=receipts,
+            signer_id="test-signer",
+        )
+
+        out = pack.build(tmp_path / "pack", keystore=tmp_keys)
+        manifest = json.loads((out / "pack_manifest.json").read_text())
+        result = verify_proof_pack(manifest, out, tmp_keys)
+        assert result.passed, f"Errors: {[e.to_dict() for e in result.errors]}"
+
     def test_verify_prefers_embedded_pubkey_over_wrong_local_key(
         self, tmp_path, tmp_keys, sample_receipts
     ):


### PR DESCRIPTION
## Summary

- Add one conformance test: `TestProofPackBuilder::test_agentmesh_namespaced_receipt_types_build_and_verify`.
- Exercises `ProofPack.build()` + `verify_proof_pack()` round-trip on a pack carrying `agentmesh.weave/v1` and `agentmesh.witness/v1`.
- **Zero production-code change.** No additions to `PROOF_PACK_ALLOWED_RECEIPT_TYPES`, no regex changes. Relies entirely on the existing namespaced-token path.

## Why

Consumer conformance lock for the AgentMesh alias_bug fix in [Haserjian/agentmesh#45](https://github.com/Haserjian/agentmesh/pull/45). Freezes the round-trip so a future Assay allowlist or regex narrowing would trip this test before breaking AgentMesh's emitter.

This is **not** a dependency on an unmerged Assay production change. Nothing in Assay needs to ship for AgentMesh's rename to work — the namespaced regex already accepts both tokens. This PR simply prevents silent regression.

## Scope

Narrow scope against the `alias_bug` reopen trigger recorded in `~/.claude/state/decision.md` (2026-03-25 ruling). This PR does **not** open shared-primitives canonicalization, `organism-schemas` activation, or cross-repo settlement coupling.

## Test plan

- [x] `python -m pytest tests/assay/test_proof_pack.py::TestProofPackBuilder::test_agentmesh_namespaced_receipt_types_build_and_verify -v` — 1 passed
- [x] `python -m pytest tests/assay/test_proof_pack.py::TestProofPackBuilder -q` — 33 passed
- [x] `python -m pytest tests/assay/test_proof_pack.py -q` — 124 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)