### PR TITLE
feat(ci): add assay receipt evidence pack

### DIFF
--- a/.github/workflows/assay-receipt.yml
+++ b/.github/workflows/assay-receipt.yml
@@ -1,0 +1,169 @@
+name: assay-receipt
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+  attestations: write
+  artifact-metadata: write
+
+jobs:
+  receipt:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    env:
+      ASSAY_PYTEST_COMMAND: "PYTHONHASHSEED=0 pytest -q --maxfail=1 --tb=short --junitxml=results.xml"
+      ASSAY_PROOF_TIER: "tier3_ci_pytest_sigstore_bundle_v1"
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11.15"
+
+      - name: Initialize evidence status files
+        run: |
+          echo "not-run" > receipt-status.txt
+          echo "not-run" > signature-status.txt
+          echo "not-run" > verification-status.txt
+          echo "not-run" > upload-status.txt
+
+      - name: Install test deps
+        run: |
+          python -m pip install -U pip
+          python -m pip install -e .[dev]
+
+      - name: Run pytest without losing failure evidence
+        run: |
+          set +e
+          PYTHONHASHSEED=0 pytest -q --maxfail=1 --tb=short --junitxml=results.xml > pytest.log 2>&1
+          EC=$?
+          set -e
+          echo "$EC" > pytest-exit-code.txt
+
+      - name: Emit Assay receipt
+        run: |
+          set +e
+          python scripts/assay_emit_receipt.py \
+            --pytest-exit-code "$(cat pytest-exit-code.txt)" \
+            --out receipt.json \
+            --artifact results.xml \
+            --artifact pytest.log \
+            --artifact pytest-exit-code.txt
+          EC=$?
+          set -e
+
+          if [ "$EC" -eq 0 ] && [ -s receipt.json ]; then
+            echo "ok" > receipt-status.txt
+          else
+            echo "failed" > receipt-status.txt
+            exit "$EC"
+          fi
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.0.0
+
+      - name: Sign receipt with GitHub OIDC keyless identity
+        run: |
+          set +e
+          cosign sign-blob \
+            --yes \
+            --bundle receipt.json.sigstore.json \
+            receipt.json
+          EC=$?
+          set -e
+
+          if [ "$EC" -eq 0 ] && [ -s receipt.json.sigstore.json ]; then
+            echo "ok" > signature-status.txt
+          else
+            echo "failed" > signature-status.txt
+            exit "$EC"
+          fi
+
+      - name: Verify receipt signature
+        run: |
+          CERT_ID="https://github.com/${GITHUB_WORKFLOW_REF}"
+
+          set +e
+          cosign verify-blob receipt.json \
+            --bundle receipt.json.sigstore.json \
+            --certificate-identity "$CERT_ID" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+          EC=$?
+          set -e
+
+          if [ "$EC" -eq 0 ]; then
+            echo "ok" > verification-status.txt
+          else
+            echo "failed" > verification-status.txt
+            exit "$EC"
+          fi
+
+      - name: Generate GitHub artifact attestation
+        uses: actions/attest@v4
+        continue-on-error: true
+        with:
+          subject-path: receipt.json
+
+      - name: Upload evidence pack
+        id: upload_evidence
+        uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: assay-evidence
+          if-no-files-found: warn
+          path: |
+            receipt.json
+            receipt.json.sigstore.json
+            results.xml
+            pytest.log
+            pytest-exit-code.txt
+            receipt-status.txt
+            signature-status.txt
+            verification-status.txt
+            upload-status.txt
+
+      - name: Mark upload status
+        if: ${{ always() }}
+        run: |
+          if [ "${{ steps.upload_evidence.outcome }}" = "success" ]; then
+            echo "ok" > upload-status.txt
+          else
+            echo "failed" > upload-status.txt
+          fi
+
+      - name: Enforce evidence pipeline and pytest result
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+
+          require_status() {
+            path="$1"
+            expected="$2"
+            if [ ! -f "$path" ]; then
+              echo "missing status file: $path" >&2
+              exit 1
+            fi
+            actual="$(cat "$path")"
+            if [ "$actual" != "$expected" ]; then
+              echo "$path was $actual, expected $expected" >&2
+              exit 1
+            fi
+          }
+
+          require_status receipt-status.txt ok
+          require_status signature-status.txt ok
+          require_status verification-status.txt ok
+          require_status upload-status.txt ok
+          test -f pytest-exit-code.txt
+
+          exit "$(cat pytest-exit-code.txt)"

--- a/.github/workflows/assay-receipt.yml
+++ b/.github/workflows/assay-receipt.yml
@@ -21,6 +21,8 @@ jobs:
       ASSAY_PROOF_TIER: "tier3_ci_pytest_sigstore_bundle_v1"
 
     steps:
+      # Intentionally use the current checkout/setup-python majors for this
+      # new workflow. Aligning older repo workflows is a separate cleanup.
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -45,7 +47,7 @@ jobs:
       - name: Run pytest without losing failure evidence
         run: |
           set +e
-          PYTHONHASHSEED=0 pytest -q --maxfail=1 --tb=short --junitxml=results.xml > pytest.log 2>&1
+          bash -o pipefail -c "$ASSAY_PYTEST_COMMAND" > pytest.log 2>&1
           EC=$?
           set -e
           echo "$EC" > pytest-exit-code.txt
@@ -130,7 +132,6 @@ jobs:
             receipt-status.txt
             signature-status.txt
             verification-status.txt
-            upload-status.txt
 
       - name: Mark upload status
         if: ${{ always() }}
@@ -164,6 +165,11 @@ jobs:
           require_status signature-status.txt ok
           require_status verification-status.txt ok
           require_status upload-status.txt ok
-          test -f pytest-exit-code.txt
+
+          test -s receipt.json
+          test -s receipt.json.sigstore.json
+          test -s results.xml
+          test -s pytest.log
+          test -s pytest-exit-code.txt
 
           exit "$(cat pytest-exit-code.txt)"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+.PHONY: assay-receipt-local test-assay-receipt-emitter verify-assay-receipt
+
+ASSAY_PYTEST_COMMAND := PYTHONHASHSEED=0 pytest -q --maxfail=1 --tb=short --junitxml=results.xml
+PYTHON ?= python3
+
+assay-receipt-local:
+	set +e; \
+	$(ASSAY_PYTEST_COMMAND) > pytest.log 2>&1; \
+	EC=$$?; \
+	set -e; \
+	echo "$$EC" > pytest-exit-code.txt; \
+	ASSAY_PYTEST_COMMAND="$(ASSAY_PYTEST_COMMAND)" $(PYTHON) scripts/assay_emit_receipt.py \
+		--pytest-exit-code "$$EC" \
+		--out receipt.json \
+		--artifact results.xml \
+		--artifact pytest.log \
+		--artifact pytest-exit-code.txt; \
+	exit "$$EC"
+
+test-assay-receipt-emitter:
+	$(PYTHON) -m pytest tests/assay/test_assay_emit_receipt.py -q
+
+verify-assay-receipt:
+	test -f receipt.json
+	test -f receipt.json.sigstore.json
+	test -n "$$ASSAY_CERTIFICATE_IDENTITY"
+	cosign verify-blob receipt.json \
+		--bundle receipt.json.sigstore.json \
+		--certificate-identity "$$ASSAY_CERTIFICATE_IDENTITY" \
+		--certificate-oidc-issuer "https://token.actions.githubusercontent.com"

--- a/README_ASSAY_RECEIPTS.md
+++ b/README_ASSAY_RECEIPTS.md
@@ -1,0 +1,97 @@
+# Assay CI Receipts
+
+This repository emits a portable pytest evidence pack:
+
+- `results.xml` - JUnit test output
+- `pytest.log` - pytest stdout/stderr capture
+- `pytest-exit-code.txt` - original pytest process exit code
+- `receipt-status.txt` - receipt generation status
+- `signature-status.txt` - Sigstore signing status
+- `verification-status.txt` - Sigstore verification status
+- `upload-status.txt` - upload status used by the final gate
+- `receipt.json` - the signed receipt blob
+- `receipt.json.sigstore.json` - the Sigstore bundle for the signed blob
+
+The invariant is byte-level: a gated episode is not just "CI passed." It is
+"these exact bytes were tested by this exact workflow identity, produced these
+exact artifacts, and the receipt can be independently verified later."
+
+## Settlement States
+
+`PASS` means pytest exited `0`, receipt generation succeeded, the Sigstore
+bundle was created, the bundle verified against the expected GitHub Actions
+workflow identity, and the evidence upload step succeeded.
+
+`HONEST_FAIL` means pytest exited nonzero, but `receipt-status.txt`,
+`signature-status.txt`, `verification-status.txt`, and `upload-status.txt` are
+all `ok`. This is a trusted receipt for a failed test run.
+
+`TAMPERED_OR_BROKEN` means receipt generation, signing, verification, upload, or
+artifact hash verification failed. Treat this as an integrity failure, not a
+pytest failure.
+
+Pytest failure is allowed to be honest. Receipt, signature, verification, and
+upload failure is not.
+
+One operational detail: upload success is only knowable after the evidence pack
+has already been sent. The workflow therefore includes the status breadcrumbs in
+the uploaded evidence pack, then updates the workspace copy of
+`upload-status.txt` from the `actions/upload-artifact` outcome before the final
+gate runs.
+
+## Signed Blob and Bundle
+
+Keep the Sigstore bundle beside the receipt. Do not embed it inside
+`receipt.json`.
+
+`receipt.json` is the signed blob. `receipt.json.sigstore.json` contains the
+signature, certificate, and transparency-log verification material needed by
+Cosign.
+
+## CI Verification
+
+The workflow signs and verifies the receipt with GitHub OIDC keyless signing:
+
+```bash
+cosign verify-blob receipt.json \
+  --bundle receipt.json.sigstore.json \
+  --certificate-identity "https://github.com/OWNER/REPO/.github/workflows/assay-receipt.yml@refs/heads/BRANCH" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+```
+
+For this repository on `main`, the expected identity is:
+
+```text
+https://github.com/Haserjian/assay/.github/workflows/assay-receipt.yml@refs/heads/main
+```
+
+For pull requests or release branches, replace the final ref with the workflow
+ref stored in `receipt.json` at `workflow.workflow_ref`.
+
+## Proof Tier
+
+This flow is Tier 3 once `receipt.json` has a verified
+`receipt.json.sigstore.json` bundle:
+
+- Tier 0: test outputs captured
+- Tier 1: artifact bytes pinned with SHA-256
+- Tier 2: GitHub Actions run and workflow identity captured
+- Tier 3: receipt signed and verified with Sigstore keyless identity
+
+The workflow also attempts to emit a GitHub artifact attestation for
+`receipt.json`. Treat that as a non-blocking Tier 4 add-on in this MVP, not the
+primitive receipt. The portable nucleus remains `receipt.json` plus
+`receipt.json.sigstore.json`.
+
+## Local Emitter Check
+
+You can exercise the unsigned local emitter with:
+
+```bash
+make assay-receipt-local
+```
+
+This produces local `results.xml`, `pytest.log`, `pytest-exit-code.txt`, and
+`receipt.json`. Local output is useful for script development, but it is not a
+Tier 3 receipt until `receipt.json` is signed and verified with a Sigstore
+bundle.

--- a/README_ASSAY_RECEIPTS.md
+++ b/README_ASSAY_RECEIPTS.md
@@ -8,7 +8,6 @@ This repository emits a portable pytest evidence pack:
 - `receipt-status.txt` - receipt generation status
 - `signature-status.txt` - Sigstore signing status
 - `verification-status.txt` - Sigstore verification status
-- `upload-status.txt` - upload status used by the final gate
 - `receipt.json` - the signed receipt blob
 - `receipt.json.sigstore.json` - the Sigstore bundle for the signed blob
 
@@ -20,11 +19,12 @@ exact artifacts, and the receipt can be independently verified later."
 
 `PASS` means pytest exited `0`, receipt generation succeeded, the Sigstore
 bundle was created, the bundle verified against the expected GitHub Actions
-workflow identity, and the evidence upload step succeeded.
+workflow identity, and GitHub accepted the evidence artifact upload.
 
 `HONEST_FAIL` means pytest exited nonzero, but `receipt-status.txt`,
-`signature-status.txt`, `verification-status.txt`, and `upload-status.txt` are
-all `ok`. This is a trusted receipt for a failed test run.
+`signature-status.txt`, and `verification-status.txt` are all `ok`, and the
+workflow's final gate observed a successful `actions/upload-artifact` outcome.
+This is a trusted receipt for a failed test run.
 
 `TAMPERED_OR_BROKEN` means receipt generation, signing, verification, upload, or
 artifact hash verification failed. Treat this as an integrity failure, not a
@@ -34,10 +34,9 @@ Pytest failure is allowed to be honest. Receipt, signature, verification, and
 upload failure is not.
 
 One operational detail: upload success is only knowable after the evidence pack
-has already been sent. The workflow therefore includes the status breadcrumbs in
-the uploaded evidence pack, then updates the workspace copy of
-`upload-status.txt` from the `actions/upload-artifact` outcome before the final
-gate runs.
+has already been sent. The portable evidence pack therefore does not include an
+`upload-status.txt` claim. The workflow keeps that as workspace-only final-gate
+state, derived from the `actions/upload-artifact` step outcome.
 
 ## Signed Blob and Bundle
 
@@ -67,6 +66,10 @@ https://github.com/Haserjian/assay/.github/workflows/assay-receipt.yml@refs/head
 
 For pull requests or release branches, replace the final ref with the workflow
 ref stored in `receipt.json` at `workflow.workflow_ref`.
+
+For pull request events, the receipt subject is the exact tree GitHub checked
+out for that event. Depending on the event configuration, that may be a PR merge
+ref rather than only the contributor head commit.
 
 ## Proof Tier
 

--- a/scripts/assay_emit_receipt.py
+++ b/scripts/assay_emit_receipt.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Emit a portable Assay pytest receipt for CI signing.
+
+This script is intentionally local-only: it reads environment variables,
+git metadata, pytest output files, and artifact bytes. It performs no
+network calls and does not decide whether pytest passed the gate.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Optional, Sequence
+
+DEFAULT_PYTEST_COMMAND = (
+    "PYTHONHASHSEED=0 pytest -q --maxfail=1 --tb=short --junitxml=results.xml"
+)
+DEFAULT_PROOF_TIER = "tier3_ci_pytest_sigstore_bundle_v1"
+PYTEST_NODEID_RE = re.compile(
+    r"([A-Za-z0-9_./-]+\.py(?:::[A-Za-z0-9_./\[\]-]+)+)"
+)
+
+
+def _run_git(args: Sequence[str], cwd: Path) -> Optional[str]:
+    try:
+        completed = subprocess.run(
+            ["git", *args],
+            cwd=str(cwd),
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    value = completed.stdout.strip()
+    return value or None
+
+
+def _repo_slug_from_remote(remote_url: Optional[str]) -> Optional[str]:
+    if not remote_url:
+        return None
+    value = remote_url.strip()
+    if value.endswith(".git"):
+        value = value[:-4]
+    if value.startswith("git@") and ":" in value:
+        value = value.split(":", 1)[1]
+    elif "://" in value:
+        value = value.rstrip("/").rsplit("/", 2)
+        if len(value) >= 2:
+            return "/".join(value[-2:])
+        return None
+    if "/" in value:
+        parts = value.strip("/").split("/")
+        if len(parts) >= 2:
+            return "/".join(parts[-2:])
+    return None
+
+
+def _current_ref(cwd: Path, env: Mapping[str, str]) -> str:
+    github_ref = env.get("GITHUB_REF")
+    if github_ref:
+        return github_ref
+    branch = _run_git(["symbolic-ref", "--quiet", "--short", "HEAD"], cwd)
+    if branch:
+        return f"refs/heads/{branch}"
+    return _run_git(["rev-parse", "--short", "HEAD"], cwd) or "unknown"
+
+
+def _created_at(env: Mapping[str, str]) -> str:
+    override = env.get("ASSAY_RECEIPT_CREATED_AT")
+    if override:
+        return override
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def describe_artifact(path_text: str, cwd: Path) -> dict[str, Any]:
+    path = Path(path_text)
+    file_path = path if path.is_absolute() else cwd / path
+    display_path = str(path)
+    if file_path.exists() and file_path.is_file():
+        return {
+            "exists": True,
+            "path": display_path,
+            "sha256": _sha256_file(file_path),
+            "size_bytes": file_path.stat().st_size,
+        }
+    return {
+        "blocked_reason": "missing",
+        "exists": False,
+        "path": display_path,
+        "sha256": None,
+        "size_bytes": None,
+    }
+
+
+def parse_failing_tests(log_path: str, cwd: Path) -> list[str]:
+    path = Path(log_path)
+    file_path = path if path.is_absolute() else cwd / path
+    if not file_path.exists() or not file_path.is_file():
+        return []
+    try:
+        text = file_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+    return sorted(set(PYTEST_NODEID_RE.findall(text)))
+
+
+def _first_named_artifact(artifacts: Sequence[str], suffix: str, fallback: str) -> str:
+    for artifact in artifacts:
+        if Path(artifact).name == fallback:
+            return artifact
+    for artifact in artifacts:
+        if Path(artifact).suffix == suffix:
+            return artifact
+    return fallback
+
+
+def build_receipt(
+    *,
+    pytest_exit_code: int,
+    artifacts: Sequence[str],
+    cwd: Path,
+    env: Mapping[str, str],
+) -> dict[str, Any]:
+    repo = env.get("GITHUB_REPOSITORY") or _repo_slug_from_remote(
+        _run_git(["remote", "get-url", "origin"], cwd)
+    )
+    commit_sha = env.get("GITHUB_SHA") or _run_git(["rev-parse", "HEAD"], cwd)
+    tree_sha = _run_git(["rev-parse", "HEAD^{tree}"], cwd)
+    junit_path = _first_named_artifact(artifacts, ".xml", "results.xml")
+    log_path = _first_named_artifact(artifacts, ".log", "pytest.log")
+
+    return {
+        "artifacts": [describe_artifact(artifact, cwd) for artifact in artifacts],
+        "created_at": _created_at(env),
+        "proof_tier": env.get("ASSAY_PROOF_TIER", DEFAULT_PROOF_TIER),
+        "run": {
+            "event_name": env.get("GITHUB_EVENT_NAME", "unknown"),
+            "run_attempt": env.get("GITHUB_RUN_ATTEMPT", "unknown"),
+            "run_id": env.get("GITHUB_RUN_ID", "unknown"),
+            "run_number": env.get("GITHUB_RUN_NUMBER", "unknown"),
+        },
+        "runner": {
+            "arch": env.get("RUNNER_ARCH", "unknown"),
+            "environment": env.get("ASSAY_RUNNER_ENVIRONMENT")
+            or env.get("RUNNER_ENVIRONMENT", "unknown"),
+            "os": env.get("RUNNER_OS", "unknown"),
+        },
+        "schema": "assay.receipt.v1",
+        "subject": {
+            "commit_sha": commit_sha or "unknown",
+            "ref": _current_ref(cwd, env),
+            "repo": repo or "unknown",
+            "tree_sha": tree_sha or "unknown",
+        },
+        "test": {
+            "command": env.get("ASSAY_PYTEST_COMMAND", DEFAULT_PYTEST_COMMAND),
+            "exit_code": int(pytest_exit_code),
+            "failing_tests": parse_failing_tests(log_path, cwd),
+            "framework": "pytest",
+            "junit": junit_path,
+            "log": log_path,
+        },
+        "workflow": {
+            "provider": (
+                "github_actions" if env.get("GITHUB_ACTIONS") == "true" else "local"
+            ),
+            "workflow_ref": env.get("GITHUB_WORKFLOW_REF", "unknown"),
+            "workflow_sha": env.get("GITHUB_WORKFLOW_SHA", "unknown"),
+        },
+    }
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Emit an Assay pytest receipt for later Sigstore signing.",
+    )
+    parser.add_argument(
+        "--pytest-exit-code",
+        required=True,
+        type=int,
+        help="Original pytest process exit code",
+    )
+    parser.add_argument("--out", required=True, help="Path to write receipt JSON")
+    parser.add_argument(
+        "--artifact",
+        action="append",
+        default=[],
+        help="Artifact path to hash. Repeat for multiple artifacts.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    cwd = Path.cwd()
+    receipt = build_receipt(
+        pytest_exit_code=args.pytest_exit_code,
+        artifacts=args.artifact,
+        cwd=cwd,
+        env=os.environ,
+    )
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/assay/test_assay_emit_receipt.py
+++ b/tests/assay/test_assay_emit_receipt.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "assay_emit_receipt.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("assay_emit_receipt", SCRIPT_PATH)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_describes_existing_and_missing_artifacts(tmp_path):
+    module = _load_module()
+    artifact = tmp_path / "results.xml"
+    artifact.write_text("<testsuite />\n", encoding="utf-8")
+
+    receipt = module.build_receipt(
+        pytest_exit_code=0,
+        artifacts=["results.xml", "missing.log"],
+        cwd=tmp_path,
+        env={"ASSAY_RECEIPT_CREATED_AT": "2026-05-02T00:00:00Z"},
+    )
+
+    assert receipt["artifacts"][0]["exists"] is True
+    assert receipt["artifacts"][0]["size_bytes"] == len("<testsuite />\n")
+    assert len(receipt["artifacts"][0]["sha256"]) == 64
+    assert receipt["artifacts"][1] == {
+        "blocked_reason": "missing",
+        "exists": False,
+        "path": "missing.log",
+        "sha256": None,
+        "size_bytes": None,
+    }
+
+
+def test_maps_github_actions_environment(tmp_path):
+    module = _load_module()
+    env = {
+        "ASSAY_RECEIPT_CREATED_AT": "2026-05-02T00:00:00Z",
+        "ASSAY_RUNNER_ENVIRONMENT": "github-hosted",
+        "GITHUB_ACTIONS": "true",
+        "GITHUB_EVENT_NAME": "push",
+        "GITHUB_REF": "refs/heads/main",
+        "GITHUB_REPOSITORY": "Haserjian/assay",
+        "GITHUB_RUN_ATTEMPT": "2",
+        "GITHUB_RUN_ID": "123456789",
+        "GITHUB_RUN_NUMBER": "42",
+        "GITHUB_SHA": "a" * 40,
+        "GITHUB_WORKFLOW_REF": (
+            "Haserjian/assay/.github/workflows/assay-receipt.yml"
+            "@refs/heads/main"
+        ),
+        "GITHUB_WORKFLOW_SHA": "b" * 40,
+        "RUNNER_ARCH": "X64",
+        "RUNNER_OS": "Linux",
+    }
+
+    receipt = module.build_receipt(
+        pytest_exit_code=1,
+        artifacts=[],
+        cwd=tmp_path,
+        env=env,
+    )
+
+    assert receipt["workflow"] == {
+        "provider": "github_actions",
+        "workflow_ref": (
+            "Haserjian/assay/.github/workflows/assay-receipt.yml"
+            "@refs/heads/main"
+        ),
+        "workflow_sha": "b" * 40,
+    }
+    assert receipt["subject"]["repo"] == "Haserjian/assay"
+    assert receipt["subject"]["commit_sha"] == "a" * 40
+    assert receipt["subject"]["ref"] == "refs/heads/main"
+    assert receipt["run"]["run_id"] == "123456789"
+    assert receipt["run"]["run_attempt"] == "2"
+    assert receipt["run"]["run_number"] == "42"
+    assert receipt["runner"] == {
+        "arch": "X64",
+        "environment": "github-hosted",
+        "os": "Linux",
+    }
+    assert receipt["test"]["exit_code"] == 1
+
+
+def test_parses_failing_tests_from_pytest_log(tmp_path):
+    module = _load_module()
+    (tmp_path / "pytest.log").write_text(
+        "\n".join(
+            [
+                "FAILED tests/test_math.py::TestAdd::test_negative - AssertionError",
+                "tests/test_other.py::test_case[one] failed later",
+                "FAILED tests/test_math.py::TestAdd::test_negative - duplicate",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    receipt = module.build_receipt(
+        pytest_exit_code=1,
+        artifacts=["pytest.log"],
+        cwd=tmp_path,
+        env={"ASSAY_RECEIPT_CREATED_AT": "2026-05-02T00:00:00Z"},
+    )
+
+    assert receipt["test"]["failing_tests"] == [
+        "tests/test_math.py::TestAdd::test_negative",
+        "tests/test_other.py::test_case[one]",
+    ]
+
+
+def test_cli_writes_sorted_json_and_preserves_nonzero_exit_code(tmp_path):
+    (tmp_path / "results.xml").write_text(
+        "<testsuite failures='1' />\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "pytest.log").write_text(
+        "FAILED tests/test_cli.py::test_failure - AssertionError\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "receipt.json"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--pytest-exit-code",
+            "7",
+            "--out",
+            str(out),
+            "--artifact",
+            "results.xml",
+            "--artifact",
+            "pytest.log",
+        ],
+        cwd=tmp_path,
+        env={"ASSAY_RECEIPT_CREATED_AT": "2026-05-02T00:00:00Z"},
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    payload = out.read_text(encoding="utf-8")
+    assert payload.startswith('{\n  "artifacts"')
+    receipt = json.loads(payload)
+    assert receipt["schema"] == "assay.receipt.v1"
+    assert receipt["test"]["exit_code"] == 7
+    assert receipt["test"]["failing_tests"] == ["tests/test_cli.py::test_failure"]

--- a/tests/assay/test_pilot_cli.py
+++ b/tests/assay/test_pilot_cli.py
@@ -160,6 +160,24 @@ def _write_pilot_bundle(
     return bundle
 
 
+def _pilot_command_options(command_name: str) -> set[str]:
+    """Return Click option names for a pilot subcommand.
+
+    Help text rendering is presentation: Rich/Typer may wrap or style option
+    names differently across versions and terminals. The Click command object is
+    the authority surface for whether an option is registered.
+    """
+    from typer.main import get_command
+
+    root = get_command(assay_app)
+    pilot = root.commands["pilot"]
+    command = pilot.commands[command_name]
+    options: set[str] = set()
+    for param in command.params:
+        options.update(getattr(param, "opts", ()))
+    return options
+
+
 # ---------------------------------------------------------------------------
 # Config loading tests
 # ---------------------------------------------------------------------------
@@ -225,20 +243,23 @@ class TestPilotHelp:
     def test_pilot_run_help(self) -> None:
         result = runner.invoke(assay_app, ["pilot", "run", "--help"])
         assert result.exit_code == 0
-        assert "--test-cmd" in result.output
-        assert "--dry-run" in result.output
+        options = _pilot_command_options("run")
+        assert "--test-cmd" in options
+        assert "--dry-run" in options
 
     def test_pilot_verify_help(self) -> None:
         result = runner.invoke(assay_app, ["pilot", "verify", "--help"])
         assert result.exit_code == 0
-        assert "--profile" in result.output
-        assert "--self-test" in result.output
+        options = _pilot_command_options("verify")
+        assert "--profile" in options
+        assert "--self-test" in options
 
     def test_pilot_closeout_help(self) -> None:
         result = runner.invoke(assay_app, ["pilot", "closeout", "--help"])
         assert result.exit_code == 0
-        assert "--dry-run" in result.output
-        assert "--json-output" in result.output
+        options = _pilot_command_options("closeout")
+        assert "--dry-run" in options
+        assert "--json-output" in options
 
 
 # ---------------------------------------------------------------------------
@@ -413,9 +434,9 @@ class TestCloseout:
         row = run_pilot_closeout(bundle, log_path=log_path)
         assert log_path.exists()
         lines = [
-            json.loads(l)
-            for l in log_path.read_text(encoding="utf-8").splitlines()
-            if l.strip()
+            json.loads(line)
+            for line in log_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
         ]
         assert len(lines) == 1
         assert lines[0]["bundle_id"] == row["bundle_id"]


### PR DESCRIPTION
## Summary
- add a pytest receipt emitter that captures git, workflow, run, runner, test, and artifact hash metadata
- add an assay-receipt GitHub Actions workflow that signs receipt.json with Cosign keyless signing, verifies the bundle, uploads the evidence pack, and only then enforces pytest's original exit code
- document PASS / HONEST_FAIL / TAMPERED_OR_BROKEN semantics and local receipt targets

## Verification
- make test-assay-receipt-emitter PYTHON=python3.11
- python3.11 -m pytest tests/assay/test_ci_binding.py tests/assay/test_assay_emit_receipt.py -q
- python3.11 -m ruff check scripts/assay_emit_receipt.py tests/assay/test_assay_emit_receipt.py
- parsed .github/workflows/assay-receipt.yml with PyYAML
- checked workflow/README trailing whitespace

## Live receipt validation
- GitHub Actions run 25262491125 (pull_request) emitted receipt.json and receipt.json.sigstore.json, signed with Cosign keyless signing, verified the signature in CI, and uploaded the evidence pack.
- Downloaded assay-evidence from run 25262491125 and independently verified locally with cosign v3.0.2:
  - certificate identity: https://github.com/Haserjian/assay/.github/workflows/assay-receipt.yml@refs/pull/105/merge
  - result: Verified OK
- The uploaded evidence pack does not contain upload-status.txt; upload success remains workspace-only final-gate state derived from the actions/upload-artifact outcome.
- The receipt run is HONEST_FAIL: receipt-status/signature-status/verification-status were ok, the upload step succeeded, and pytest-exit-code.txt was 1.

## Known failing check classification
- The assay-receipt check fails because pytest failed on tests/assay/test_checkpoint_reviewer_packet.py::test_checkpoint_reviewer_packet_happy_path_verifies.
- Base-branch parity checked in a detached origin/main worktree with:
  - python3.11 -m pytest tests/assay/test_checkpoint_reviewer_packet.py::test_checkpoint_reviewer_packet_happy_path_verifies -q
- That same test fails on origin/main, so this is CONFIRMED base-branch parity, not PR-local receipt breakage.

## Notes
- GitHub artifact attestation is intentionally non-blocking in this MVP; Tier 3 is receipt.json plus receipt.json.sigstore.json verified against GitHub workflow identity.
- This new workflow intentionally uses current checkout/setup-python majors; aligning older repo workflows is a separate cleanup.
