### PR TITLE
test(proof_pack): preserve counter-doctrine tripwire as strict xfail

### DIFF
--- a/tests/assay/test_proof_pack.py
+++ b/tests/assay/test_proof_pack.py
@@ -538,6 +538,27 @@ class TestProofPackBuilder:
         )
         assert any("experimental_verdict" in e.message for e in result.errors)
 
+    @pytest.mark.xfail(strict=True, reason="Counter-doctrine tripwire: generic non-loom namespaced receipt types are proof-pack-admissible by regex; only loom.* types are registry-gated by LOOM_RECEIPT_MAPPING_REGISTRY_V1")
+    def test_verify_proof_pack_rejects_unknown_main_chain_namespaced_type(
+        self, tmp_path, tmp_keys
+    ):
+        """Unknown receipt_pack.jsonl receipt types must not verify as PASS."""
+        out, manifest = _make_external_pack_with_unknown_type(
+            tmp_path,
+            tmp_keys,
+            unknown_type="partner.audit/v1",
+        )
+
+        result = verify_proof_pack(manifest, out, tmp_keys)
+
+        assert not result.passed
+        assert any(
+            e.code == E_SCHEMA_UNKNOWN
+            and e.field == "type"
+            and "partner.audit/v1" in e.message
+            for e in result.errors
+        )
+
     @pytest.mark.parametrize("receipt_type", ["loom.unknown/v1", "loom.dip/v1"])
     def test_verify_proof_pack_rejects_non_current_loom_receipt_type(
         self, tmp_path, tmp_keys, receipt_type

--- a/tests/assay/test_proof_pack.py
+++ b/tests/assay/test_proof_pack.py
@@ -539,25 +539,38 @@ class TestProofPackBuilder:
         assert any("experimental_verdict" in e.message for e in result.errors)
 
     @pytest.mark.xfail(strict=True, reason="Counter-doctrine tripwire: generic non-loom namespaced receipt types are proof-pack-admissible by regex; only loom.* types are registry-gated by LOOM_RECEIPT_MAPPING_REGISTRY_V1")
-    def test_verify_proof_pack_rejects_unknown_main_chain_namespaced_type(
+    def test_drift_tripwire_non_loom_namespaced_now_rejected(
         self, tmp_path, tmp_keys
     ):
-        """Unknown receipt_pack.jsonl receipt types must not verify as PASS."""
+        """Counterfactual / expected failure.
+
+        Asserts the OPPOSITE of doctrine: that a non-loom namespaced receipt
+        (partner.audit/v1) is rejected. Per LOOM_RECEIPT_MAPPING_REGISTRY_V1,
+        rejection MUST NOT happen for generic non-loom namespaced types —
+        admission is by regex, distinct from trust certification. Strict
+        xfail means: if this test ever unexpectedly passes (rejection of any
+        shape begins happening), CI breaks and forces conscious doctrine
+        review.
+
+        Behavioral invariant only — does not assert specific error code,
+        field, or message. Any rejection signal — `passed=False` OR a raised
+        exception during verify — counts as drift detection.
+        """
         out, manifest = _make_external_pack_with_unknown_type(
             tmp_path,
             tmp_keys,
             unknown_type="partner.audit/v1",
         )
 
-        result = verify_proof_pack(manifest, out, tmp_keys)
+        try:
+            result = verify_proof_pack(manifest, out, tmp_keys)
+        except Exception:
+            # Drift: rejection via exception. Test exits without assertion
+            # failure, so strict-xfail records an unexpected pass and breaks
+            # the suite — exactly the drift-detection signal we want.
+            return
 
         assert not result.passed
-        assert any(
-            e.code == E_SCHEMA_UNKNOWN
-            and e.field == "type"
-            and "partner.audit/v1" in e.message
-            for e in result.errors
-        )
 
     @pytest.mark.parametrize("receipt_type", ["loom.unknown/v1", "loom.dip/v1"])
     def test_verify_proof_pack_rejects_non_current_loom_receipt_type(


### PR DESCRIPTION
## Summary

Adds a single strict `@pytest.mark.xfail` test as a counter-doctrine tripwire. No verifier change; no behavior change.

The added test asserts the OPPOSITE of doctrine — that `verify_proof_pack` rejects a pack containing a non-Loom namespaced receipt type (`partner.audit/v1`). Per `docs/specs/LOOM_RECEIPT_MAPPING_REGISTRY_V1.md`, generic non-Loom namespaced tokens are intentionally **proof-pack-admissible by regex** — admission is not trust certification, and only `loom.*` types are registry-gated.

`strict=True` makes the suite break if this test **unexpectedly passes** in the future — i.e., if implementation drift begins rejecting non-loom namespaced receipts in any form. That converts silent doctrine drift into a visible suite break.

## Tightening (after review)

The first commit entangled two invariants: behavioral (pass vs fail) and error-shape (`E_SCHEMA_UNKNOWN` + specific message). The second commit narrowed the test to the behavioral invariant only and added an exception-as-drift catch, so any rejection signal — `passed=False` OR a raised exception during verify — now trips the wire. Renamed to `test_drift_tripwire_non_loom_namespaced_now_rejected` to align vocabulary with the adjacent positive test and signal counterfactual semantics; docstring rewritten to mark the test explicitly as counterfactual / expected failure.

## Why

The existing `test_non_loom_namespaced_receipt_type_remains_allowed` (line 682) positively encodes current behavior. This xfail preserves the **opposite** assertion as a tripwire without contradicting the existing test (xfail = expected failure). Verifier code at `proof_pack.py:294-304` is consistent with the registry doctrine — this is **not** an implementation bug fix.

## Test plan

- [x] `python -m pytest tests/assay/test_proof_pack.py -v` for the affected tests:
  - `test_drift_tripwire_non_loom_namespaced_now_rejected` → **XFAIL**
  - `test_non_loom_namespaced_receipt_type_remains_allowed` → PASSED
  - `test_verify_proof_pack_rejects_non_current_loom_receipt_type[loom.unknown/v1]` → PASSED
  - `test_verify_proof_pack_rejects_non_current_loom_receipt_type[loom.dip/v1]` → PASSED
  - `test_generic_verify_pack_manifest_still_accepts_unknown_type` → PASSED
- Result: **4 passed, 1 xfailed in 0.53s**

## Doctrine source

`docs/specs/LOOM_RECEIPT_MAPPING_REGISTRY_V1.md` (DRAFT, 2026-04-08):

> Proof-pack admission policy currently accepts only:
> (1) a fixed flat allowlist of legacy Assay receipt types
> (2) lowercase namespaced dotted tokens matching the proof-pack regex

> `assay verify-pack` proves the proof-pack contract and the bytes admitted into the pack. It does not become a blanket verifier for the full Loom ontology.

> Non-Goal: namespaced admission [does not imply] deep semantic verification.

## Evidence chain

This patch is the resolution step of a 5-receipt dispatcher chain that adjudicated the doctrine question without changing implementation:

1. Inspector — mapped verification path (`tsk-2026-04-29-e401f9d3`)
2. Executor — wrote the proposed regression test (`tsk-2026-04-29-97410b3a`)
3. Reviewer — falsified the executor's claim, found contradiction with line-682 test (`tsk-2026-04-29-1c7c64a1`)
4. Baseline — captured executable doctrine state, 1 failed/4 passed (`tsk-2026-04-29-e4310a2c`)
5. Resolution — strict xfail applied, 4 passed/1 xfailed (`tsk-2026-04-29-600e1b4c`)

## Files

`tests/assay/test_proof_pack.py`: net +13 lines (one new test method with strict xfail decorator + tightened assertion shape)