### PR TITLE
feat(proof_pack): wire ReceiptV2 as opt-in sidecar (first production caller)

### DIFF
--- a/src/assay/proof_pack.py
+++ b/src/assay/proof_pack.py
@@ -30,6 +30,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from assay._receipts import build_v2_base_receipt, emit_v2_receipt
 from assay._receipts.canonicalize import prepare_receipt_for_hashing
 from assay._receipts.jcs import canonicalize as jcs_canonicalize
 from assay.claim_verifier import ClaimSetResult, ClaimSpec, verify_claims
@@ -475,6 +476,7 @@ class ProofPack:
         emit_adc: bool = False,
         claim_namespace: Optional[str] = None,
         authority_snapshot: Optional[Dict[str, Any]] = None,
+        emit_v2_receipts: bool = False,
     ):
         # run_id is canonical; trace_id accepted as alias for backward compat
         resolved_run_id = run_id or trace_id
@@ -491,6 +493,7 @@ class ProofPack:
         self.emit_adc = emit_adc
         self.claim_namespace = claim_namespace
         self.authority_snapshot = authority_snapshot
+        self.emit_v2_receipts = emit_v2_receipts
 
         # Default hashes for fields not yet wired
         self.policy_hash = policy_hash or _sha256_hex(b"default-policy-v0")
@@ -612,6 +615,17 @@ class ProofPack:
             )
             pack_id = _generate_pack_id(deterministic_seed=seed)
         (staging_dir / "receipt_pack.jsonl").write_bytes(receipt_pack_bytes)
+
+        # 1b. (optional) Mint ReceiptV2 envelopes alongside the v1 pack.
+        # First production caller of emit_v2_receipt(). Sidecar artifact only:
+        # written to unsigned/receipt_pack_v2.jsonl, NOT included in
+        # pack_root_sha256, NOT in the 5-file v1 verification kernel.
+        # Each envelope is individually Ed25519-signed using the same signer
+        # as the pack-level signature.
+        if self.emit_v2_receipts:
+            self._write_receipt_pack_v2(
+                staging_dir, sorted_entries, ks, deterministic_ts=deterministic_ts
+            )
 
         # 2. Verify receipts (structural integrity)
         verify_result = verify_receipt_pack(sorted_entries)
@@ -870,6 +884,57 @@ class ProofPack:
         os.rename(str(staging_dir), str(output_dir))
         return output_dir
 
+    def _write_receipt_pack_v2(
+        self,
+        staging_dir: Path,
+        sorted_entries: List[Dict[str, Any]],
+        ks: AssayKeyStore,
+        *,
+        deterministic_ts: Optional[str] = None,
+    ) -> None:
+        """Mint and write ReceiptV2 envelopes to unsigned/receipt_pack_v2.jsonl.
+
+        First production caller of emit_v2_receipt(). Sidecar artifact only —
+        outside the v1 5-file kernel and outside pack_root_sha256.
+        Each envelope is individually Ed25519-signed using the same signer
+        as the pack-level signature.
+
+        Identity fields (type, receipt_id, timestamp) are lifted from the
+        v1 entry. Pack-internal meta keys (anything else, including
+        underscore-prefixed _trace_id / _stored_at) and v1-specific cruft
+        (schema_version, seq) are demoted into the attested payload, except
+        the cruft fields which are dropped entirely.
+        """
+        ks.ensure_key(self.signer_id)
+        signing_key = ks.get_signing_key(self.signer_id)
+
+        v2_lines: List[str] = []
+        for entry in sorted_entries:
+            payload = {
+                k: v
+                for k, v in entry.items()
+                if k not in {"type", "receipt_id", "timestamp", "schema_version", "seq"}
+            }
+            base = build_v2_base_receipt(
+                receipt_type=entry.get("type") or "assay.legacy_receipt_v1",
+                payload=payload,
+                receipt_id=entry.get("receipt_id"),
+                timestamp=entry.get("timestamp"),
+            )
+            envelope = emit_v2_receipt(
+                base,
+                signing_key=signing_key,
+                signer_id=self.signer_id,
+                add_signed_at=deterministic_ts is None,
+            )
+            v2_lines.append(jcs_canonicalize(envelope).decode("utf-8"))
+
+        content = ("\n".join(v2_lines) + "\n") if v2_lines else ""
+
+        unsigned_dir = get_unsigned_sidecar_dir(staging_dir)
+        unsigned_dir.mkdir(parents=True, exist_ok=True)
+        (unsigned_dir / "receipt_pack_v2.jsonl").write_bytes(content.encode("utf-8"))
+
 
 def build_proof_pack(
     trace_id: str,
@@ -880,6 +945,7 @@ def build_proof_pack(
     claims: Optional[List[ClaimSpec]] = None,
     ci_binding: Optional[Dict[str, Any]] = None,
     authority_snapshot: Optional[Dict[str, Any]] = None,
+    emit_v2_receipts: bool = False,
 ) -> Path:
     """Convenience function: load trace from store and build a Proof Pack.
 
@@ -889,6 +955,11 @@ def build_proof_pack(
         keystore: Optional key store (default: ~/.assay/keys/).
         mode: shadow | enforced | breakglass.
         claims: Optional list of ClaimSpecs for semantic verification.
+        emit_v2_receipts: When True, additionally write a sidecar
+            ``unsigned/receipt_pack_v2.jsonl`` containing one
+            individually Ed25519-signed ReceiptV2 envelope per entry.
+            The v2 file is NOT in the pack manifest and does not affect
+            v1 verification.
 
     Returns:
         Path to the output directory.
@@ -913,6 +984,7 @@ def build_proof_pack(
         claims=claims,
         ci_binding=ci_binding,
         authority_snapshot=authority_snapshot,
+        emit_v2_receipts=emit_v2_receipts,
     )
     return pack.build(output_dir, keystore=keystore)
 

--- a/tests/assay/test_proof_pack_v2_wire.py
+++ b/tests/assay/test_proof_pack_v2_wire.py
@@ -1,0 +1,128 @@
+"""ReceiptV2 production-caller wire test.
+
+Proves the smallest happy-path integration of ReceiptV2 into the canonical
+proof-pack producer (`ProofPack._build_into`):
+
+- ``emit_v2_receipts=True`` writes ``unsigned/receipt_pack_v2.jsonl``
+- Each line is a v2 envelope (``signatures[]`` + ``verification_bundle``)
+- ``digest_valid`` and per-signature ``cryptographically_valid`` both hold
+  via ``verify_v2(envelope, key_resolver=...)``
+- The v1 5-file kernel is unaffected — ``verify_proof_pack`` still passes
+  (v2 sidecar lives outside ``pack_root_sha256``)
+- ``emit_v2_receipts=False`` (default) produces no v2 file
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+import pytest
+
+from assay._receipts import verify_v2
+from assay.keystore import DEFAULT_SIGNER_ID, AssayKeyStore
+from assay.proof_pack import (
+    ProofPack,
+    get_unsigned_sidecar_dir,
+    verify_proof_pack,
+)
+
+
+@pytest.fixture
+def tmp_keys(tmp_path):
+    return AssayKeyStore(keys_dir=tmp_path / "keys")
+
+
+def _make_receipt(seq: int) -> dict:
+    return {
+        "receipt_id": f"r_{uuid.uuid4().hex[:8]}",
+        "type": "model_call",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "schema_version": "3.0",
+        "seq": seq,
+        "task": "loan_application_analysis",
+        "model_id": "claude-sonnet-4-20250514",
+        "input_tokens": 100 + seq,
+        "output_tokens": 50 + seq,
+    }
+
+
+def _make_resolver(
+    ks: AssayKeyStore, signer_id: str = DEFAULT_SIGNER_ID
+) -> Callable[[str, Optional[str]], Optional[bytes]]:
+    """Build a key_resolver that returns the matching pubkey bytes."""
+    ks.ensure_key(signer_id)
+    pubkey_bytes = ks.get_verify_key(signer_id).encode()  # 32-byte raw
+
+    def resolver(sid, _pubkey_sha256=None):
+        return pubkey_bytes if sid == signer_id else None
+
+    return resolver
+
+
+def test_emit_v2_off_by_default_produces_no_sidecar(tmp_path, tmp_keys):
+    entries = [_make_receipt(i) for i in range(2)]
+    pack = ProofPack(run_id=f"trace_{uuid.uuid4().hex[:8]}", entries=entries)
+    out = pack.build(tmp_path / "pack_default", keystore=tmp_keys)
+
+    sidecar = get_unsigned_sidecar_dir(out) / "receipt_pack_v2.jsonl"
+    assert not sidecar.exists(), (
+        "v2 sidecar must NOT be produced when emit_v2_receipts=False (default)"
+    )
+
+
+def test_emit_v2_writes_signed_envelopes_and_v1_still_verifies(
+    tmp_path, tmp_keys
+):
+    entries = [_make_receipt(i) for i in range(3)]
+    pack = ProofPack(
+        run_id=f"trace_{uuid.uuid4().hex[:8]}",
+        entries=entries,
+        emit_v2_receipts=True,
+    )
+    out = pack.build(tmp_path / "pack_v2", keystore=tmp_keys)
+
+    sidecar = get_unsigned_sidecar_dir(out) / "receipt_pack_v2.jsonl"
+    assert sidecar.exists(), (
+        "v2 sidecar must be produced when emit_v2_receipts=True"
+    )
+
+    lines = [line for line in sidecar.read_text().splitlines() if line.strip()]
+    assert len(lines) == len(entries), (
+        f"expected {len(entries)} v2 envelopes, got {len(lines)}"
+    )
+
+    resolver = _make_resolver(tmp_keys)
+
+    for line in lines:
+        env = json.loads(line)
+        assert env.get("signatures"), "v2 envelope missing signatures[]"
+        assert env.get("verification_bundle"), (
+            "v2 envelope missing verification_bundle"
+        )
+        # Identity preserved from the source v1 entry
+        assert env.get("type") == "model_call"
+        assert env.get("receipt_id", "").startswith("r_")
+
+        # End-to-end v2 verification
+        result = verify_v2(env, key_resolver=resolver)
+        assert result.digest_valid, (
+            f"digest_valid=False, status={result.digest_status}"
+        )
+        assert result.signature_results, "no signature_results returned"
+        sig = result.signature_results[0]
+        assert sig.cryptographically_valid, (
+            f"cryptographic verification failed: {sig.error}"
+        )
+        assert sig.algorithm_acceptable, (
+            f"algorithm not acceptable: {sig.algorithm}"
+        )
+
+    # v1 5-file kernel still verifies — sidecar lives outside pack_root_sha256
+    manifest = json.loads((out / "pack_manifest.json").read_text())
+    v1_result = verify_proof_pack(manifest, out, keystore=tmp_keys)
+    assert v1_result.passed, (
+        f"v1 verification failed after v2 emission: {v1_result.errors}"
+    )


### PR DESCRIPTION
## Summary
First production caller of \`emit_v2_receipt()\`. Closes the long-standing decorative-contract gap on ReceiptV2.

- Adds \`emit_v2_receipts=False\` param to \`ProofPack\` and \`build_proof_pack()\`
- When True, mints one Ed25519-signed v2 envelope per entry and writes them to \`unsigned/receipt_pack_v2.jsonl\`
- Default behavior unchanged; v1 5-file kernel untouched

## Why this shape
- **Sidecar, not in-manifest:** v2 lives in \`unsigned/\`, outside \`pack_root_sha256\`. v1 verification cannot break from v2 emission.
- **One tap point:** single new method \`_write_receipt_pack_v2\` invoked from \`_build_into\` after \`receipt_pack.jsonl\` is written. No refactor of v1 paths.
- **Identity preserved:** type / receipt_id / timestamp lifted from v1 entries; \`schema_version\` and \`seq\` dropped (v1-specific cruft).

## Test plan
- [x] New test \`tests/assay/test_proof_pack_v2_wire.py\` (2 cases): default-off produces no sidecar; opt-in produces signed envelopes that pass \`verify_v2\` AND \`verify_proof_pack\` still passes the v1 kernel.
- [x] Existing \`tests/assay/test_proof_pack.py\` — 124/124 passing (no regression).
- [x] \`tests/assay/test_v2_{sign,verify,canonicalize}.py\` — 147/148 passing. The 1 failure (\`test_unicode_in_custom_field_key\`) is **pre-existing on origin/main**; verified by checking out main and reproducing.

## Known risks (accepted for first wire)
- v2 sidecar is not referenced by the v1 manifest. Future slice could optionally attest it (e.g., \`v2_sidecar_sha256\` field).
- v2 envelopes share the pack-level signer (\`DEFAULT_SIGNER_ID\`). Future slice could allow distinct v2 signer policy.

## Doctrine note
This satisfies the operating invariant from MEMORY: *no new contract without a consuming path*. The consumer here is the production caller; the test is the verifier consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)