### PR TITLE
docs: inoculate README hero against crypto/blockchain misread

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ One byte changed. Verification fails. No server call. Just math.
 
 Receipts are forwardable, offline-verifiable, and tamper-evident.
 
+Not blockchain. Not cryptocurrency. Just signed, inspectable AI evidence.
+
 ### Install
 
 ```bash


### PR DESCRIPTION
Adds a single-line disclaimer-and-anchor to the README hero block:

> Not blockchain. Not cryptocurrency. Just signed, inspectable AI evidence.

## Why

The hero already says "signed," "verifiable," "tamper-evident," and "just math" in three consecutive sentences. Skim readers (especially those already pattern-matching on receipt + hash + signature) bucket the project as crypto/blockchain. The negation alone leaves a category vacuum; the trailing clause re-anchors the reader in "AI evidence."

## Scope

- README.md only
- Pure addition: `+2 / -0`
- No other surfaces touched
- No homepage rewrite, no positioning rewrite, no GTM-shaping language

## Doctrine alignment

Aligned with the receipt-positioning gate (internal brief; not in this PR). The line forecloses a wrong category bucket and anchors in a category Assay can already deliver. It does not promise any reviewer/buyer outcome. Safe under "first gate must be real before public."

🤖 Generated with [Claude Code](https://claude.com/claude-code)