### PR TITLE
fix(test): restore base pytest gate

### DIFF
--- a/src/assay/_receipts/v2_types.py
+++ b/src/assay/_receipts/v2_types.py
@@ -120,7 +120,6 @@ ALGORITHM_STATUS: Dict[str, str] = {
 
 OPERATIONAL_ALGORITHMS: frozenset = frozenset({
     "ed25519",
-    "ml-dsa-44", "ml-dsa-65", "ml-dsa-87",
 })
 
 ARCHIVAL_ALGORITHMS: frozenset = frozenset({
@@ -132,7 +131,11 @@ ARCHIVAL_ALGORITHMS: frozenset = frozenset({
 # Algorithms recognized by this spec but not implemented in this build.
 # Verifier MUST return status="unsupported_algorithm" for these,
 # not a cryptographic failure.
-UNSUPPORTED_ALGORITHMS: frozenset = frozenset()
+UNSUPPORTED_ALGORITHMS: frozenset = frozenset({
+    "ml-dsa-44", "ml-dsa-65", "ml-dsa-87",
+    "slh-dsa-sha2-128s", "slh-dsa-sha2-128f",
+    "slh-dsa-sha2-192s", "slh-dsa-sha2-256s",
+})
 
 
 __all__ = [

--- a/src/assay/_receipts/v2_verify.py
+++ b/src/assay/_receipts/v2_verify.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import warnings
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional
 
@@ -128,6 +129,13 @@ def _shim_v1_signatures(receipt: Dict[str, Any]) -> List[Dict[str, Any]]:
     - algorithm         → "ed25519" (v1 was always Ed25519)
     """
     if "signatures" in receipt:
+        if "signature" in receipt:
+            warnings.warn(
+                "Receipt contains both flat v1 'signature' and v2 'signatures'; "
+                "using v2 'signatures' and ignoring flat 'signature'.",
+                UserWarning,
+                stacklevel=2,
+            )
         sigs = receipt["signatures"]
         return sigs if isinstance(sigs, list) else []
     if "signature" not in receipt:
@@ -143,7 +151,6 @@ def _shim_v1_signatures(receipt: Dict[str, Any]) -> List[Dict[str, Any]]:
 def _verify_ed25519(pubkey_bytes: bytes, message: bytes, sig_bytes: bytes) -> bool:
     try:
         from nacl.signing import VerifyKey
-        from nacl.exceptions import BadSignatureError
         vk = VerifyKey(pubkey_bytes)
         vk.verify(message, sig_bytes)
         return True

--- a/tests/assay/test_bridge.py
+++ b/tests/assay/test_bridge.py
@@ -152,6 +152,11 @@ class MockInvoker:
 # ---------------------------------------------------------------------------
 
 class TestReceiptBridge:
+    @pytest.fixture(autouse=True)
+    def _isolate_default_store(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(store_mod, "_default_store", AssayStore(base_dir=tmp_path / "assay_store"))
+        monkeypatch.delenv("ASSAY_TRACE_ID", raising=False)
+
     def _make_bridge(self, tmp_path: Path, **invoker_kwargs) -> tuple[ReceiptBridge, MockInvoker]:
         cfg = BridgeConfig(artifacts_dir=tmp_path / "artifacts", cwd=str(tmp_path))
         invoker = MockInvoker(**invoker_kwargs)

--- a/tests/assay/test_checkpoint_reviewer_packet.py
+++ b/tests/assay/test_checkpoint_reviewer_packet.py
@@ -25,6 +25,12 @@ ROOT = Path(__file__).resolve().parents[2]
 EXAMPLES_DIR = ROOT / "docs" / "examples" / "checkpoints"
 runner = CliRunner()
 PACK_TS = "2026-03-19T13:00:00+00:00"
+PACK_VALID_FOR = "P3650D"
+
+
+def _packet_overrides(packet_id: str) -> dict:
+    # Keep static packet timestamps from aging into freshness failures.
+    return {"generated_at": PACK_TS, "packet_id": packet_id, "valid_for": PACK_VALID_FOR}
 
 
 @pytest.fixture
@@ -161,7 +167,7 @@ def test_checkpoint_reviewer_packet_happy_path_verifies(tmp_path: Path, tmp_stor
         checkpoint_attempt_id=template["checkpoint_id"],
         out_dir=packet_dir,
         decision_receipts=[decision],
-        packet_overrides={"generated_at": PACK_TS, "packet_id": "rp_checkpoint_happy"},
+        packet_overrides=_packet_overrides("rp_checkpoint_happy"),
     )
 
     assert result["packet_profile"] == CHECKPOINT_REVIEWER_PACKET_PROFILE
@@ -185,7 +191,7 @@ def test_checkpoint_reviewer_packet_degrades_without_canonical_decisions(tmp_pat
         proof_pack_dir=proof_pack_dir,
         checkpoint_attempt_id=template["checkpoint_id"],
         out_dir=packet_dir,
-        packet_overrides={"generated_at": PACK_TS, "packet_id": "rp_checkpoint_degraded"},
+        packet_overrides=_packet_overrides("rp_checkpoint_degraded"),
     )
 
     authority_row = next(row for row in result["coverage_rows"] if row["Claim / Question"].startswith("Is the authority"))
@@ -216,7 +222,7 @@ def test_checkpoint_reviewer_packet_legacy_resolution_compatibility(tmp_path: Pa
         checkpoint_attempt_id=template["checkpoint_id"],
         out_dir=packet_dir,
         decision_receipts=[decision],
-        packet_overrides={"generated_at": PACK_TS, "packet_id": "rp_checkpoint_legacy"},
+        packet_overrides=_packet_overrides("rp_checkpoint_legacy"),
     )
 
     posture_row = next(row for row in result["coverage_rows"] if row["Claim / Question"].startswith("Which evaluation"))
@@ -256,7 +262,7 @@ def test_checkpoint_packet_uses_carried_forward_evaluation_not_latest(tmp_path: 
         checkpoint_attempt_id=template["checkpoint_id"],
         out_dir=packet_dir,
         decision_receipts=[decision],
-        packet_overrides={"generated_at": PACK_TS, "packet_id": "rp_checkpoint_multieval"},
+        packet_overrides=_packet_overrides("rp_checkpoint_multieval"),
     )
 
     assert result["settlement_state"] == "VERIFIED"
@@ -281,7 +287,7 @@ def test_checkpoint_reviewer_packet_invalid_lifecycle_settles_incomplete(tmp_pat
         checkpoint_attempt_id=template["checkpoint_id"],
         out_dir=packet_dir,
         decision_receipts=[bad_decision],
-        packet_overrides={"generated_at": PACK_TS, "packet_id": "rp_checkpoint_incomplete"},
+        packet_overrides=_packet_overrides("rp_checkpoint_incomplete"),
     )
 
     assert result["settlement_state"] == "INCOMPLETE_EVIDENCE"
@@ -306,7 +312,7 @@ def test_checkpoint_export_reviewer_rejects_unresolved_attempt(tmp_path: Path, t
             proof_pack_dir=proof_pack_dir,
             checkpoint_attempt_id=template["checkpoint_id"],
             out_dir=packet_dir,
-            packet_overrides={"generated_at": PACK_TS, "packet_id": "rp_checkpoint_unresolved"},
+            packet_overrides=_packet_overrides("rp_checkpoint_unresolved"),
         )
 
     assert not packet_dir.exists()
@@ -321,7 +327,7 @@ def test_checkpoint_reviewer_packet_detects_tampered_nested_proof_pack(tmp_path:
         checkpoint_attempt_id=template["checkpoint_id"],
         out_dir=packet_dir,
         decision_receipts=[decision],
-        packet_overrides={"generated_at": PACK_TS, "packet_id": "rp_checkpoint_tamper_pack"},
+        packet_overrides=_packet_overrides("rp_checkpoint_tamper_pack"),
     )
 
     receipt_path = packet_dir / "proof_pack" / "receipt_pack.jsonl"
@@ -344,7 +350,7 @@ def test_checkpoint_reviewer_packet_detects_tampered_packaged_decision_receipt(t
         checkpoint_attempt_id=template["checkpoint_id"],
         out_dir=packet_dir,
         decision_receipts=[decision],
-        packet_overrides={"generated_at": PACK_TS, "packet_id": "rp_checkpoint_tamper_decision"},
+        packet_overrides=_packet_overrides("rp_checkpoint_tamper_decision"),
     )
 
     decision_file = next((packet_dir / "decision_receipts").glob("*.json"))
@@ -383,7 +389,7 @@ def test_checkpoint_reviewer_packet_sanitizes_adversarial_decision_receipt_ids(t
         checkpoint_attempt_id=template["checkpoint_id"],
         out_dir=packet_dir,
         decision_receipts=[malicious_decision],
-        packet_overrides={"generated_at": PACK_TS, "packet_id": "rp_checkpoint_sanitized"},
+        packet_overrides=_packet_overrides("rp_checkpoint_sanitized"),
     )
 
     decision_dir = packet_dir / "decision_receipts"

--- a/tests/assay/test_passport_cli.py
+++ b/tests/assay/test_passport_cli.py
@@ -44,7 +44,7 @@ def unsigned_passport(tmp_path: Path) -> Path:
     passport = {
         "passport_version": "0.1",
         "issued_at": "2026-03-14T00:00:00+00:00",
-        "valid_until": "2026-04-13T00:00:00+00:00",
+        "valid_until": "2036-04-13T00:00:00+00:00",
         "status": {"state": "FRESH", "reason": "ok", "checked_at": "2026-03-14T00:00:00+00:00"},
         "reliance": {"class": "R0", "label": "Unsigned"},
         "subject": {

--- a/tests/assay/test_passport_lifecycle.py
+++ b/tests/assay/test_passport_lifecycle.py
@@ -2,10 +2,8 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
-
-import pytest
 
 from assay.passport_lifecycle import (
     PassportState,
@@ -20,7 +18,7 @@ def _make_passport(**overrides) -> dict:
     base = {
         "passport_version": "0.1",
         "issued_at": "2026-03-14T00:00:00+00:00",
-        "valid_until": "2026-04-13T00:00:00+00:00",
+        "valid_until": "2036-04-13T00:00:00+00:00",
         "status": {"state": "FRESH", "reason": "ok", "checked_at": "2026-03-14T00:00:00+00:00"},
         "relationships": {
             "supersedes": None,

--- a/tests/assay/test_reviewer_packet_verify.py
+++ b/tests/assay/test_reviewer_packet_verify.py
@@ -17,6 +17,7 @@ from assay.vendorq_models import load_json
 runner = CliRunner()
 
 _TS = "2026-03-11T12:00:00+00:00"
+_TEST_VALID_FOR = "P3650D"
 
 
 def _fixture_dir() -> Path:
@@ -73,7 +74,7 @@ def _base_boundary() -> dict[str, object]:
         "controls_declared": ["Signed proof pack"],
         "excluded_components": [],
         "boundary_notes": [],
-        "freshness_policy": {"valid_for": "P30D"},
+        "freshness_policy": {"valid_for": _TEST_VALID_FOR},
         "signed_by": "assay reviewer-packet compiler",
     }
 

--- a/tests/assay/test_trust_cli.py
+++ b/tests/assay/test_trust_cli.py
@@ -37,8 +37,10 @@ def _build_pack(tmp_path: Path, ks: AssayKeyStore, signer_id: str = "test-signer
     from datetime import datetime, timezone
     receipt = {
         "receipt_id": "r1",
-        "type": "test",
+        "type": "model_call",
         "timestamp": datetime.now(timezone.utc).isoformat(),
+        "provider": "openai",
+        "model_id": "gpt-4o",
     }
     pack = ProofPack(run_id="trust-cli-test", entries=[receipt], signer_id=signer_id)
     return pack.build(tmp_path / "pack", keystore=ks)

--- a/tests/assay/test_v2_sign.py
+++ b/tests/assay/test_v2_sign.py
@@ -857,16 +857,14 @@ class TestAdversarialProjection:
         result = verify_v2(receipt, key_resolver=key_resolver)
         assert result.operational_valid is True
 
-    def test_unicode_in_custom_field_key(self, sk, key_resolver):
-        """Unicode field keys in the receipt are valid attested content."""
+    def test_unicode_in_custom_field_key(self, sk):
+        """Unicode field keys are rejected by the receipt field-name policy."""
         base = build_v2_base_receipt("t",
             receipt_id="r1", timestamp="2026-01-01T00:00:00Z",
             **{"résumé": "non-ascii key"},
         )
-        receipt = emit_v2_receipt(base, signing_key=sk, signer_id="s", add_signed_at=False)
-        result = verify_v2(receipt, key_resolver=key_resolver)
-        assert result.operational_valid is True
-        assert "résumé" in receipt["verification_bundle"]["covers"]
+        with pytest.raises(ValueError, match="ASCII-only"):
+            emit_v2_receipt(base, signing_key=sk, signer_id="s", add_signed_at=False)
 
     def test_unicode_normalization_stability(self, sk):
         """Same logical unicode string must produce the same digest regardless

--- a/tests/assay/test_xray.py
+++ b/tests/assay/test_xray.py
@@ -2,13 +2,12 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 
 from assay.keystore import AssayKeyStore
-from assay.xray import XRayFinding, XRayResult, xray_passport
+from assay.xray import XRayResult, xray_passport
 
 
 @pytest.fixture
@@ -34,7 +33,7 @@ def _make_passport(**overrides) -> dict:
     base = {
         "passport_version": "0.1",
         "issued_at": "2026-03-14T00:00:00+00:00",
-        "valid_until": "2026-04-13T00:00:00+00:00",
+        "valid_until": "2036-04-13T00:00:00+00:00",
         "status": {"state": "FRESH", "reason": "ok"},
         "reliance": {"class": "R2", "label": "Signed, partial"},
         "trust_posture": {


### PR DESCRIPTION
## Summary
- keep fixed-date reviewer/passport/X-Ray fixtures from expiring with wall-clock time while preserving explicit stale tests
- isolate bridge tests from a developer's default ~/.assay store
- update trust/v2 signing tests to match current receipt schema and ASCII field-name policy
- enforce unsupported PQ algorithms as non-operational and warn on ambiguous v1/v2 signature fields

## Why
PR #105's receipt workflow correctly surfaced a base-branch pytest failure. After fixing that first failure, the same workflow-shaped pytest command exposed additional base drift. This PR restores the base pytest gate so PR #105 can rerun to PASS instead of carrying HONEST_FAIL.

## Verification
- python3.11 -m pip install -e '.[dev]'
- python3.11 -m ruff check src/assay/_receipts/v2_verify.py src/assay/_receipts/v2_types.py tests/assay/test_xray.py tests/assay/test_v2_sign.py tests/assay/test_trust_cli.py tests/assay/test_passport_lifecycle.py tests/assay/test_passport_cli.py tests/assay/test_bridge.py tests/assay/test_checkpoint_reviewer_packet.py tests/assay/test_reviewer_packet_verify.py
- HOME=/tmp/assay-ci-home PYTHONPATH=/Users/timmymacbookpro/Library/Python/3.11/lib/python/site-packages PYTHONHASHSEED=0 python3.11 -m pytest -q --maxfail=1 --tb=short

Full pytest result: 3415 passed, 59 skipped, 1 xfailed, 18 warnings.

Note: I used a clean temporary HOME because the local machine's /Users/timmymacbookpro/.assay store is in mixed legacy state; GitHub Actions uses a clean runner home.