### PR TITLE
feat(derived): add receipted derived context foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,11 @@ artifacts/
 # Local Assay runtime state
 .assay/
 
+# Local smoke/demo outputs
+.assay-ci-smoke/
+assay_quickstart_report.html
+demo/constitutional_verification/demo_output/
+
 # Internal commercial docs (not public)
 docs/commercial/
 docs/STRATEGY_STACK_HIERARCHY.md

--- a/docs/adr/receipted-derived-context.md
+++ b/docs/adr/receipted-derived-context.md
@@ -1,0 +1,89 @@
+# ADR: Receipted Derived Context
+
+## Status
+
+Proposed
+
+## Decision
+
+Loom/Assay will treat derived cognitive context as receipted artifacts.
+Derived context includes chunks, summaries, embeddings, symbol edges, repo maps,
+MemoryGraph projections, and retrieval index rows.
+
+A derived artifact is trusted only when it can identify:
+
+- source snapshot(s)
+- input artifact(s), if any
+- transform name/version
+- transform code hash
+- config hash
+- model, prompt, or policy hash when applicable
+- runtime/environment hash when applicable
+- output hash
+- receipt
+- derivation verification level
+
+## Trust Tier
+
+The MVP derived-context receipt path is T0: structural-validation and
+digest-locked self-attestation. Receipt IDs are recomputed from JCS canonical
+payload bytes, output hashes are checked, and deterministic source chunks can be
+recomputed, but these receipts are not independently signed or Sigstore
+verified in this slice.
+
+Downstream consumers must not treat `derived.*` receipts as T1 or CI-signed
+evidence unless a later integration explicitly wraps them in a signed Assay
+proof-pack or equivalent verifier path.
+
+## Law
+
+All derived context must be content-addressed, lineage-bearing, receipt-backed,
+and reproducible or honestly marked non-reproducible from source snapshots plus
+versioned transforms.
+
+Caches accelerate. Receipts and committed state authorize.
+Indexers propose. Guardian commits.
+
+## Rationale
+
+Fresh context is useful but dangerous if it is not explainable. The system must
+be able to answer why an artifact exists, what produced it, whether it is stale,
+and whether it can be reproduced.
+
+## Authority
+
+Caches are not authority. External indexers are not authority.
+Receipts, source snapshots, and committed graph state are authority.
+
+## Architecture
+
+Derived context uses a staged flow:
+
+scan -> plan -> derive -> receipt -> verify -> Guardian gate -> commit
+
+The indexer proposes changes. Guardian controls commitment.
+
+## Integration Status
+
+`NativeAssayBackend` is pre-consumer foundation in this slice. The hidden
+experimental CLI exercises the planner/store/verifier path, and tests assert
+that the native backend satisfies the `DerivedBackend` protocol, but no
+production caller outside `assay.derived` consumes that protocol yet.
+
+The first non-test integration must name its caller before this work is claimed
+as a wired backend integration.
+
+## CocoIndex
+
+CocoIndex and similar tools may be evaluated as replaceable backends for
+incremental processing. They may not become constitutional infrastructure unless
+they satisfy the Assay receipt and lineage contract.
+
+## Consequences
+
+This may be slower than direct indexing, but it preserves auditability,
+rebuildability, and trust boundaries.
+
+The first native implementation intentionally excludes CocoIndex, embeddings,
+LLM summaries, provider calls, background daemons, live watchers, and MemoryGraph
+writes.

--- a/docs/derived-context-quickstart.md
+++ b/docs/derived-context-quickstart.md
@@ -1,0 +1,107 @@
+# Receipted Derived Context Quickstart
+
+Receipted Derived Context treats generated context as evidence-bearing state.
+The first native backend is deterministic and local:
+
+```text
+local files -> source snapshots -> line chunks -> receipts -> verify
+```
+
+No CocoIndex, embeddings, LLM calls, MemoryGraph writes, providers, watchers, or
+daemon mode are involved in this flow.
+
+## Commands
+
+Scan a repository path:
+
+```bash
+assay derived scan .
+```
+
+Preview proposed derived-state changes:
+
+```bash
+assay derived plan .
+```
+
+Commit the staged plan transactionally:
+
+```bash
+assay derived apply .
+```
+
+Explain a committed artifact:
+
+```bash
+assay derived explain art_91f3c4...
+```
+
+Verify a receipt:
+
+```bash
+assay derived verify drcpt_f640c9...
+```
+
+## Reviewer-Readable Explain Output
+
+Example shape:
+
+```json
+{
+  "status": "ok",
+  "explain": {
+    "artifact": {
+      "artifact_id": "art_91f3c4...",
+      "artifact_type": "source_chunk",
+      "source_snapshot_id": "snap_a80d7b...",
+      "transform_id": "xfm_78ae13...",
+      "output_hash": "sha256:...",
+      "receipt_id": "drcpt_f640c9...",
+      "derivation_verification_level": "DV1",
+      "status": "active"
+    },
+    "source": {
+      "source_type": "local_file",
+      "uri": "file://src/example.py"
+    },
+    "transform": {
+      "name": "line_chunker",
+      "version": "0.1.0",
+      "code_hash": "sha256:...",
+      "config_hash": "sha256:...",
+      "runtime_hash": "sha256:..."
+    },
+    "receipt": {
+      "kind": "derived.artifact.created",
+      "subject_id": "art_91f3c4...",
+      "output_hash": "sha256:...",
+      "derivation_verification_level": "DV1",
+      "metadata": {
+        "receipt_schema_version": "1"
+      }
+    }
+  }
+}
+```
+
+`verify` recomputes deterministic source chunks and checks that the receipt JSON,
+receipt ID, committed artifact, transform, source snapshots, input artifacts, and
+derivation verification level are internally consistent.
+
+## Trust Boundary
+
+This MVP emits T0 derived-context receipts: JCS-canonical, digest-locked,
+structurally verified, and self-attested. They are not T1/Tier 3 evidence until
+wrapped by a signed Assay proof-pack or another explicit signing path.
+
+## Backend Boundary
+
+The native backend is the authority-preserving implementation for this MVP.
+CocoIndex may later be evaluated as a `DerivedBackend`, but only as a proposal
+engine. Assay receipts and committed state remain authority; Guardian controls
+commitment.
+
+`DerivedBackend` is a pre-consumer protocol in this slice. The hidden
+experimental CLI exercises the native planner/store/verifier path directly; the
+first production caller of `DerivedBackend` must be named before claiming wired
+backend integration.

--- a/docs/outbound/START_HERE.md
+++ b/docs/outbound/START_HERE.md
@@ -9,7 +9,7 @@ surviving runs into auditable evidence.
 
 ### Engineering lead / VP Eng
 
-Watch the 60-second demo. It shows an apparent +11.1% gain get denied because the
+Run the 60-second demo. It shows an apparent +11.1% gain get denied because the
 judge drifted, then a rerun under pinned config reveals the real improvement is +4.7%.
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ where = ["src"]
 include = ["assay*"]
 
 [tool.setuptools.package-data]
-assay = ["schemas/*.json", "contracts/*.yaml"]
+assay = ["schemas/*.json", "contracts/*.yaml", "derived/*.sql"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/src/assay/commands.py
+++ b/src/assay/commands.py
@@ -59,6 +59,7 @@ from typing import Any, Dict, List, Optional
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import typer
+from assay.derived.cli import derived_app
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
@@ -14299,6 +14300,10 @@ def _render_constitutional_diff(diff, contract) -> None:
         )
 
     console.print()
+
+assay_app.add_typer(
+    derived_app, name="derived", hidden=True, rich_help_panel="Advanced"
+)
 
 
 def main():

--- a/src/assay/derived/__init__.py
+++ b/src/assay/derived/__init__.py
@@ -1,0 +1,33 @@
+"""Receipted Derived Context for Assay.
+
+This package is intentionally native-first. CocoIndex and similar systems may
+later implement the backend contract, but they are not authority here.
+"""
+
+from assay.derived.models import (
+    ArtifactInput,
+    ArtifactTombstone,
+    DerivationReceipt,
+    DerivedArtifact,
+    IndexUpdatePlan,
+    Source,
+    SourceSnapshot,
+    TransformSpec,
+    VerificationResult,
+)
+from assay.derived.backends import DerivedBackend, IndexBackend, NativeAssayBackend
+
+__all__ = [
+    "ArtifactInput",
+    "ArtifactTombstone",
+    "DerivationReceipt",
+    "DerivedArtifact",
+    "IndexUpdatePlan",
+    "Source",
+    "SourceSnapshot",
+    "TransformSpec",
+    "VerificationResult",
+    "DerivedBackend",
+    "IndexBackend",
+    "NativeAssayBackend",
+]

--- a/src/assay/derived/backends.py
+++ b/src/assay/derived/backends.py
@@ -1,0 +1,85 @@
+"""Backend contract for receipted derived context."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
+
+from assay.derived.models import IndexUpdatePlan, SourceSnapshot, VerificationResult
+from assay.derived.planner import apply_derived_context, plan_derived_context
+from assay.derived.scanner import scan_repository
+from assay.derived.store import DerivedStore
+from assay.derived.transforms import (
+    DEFAULT_CHUNKER_VERSION,
+    DEFAULT_MAX_LINES,
+    line_chunk_transform_spec,
+)
+from assay.derived.verifier import verify_receipt
+
+
+@runtime_checkable
+class DerivedBackend(Protocol):
+    """Contract that any derived-context engine must satisfy."""
+
+    def scan(self, root: Path) -> List[SourceSnapshot]: ...
+
+    def plan(self, root: Path) -> IndexUpdatePlan: ...
+
+    def apply(self, root: Path) -> IndexUpdatePlan: ...
+
+    def explain(self, artifact_id: str) -> Optional[Dict[str, Any]]: ...
+
+    def verify(self, receipt_id: str) -> VerificationResult: ...
+
+
+IndexBackend = DerivedBackend
+
+
+class NativeAssayBackend:
+    """Native deterministic backend for the Assay receipt contract.
+
+    TODO: evaluate CocoIndex later as a DerivedBackend implementation. It must
+    export receipt-grade lineage and remain a proposal engine, not authority.
+    """
+
+    def __init__(
+        self,
+        store: DerivedStore,
+        *,
+        chunk_lines: int = DEFAULT_MAX_LINES,
+        chunker_version: str = DEFAULT_CHUNKER_VERSION,
+    ) -> None:
+        self.store = store
+        self.chunk_lines = chunk_lines
+        self.chunker_version = chunker_version
+
+    def scan(self, root: Path) -> List[SourceSnapshot]:
+        return [item.snapshot for item in scan_repository(Path(root))]
+
+    def plan(self, root: Path) -> IndexUpdatePlan:
+        transform = line_chunk_transform_spec(
+            version=self.chunker_version, max_lines=self.chunk_lines
+        )
+        return plan_derived_context(
+            Path(root),
+            self.store,
+            transform=transform,
+            max_lines=self.chunk_lines,
+        )
+
+    def apply(self, root: Path) -> IndexUpdatePlan:
+        transform = line_chunk_transform_spec(
+            version=self.chunker_version, max_lines=self.chunk_lines
+        )
+        return apply_derived_context(
+            Path(root),
+            self.store,
+            transform=transform,
+            max_lines=self.chunk_lines,
+        )
+
+    def explain(self, artifact_id: str) -> Optional[Dict[str, Any]]:
+        return self.store.explain_artifact(artifact_id)
+
+    def verify(self, receipt_id: str) -> VerificationResult:
+        return verify_receipt(self.store, receipt_id)

--- a/src/assay/derived/cli.py
+++ b/src/assay/derived/cli.py
@@ -1,0 +1,210 @@
+"""Experimental CLI for Assay receipted derived context."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import typer
+
+from assay.derived.planner import apply_derived_context, plan_derived_context
+from assay.derived.scanner import scan_repository
+from assay.derived.store import DerivedStore
+from assay.derived.transforms import (
+    DEFAULT_CHUNKER_VERSION,
+    DEFAULT_MAX_LINES,
+    line_chunk_transform_spec,
+)
+from assay.derived.verifier import verify_receipt
+
+
+derived_app = typer.Typer(
+    help="Experimental receipted derived context commands.",
+    no_args_is_help=True,
+)
+
+
+@derived_app.command("scan")
+def scan_command(
+    path: Path = typer.Argument(..., exists=True, file_okay=False, dir_okay=True),
+) -> None:
+    snapshots = scan_repository(path)
+    _emit(
+        {
+            "status": "ok",
+            "root": str(path.resolve()),
+            "snapshot_count": len(snapshots),
+            "snapshots": [
+                _snapshot_output(item.snapshot.to_dict()) for item in snapshots
+            ],
+        }
+    )
+
+
+@derived_app.command("plan")
+def plan_command(
+    path: Path = typer.Argument(..., exists=True, file_okay=False, dir_okay=True),
+    db: Optional[Path] = typer.Option(None, "--db", help="SQLite store path."),
+    chunk_lines: int = typer.Option(
+        DEFAULT_MAX_LINES, "--chunk-lines", help="Maximum lines per source chunk."
+    ),
+    chunker_version: str = typer.Option(
+        DEFAULT_CHUNKER_VERSION,
+        "--chunker-version",
+        help="Line chunker transform version.",
+    ),
+) -> None:
+    store = _store_for_path(path, db)
+    transform = line_chunk_transform_spec(
+        version=chunker_version, max_lines=chunk_lines
+    )
+    plan = plan_derived_context(path, store, transform=transform, max_lines=chunk_lines)
+    store.put_plan(plan)
+    _emit(_plan_output(plan, store))
+
+
+@derived_app.command("apply")
+def apply_command(
+    path: Path = typer.Argument(..., exists=True, file_okay=False, dir_okay=True),
+    db: Optional[Path] = typer.Option(None, "--db", help="SQLite store path."),
+    chunk_lines: int = typer.Option(
+        DEFAULT_MAX_LINES, "--chunk-lines", help="Maximum lines per source chunk."
+    ),
+    chunker_version: str = typer.Option(
+        DEFAULT_CHUNKER_VERSION,
+        "--chunker-version",
+        help="Line chunker transform version.",
+    ),
+) -> None:
+    store = _store_for_path(path, db)
+    transform = line_chunk_transform_spec(
+        version=chunker_version, max_lines=chunk_lines
+    )
+    plan = apply_derived_context(
+        path, store, transform=transform, max_lines=chunk_lines
+    )
+    _emit(_plan_output(plan, store))
+
+
+@derived_app.command("explain")
+def explain_command(
+    artifact_id: str = typer.Argument(...),
+    db: Optional[Path] = typer.Option(None, "--db", help="SQLite store path."),
+) -> None:
+    store = _store_for_current_dir(db)
+    explanation = store.explain_artifact(artifact_id)
+    if explanation is None:
+        _emit({"status": "missing", "artifact_id": artifact_id})
+        raise typer.Exit(1)
+    _emit({"status": "ok", "explain": _redact_explanation(explanation)})
+
+
+@derived_app.command("verify")
+def verify_command(
+    receipt_id: str = typer.Argument(...),
+    db: Optional[Path] = typer.Option(None, "--db", help="SQLite store path."),
+) -> None:
+    store = _store_for_current_dir(db)
+    result = verify_receipt(store, receipt_id)
+    _emit({"status": "ok" if result.ok else "failed", "verification": result.to_dict()})
+    if not result.ok:
+        raise typer.Exit(2)
+
+
+def _store_for_path(path: Path, db: Optional[Path]) -> DerivedStore:
+    return DerivedStore((db or _default_db(path)).resolve())
+
+
+def _store_for_current_dir(db: Optional[Path]) -> DerivedStore:
+    return DerivedStore((db or _default_db(Path.cwd())).resolve())
+
+
+def _default_db(root: Path) -> Path:
+    return root.resolve() / ".assay" / "derived.sqlite"
+
+
+def _emit(data: Dict[str, Any]) -> None:
+    print(json.dumps(data, indent=2, default=str))
+
+
+def _plan_output(plan, store: DerivedStore) -> Dict[str, Any]:
+    return {
+        "status": "ok",
+        "db": str(store.path),
+        "plan": {
+            "plan_id": plan.plan_id,
+            "root": plan.root,
+            "previous_state_hash": plan.previous_state_hash,
+            "proposed_state_hash": plan.proposed_state_hash,
+            "added_count": plan.added_count,
+            "updated_count": plan.updated_count,
+            "deleted_count": plan.deleted_count,
+            "operation_count": len(plan.operations),
+            "operations": [_operation_summary(op) for op in plan.operations],
+        },
+    }
+
+
+def _operation_summary(operation: Dict[str, Any]) -> Dict[str, Any]:
+    op_type = operation["type"]
+    summary: Dict[str, Any] = {"type": op_type}
+    if op_type == "add_artifact":
+        artifact = operation["artifact"]
+        summary.update(
+            {
+                "artifact_id": artifact["artifact_id"],
+                "artifact_type": artifact["artifact_type"],
+                "source_snapshot_id": artifact["source_snapshot_id"],
+                "receipt_id": artifact["receipt_id"],
+            }
+        )
+    elif op_type in {"stale_artifact", "tombstone_artifact"}:
+        summary["artifact_id"] = operation["artifact_id"]
+        summary["receipt_id"] = operation["receipt"]["receipt_id"]
+    elif op_type == "add_snapshot":
+        summary["snapshot_id"] = operation["snapshot"]["snapshot_id"]
+    elif op_type == "upsert_source":
+        summary["source_id"] = operation["source"]["source_id"]
+        summary["uri"] = operation["source"]["uri"]
+    elif op_type == "add_transform":
+        summary["transform_id"] = operation["transform"]["transform_id"]
+    return summary
+
+
+def _snapshot_output(snapshot: Dict[str, Any]) -> Dict[str, Any]:
+    metadata = dict(snapshot.get("metadata", {}))
+    metadata.pop("content_text", None)
+    snapshot = dict(snapshot)
+    snapshot["metadata"] = metadata
+    return snapshot
+
+
+def _redact_explanation(explanation: Dict[str, Any]) -> Dict[str, Any]:
+    result = json.loads(json.dumps(explanation, default=str))
+    source_snapshot = result.get("source_snapshot")
+    if source_snapshot:
+        source_snapshot["metadata"] = _metadata_preview(
+            source_snapshot.get("metadata", {})
+        )
+    artifact = result.get("artifact")
+    if artifact:
+        artifact["metadata"] = _metadata_preview(artifact.get("metadata", {}))
+    return result
+
+
+def _metadata_preview(metadata: Dict[str, Any]) -> Dict[str, Any]:
+    result = dict(metadata)
+    content_text = result.pop("content_text", None)
+    chunk_text = result.pop("text", None)
+    if isinstance(content_text, str):
+        result["content_text_preview"] = _preview(content_text)
+    if isinstance(chunk_text, str):
+        result["text_preview"] = _preview(chunk_text)
+    return result
+
+
+def _preview(text: str, limit: int = 160) -> str:
+    if len(text) <= limit:
+        return text
+    return text[:limit] + "..."

--- a/src/assay/derived/hashing.py
+++ b/src/assay/derived/hashing.py
@@ -1,0 +1,42 @@
+"""Hashing helpers for receipted derived context.
+
+Human JSON is for reading. JCS bytes are for IDs, hashes, signatures, and
+receipts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any, Mapping
+
+from assay._receipts.jcs import canonicalize as jcs_canonicalize
+
+
+def sha256_bytes(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def sha256_text(text: str) -> str:
+    return sha256_bytes(text.encode("utf-8"))
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            h.update(chunk)
+    return "sha256:" + h.hexdigest()
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return jcs_canonicalize(value)
+
+
+def canonical_hash(value: Any) -> str:
+    return sha256_bytes(canonical_bytes(value))
+
+
+def stable_id(prefix: str, payload: Mapping[str, Any], length: int = 24) -> str:
+    digest = canonical_hash(dict(payload)).split(":", 1)[1]
+    return f"{prefix}_{digest[:length]}"

--- a/src/assay/derived/models.py
+++ b/src/assay/derived/models.py
@@ -1,0 +1,150 @@
+"""Data models for Assay receipted derived context."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+
+DERIVED_SCHEMA_VERSION = "1"
+RECEIPT_SCHEMA_VERSION = "1"
+DERIVATION_LEVELS = ("DV0", "DV1", "DV2", "DV3", "DV4")
+RECEIPT_KINDS = (
+    "derived.artifact.created",
+    "derived.artifact.staled",
+    "derived.artifact.tombstoned",
+)
+
+
+@dataclass(frozen=True)
+class Source:
+    source_id: str
+    source_type: str
+    uri: str
+    first_seen_at: str
+    last_seen_at: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class SourceSnapshot:
+    snapshot_id: str
+    source_id: str
+    content_hash: str
+    size_bytes: int
+    observed_at: str
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class TransformSpec:
+    transform_id: str
+    name: str
+    version: str
+    code_hash: str
+    config_hash: str
+    runtime_hash: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ArtifactInput:
+    artifact_id: str
+    input_artifact_id: str
+    input_role: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class DerivedArtifact:
+    artifact_id: str
+    artifact_type: str
+    source_snapshot_id: Optional[str]
+    input_artifact_ids: Tuple[str, ...]
+    transform_id: str
+    output_hash: str
+    receipt_id: str
+    derivation_verification_level: str
+    status: str
+    created_at: str
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data["input_artifact_ids"] = list(self.input_artifact_ids)
+        return data
+
+
+@dataclass(frozen=True)
+class DerivationReceipt:
+    receipt_id: str
+    kind: str
+    subject_id: str
+    source_snapshot_ids: Tuple[str, ...]
+    input_artifact_ids: Tuple[str, ...]
+    transform_id: str
+    output_hash: str
+    derivation_verification_level: str
+    status: str
+    created_at: str
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data["source_snapshot_ids"] = list(self.source_snapshot_ids)
+        data["input_artifact_ids"] = list(self.input_artifact_ids)
+        return data
+
+
+@dataclass(frozen=True)
+class ArtifactTombstone:
+    artifact_id: str
+    reason: str
+    tombstoned_at: str
+    receipt_id: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class IndexUpdatePlan:
+    plan_id: str
+    previous_state_hash: Optional[str]
+    proposed_state_hash: str
+    added_count: int
+    updated_count: int
+    deleted_count: int
+    created_at: str
+    root: str
+    transform_id: str
+    operations: List[Dict[str, Any]]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    receipt_id: str
+    subject_id: str
+    ok: bool
+    derivation_verification_level: str
+    status: str
+    errors: Tuple[str, ...] = ()
+    expected_output_hash: Optional[str] = None
+    actual_output_hash: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data["errors"] = list(self.errors)
+        return data

--- a/src/assay/derived/planner.py
+++ b/src/assay/derived/planner.py
@@ -1,0 +1,326 @@
+"""Planner for native receipted derived context."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Set
+
+from assay.derived.hashing import canonical_hash, stable_id
+from assay.derived.models import (
+    DerivedArtifact,
+    IndexUpdatePlan,
+    Source,
+    TransformSpec,
+)
+from assay.derived.receipts import make_derivation_receipt, now_iso
+from assay.derived.scanner import ScannedSnapshot, scan_repository
+from assay.derived.store import DerivedStore
+from assay.derived.transforms import (
+    DEFAULT_MAX_LINES,
+    TextChunk,
+    chunk_lines,
+    line_chunk_transform_spec,
+)
+
+
+TIME_KEYS = {
+    "created_at",
+    "observed_at",
+    "first_seen_at",
+    "last_seen_at",
+    "tombstoned_at",
+}
+
+
+def artifact_id_for_chunk(snapshot_id: str, transform_id: str, chunk: TextChunk) -> str:
+    return stable_id(
+        "art",
+        {
+            "artifact_type": "source_chunk",
+            "source_snapshot_id": snapshot_id,
+            "transform_id": transform_id,
+            "chunk_index": chunk.chunk_index,
+            "output_hash": chunk.output_hash,
+        },
+    )
+
+
+def plan_derived_context(
+    root: Path,
+    store: DerivedStore,
+    *,
+    transform: Optional[TransformSpec] = None,
+    max_lines: int = DEFAULT_MAX_LINES,
+) -> IndexUpdatePlan:
+    """Build a staged derived-context plan without mutating committed artifacts."""
+
+    root = Path(root).resolve()
+    if not root.exists() or not root.is_dir():
+        raise FileNotFoundError(f"derived scan root does not exist: {root}")
+
+    transform_spec = transform or line_chunk_transform_spec(max_lines=max_lines)
+    created_at = now_iso()
+    scanned = scan_repository(root, observed_at=created_at)
+    active_records = store.list_active_artifacts_with_sources()
+    active_ids = {record["artifact"].artifact_id for record in active_records}
+
+    operations: List[Dict[str, Any]] = []
+    proposed_artifacts: List[DerivedArtifact] = []
+    proposed_ids: Set[str] = set()
+    scanned_source_ids = {item.snapshot.source_id for item in scanned}
+
+    if not store.has_transform(transform_spec.transform_id):
+        operations.append(
+            {"type": "add_transform", "transform": transform_spec.to_dict()}
+        )
+
+    for item in scanned:
+        source = _source_for_scanned(item, store, created_at)
+        operations.append({"type": "upsert_source", "source": source.to_dict()})
+        if not store.has_snapshot(item.snapshot.snapshot_id):
+            operations.append(
+                {"type": "add_snapshot", "snapshot": item.snapshot.to_dict()}
+            )
+        for artifact in _artifacts_for_snapshot(
+            item, transform_spec, max_lines=max_lines, created_at=created_at
+        ):
+            proposed_artifacts.append(artifact)
+            proposed_ids.add(artifact.artifact_id)
+            if artifact.artifact_id not in active_ids:
+                operations.append(
+                    {
+                        "type": "add_artifact",
+                        "artifact": artifact.to_dict(),
+                        "inputs": [],
+                        "receipt": _creation_receipt(
+                            artifact, item, transform_spec, created_at
+                        ).to_dict(),
+                    }
+                )
+
+    for record in active_records:
+        artifact = record["artifact"]
+        if artifact.artifact_id in proposed_ids:
+            continue
+        if record["source_id"] not in scanned_source_ids:
+            receipt = _tombstone_receipt(artifact, created_at)
+            operations.append(
+                {
+                    "type": "tombstone_artifact",
+                    "artifact_id": artifact.artifact_id,
+                    "tombstone": {
+                        "artifact_id": artifact.artifact_id,
+                        "reason": "source_disappeared",
+                        "tombstoned_at": created_at,
+                        "receipt_id": receipt.receipt_id,
+                    },
+                    "receipt": receipt.to_dict(),
+                }
+            )
+        else:
+            receipt = _stale_receipt(artifact, created_at)
+            operations.append(
+                {
+                    "type": "stale_artifact",
+                    "artifact_id": artifact.artifact_id,
+                    "receipt": receipt.to_dict(),
+                }
+            )
+
+    previous_state_hash = _state_hash([record["artifact"] for record in active_records])
+    proposed_state_hash = _state_hash(proposed_artifacts)
+    identity_payload = {
+        "root": str(root),
+        "previous_state_hash": previous_state_hash,
+        "proposed_state_hash": proposed_state_hash,
+        "operations": [_strip_times(operation) for operation in operations],
+    }
+    plan_id = stable_id("dplan", identity_payload)
+    return IndexUpdatePlan(
+        plan_id=plan_id,
+        previous_state_hash=previous_state_hash,
+        proposed_state_hash=proposed_state_hash,
+        added_count=sum(1 for op in operations if op["type"] == "add_artifact"),
+        updated_count=sum(1 for op in operations if op["type"] == "stale_artifact"),
+        deleted_count=sum(1 for op in operations if op["type"] == "tombstone_artifact"),
+        created_at=created_at,
+        root=str(root),
+        transform_id=transform_spec.transform_id,
+        operations=operations,
+    )
+
+
+def apply_derived_context(
+    root: Path,
+    store: DerivedStore,
+    *,
+    transform: Optional[TransformSpec] = None,
+    max_lines: int = DEFAULT_MAX_LINES,
+    fail_after_operations: Optional[int] = None,
+) -> IndexUpdatePlan:
+    plan = plan_derived_context(root, store, transform=transform, max_lines=max_lines)
+    store.apply_plan(plan, fail_after_operations=fail_after_operations)
+    return plan
+
+
+def _source_for_scanned(
+    item: ScannedSnapshot, store: DerivedStore, observed_at: str
+) -> Source:
+    existing = store.get_source(item.snapshot.source_id)
+    return Source(
+        source_id=item.snapshot.source_id,
+        source_type=item.source_type,
+        uri=item.uri,
+        first_seen_at=existing.first_seen_at if existing else observed_at,
+        last_seen_at=observed_at,
+    )
+
+
+def _artifacts_for_snapshot(
+    item: ScannedSnapshot,
+    transform: TransformSpec,
+    *,
+    max_lines: int,
+    created_at: str,
+) -> List[DerivedArtifact]:
+    content = item.snapshot.metadata.get("content_text", "")
+    artifacts: List[DerivedArtifact] = []
+    for chunk in chunk_lines(content, max_lines=max_lines):
+        artifact_id = artifact_id_for_chunk(
+            item.snapshot.snapshot_id, transform.transform_id, chunk
+        )
+        metadata = {
+            "relative_path": item.relative_path,
+            "chunk_index": chunk.chunk_index,
+            "start_line": chunk.start_line,
+            "end_line": chunk.end_line,
+            "text": chunk.text,
+            "transform_config": {"max_lines": max_lines},
+        }
+        receipt = make_derivation_receipt(
+            kind="derived.artifact.created",
+            subject_id=artifact_id,
+            source_snapshot_ids=[item.snapshot.snapshot_id],
+            input_artifact_ids=[],
+            transform_id=transform.transform_id,
+            output_hash=chunk.output_hash,
+            derivation_verification_level="DV1",
+            status="committed",
+            created_at=created_at,
+            metadata={
+                "artifact_type": "source_chunk",
+                "relative_path": item.relative_path,
+                "chunk_index": chunk.chunk_index,
+                "transform_config": {"max_lines": max_lines},
+                "transform": transform.to_dict(),
+            },
+        )
+        artifacts.append(
+            DerivedArtifact(
+                artifact_id=artifact_id,
+                artifact_type="source_chunk",
+                source_snapshot_id=item.snapshot.snapshot_id,
+                input_artifact_ids=(),
+                transform_id=transform.transform_id,
+                output_hash=chunk.output_hash,
+                receipt_id=receipt.receipt_id,
+                derivation_verification_level="DV1",
+                status="active",
+                created_at=created_at,
+                metadata=metadata,
+            )
+        )
+    return artifacts
+
+
+def _creation_receipt(
+    artifact: DerivedArtifact,
+    item: ScannedSnapshot,
+    transform: TransformSpec,
+    created_at: str,
+):
+    return make_derivation_receipt(
+        kind="derived.artifact.created",
+        subject_id=artifact.artifact_id,
+        source_snapshot_ids=[item.snapshot.snapshot_id],
+        input_artifact_ids=[],
+        transform_id=artifact.transform_id,
+        output_hash=artifact.output_hash,
+        derivation_verification_level="DV1",
+        status="committed",
+        created_at=created_at,
+        metadata={
+            "artifact_type": artifact.artifact_type,
+            "relative_path": item.relative_path,
+            "chunk_index": artifact.metadata.get("chunk_index"),
+            "transform_config": artifact.metadata.get("transform_config", {}),
+            "transform": transform.to_dict(),
+        },
+    )
+
+
+def _stale_receipt(artifact: DerivedArtifact, created_at: str):
+    return make_derivation_receipt(
+        kind="derived.artifact.staled",
+        subject_id=artifact.artifact_id,
+        source_snapshot_ids=(
+            [artifact.source_snapshot_id] if artifact.source_snapshot_id else []
+        ),
+        input_artifact_ids=artifact.input_artifact_ids,
+        transform_id=artifact.transform_id,
+        output_hash=artifact.output_hash,
+        derivation_verification_level="DV1",
+        status="committed",
+        created_at=created_at,
+        metadata={
+            "reason": "source_snapshot_or_transform_changed",
+            "previous_status": artifact.status,
+        },
+    )
+
+
+def _tombstone_receipt(artifact: DerivedArtifact, created_at: str):
+    return make_derivation_receipt(
+        kind="derived.artifact.tombstoned",
+        subject_id=artifact.artifact_id,
+        source_snapshot_ids=(
+            [artifact.source_snapshot_id] if artifact.source_snapshot_id else []
+        ),
+        input_artifact_ids=artifact.input_artifact_ids,
+        transform_id=artifact.transform_id,
+        output_hash=artifact.output_hash,
+        derivation_verification_level="DV1",
+        status="committed",
+        created_at=created_at,
+        metadata={"reason": "source_disappeared", "previous_status": artifact.status},
+    )
+
+
+def _state_hash(artifacts: Sequence[DerivedArtifact]) -> str:
+    records = []
+    for artifact in sorted(artifacts, key=lambda item: item.artifact_id):
+        records.append(
+            {
+                "artifact_id": artifact.artifact_id,
+                "artifact_type": artifact.artifact_type,
+                "source_snapshot_id": artifact.source_snapshot_id,
+                "input_artifact_ids": list(artifact.input_artifact_ids),
+                "transform_id": artifact.transform_id,
+                "output_hash": artifact.output_hash,
+                "derivation_verification_level": artifact.derivation_verification_level,
+                "status": artifact.status,
+            }
+        )
+    return canonical_hash(records)
+
+
+def _strip_times(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _strip_times(item)
+            for key, item in value.items()
+            if key not in TIME_KEYS
+        }
+    if isinstance(value, list):
+        return [_strip_times(item) for item in value]
+    return value

--- a/src/assay/derived/receipts.py
+++ b/src/assay/derived/receipts.py
@@ -1,0 +1,73 @@
+"""Receipt construction helpers for derived context."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Sequence
+
+from assay.derived.hashing import stable_id
+from assay.derived.models import DerivationReceipt, RECEIPT_SCHEMA_VERSION
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def make_derivation_receipt(
+    *,
+    kind: str,
+    subject_id: str,
+    source_snapshot_ids: Sequence[str],
+    input_artifact_ids: Sequence[str],
+    transform_id: str,
+    output_hash: str,
+    derivation_verification_level: str,
+    status: str,
+    created_at: str,
+    metadata: Dict[str, Any],
+) -> DerivationReceipt:
+    """Build a receipt with a deterministic ID that excludes timestamps."""
+
+    metadata = dict(metadata)
+    metadata.setdefault("receipt_schema_version", RECEIPT_SCHEMA_VERSION)
+    receipt_id = receipt_id_for_payload(
+        {
+            "kind": kind,
+            "subject_id": subject_id,
+            "source_snapshot_ids": list(source_snapshot_ids),
+            "input_artifact_ids": list(input_artifact_ids),
+            "transform_id": transform_id,
+            "output_hash": output_hash,
+            "derivation_verification_level": derivation_verification_level,
+            "status": status,
+            "metadata": metadata,
+        }
+    )
+    return DerivationReceipt(
+        receipt_id=receipt_id,
+        kind=kind,
+        subject_id=subject_id,
+        source_snapshot_ids=tuple(source_snapshot_ids),
+        input_artifact_ids=tuple(input_artifact_ids),
+        transform_id=transform_id,
+        output_hash=output_hash,
+        derivation_verification_level=derivation_verification_level,
+        status=status,
+        created_at=created_at,
+        metadata=metadata,
+    )
+
+
+def receipt_id_for_payload(payload: Dict[str, Any]) -> str:
+    id_payload = {
+        "kind": payload["kind"],
+        "subject_id": payload["subject_id"],
+        "source_snapshot_ids": list(payload.get("source_snapshot_ids", [])),
+        "input_artifact_ids": list(payload.get("input_artifact_ids", [])),
+        "transform_id": payload.get("transform_id", ""),
+        "output_hash": payload.get("output_hash", ""),
+        "derivation_verification_level": payload["derivation_verification_level"],
+        "status": payload["status"],
+        "metadata": payload.get("metadata", {}),
+    }
+    return stable_id("drcpt", id_payload)

--- a/src/assay/derived/scanner.py
+++ b/src/assay/derived/scanner.py
@@ -1,0 +1,116 @@
+"""Deterministic local-file scanner for receipted derived context."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence
+
+from assay.derived.hashing import sha256_bytes, stable_id
+from assay.derived.models import SourceSnapshot
+
+
+DEFAULT_INCLUDE_SUFFIXES = (".py", ".md", ".txt")
+DEFAULT_EXCLUDES = (
+    ".git",
+    ".assay",
+    "__pycache__",
+    ".venv",
+    ".pytest_cache",
+    "dist",
+    "build",
+)
+
+
+@dataclass(frozen=True)
+class ScannedSnapshot:
+    snapshot: SourceSnapshot
+    source_type: str
+    uri: str
+    relative_path: str
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def source_id_for_uri(uri: str, source_type: str = "local_file") -> str:
+    return stable_id("src", {"source_type": source_type, "uri": uri})
+
+
+def snapshot_id_for_source(source_id: str, content_hash: str) -> str:
+    return stable_id("snap", {"source_id": source_id, "content_hash": content_hash})
+
+
+def should_exclude(path: Path, root: Path, excludes: Sequence[str]) -> bool:
+    try:
+        relative = path.relative_to(root)
+    except ValueError:
+        return True
+    return any(part in excludes for part in relative.parts)
+
+
+def iter_source_files(
+    root: Path,
+    *,
+    include_suffixes: Sequence[str] = DEFAULT_INCLUDE_SUFFIXES,
+    excludes: Sequence[str] = DEFAULT_EXCLUDES,
+) -> Iterable[Path]:
+    root = root.resolve()
+    suffixes = tuple(include_suffixes)
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        if should_exclude(path, root, excludes):
+            continue
+        if path.suffix not in suffixes:
+            continue
+        yield path
+
+
+def scan_repository(
+    root: Path,
+    *,
+    include_suffixes: Sequence[str] = DEFAULT_INCLUDE_SUFFIXES,
+    excludes: Sequence[str] = DEFAULT_EXCLUDES,
+    observed_at: Optional[str] = None,
+) -> List[ScannedSnapshot]:
+    root = root.resolve()
+    observed = observed_at or _now_iso()
+    scanned: List[ScannedSnapshot] = []
+    for path in iter_source_files(
+        root, include_suffixes=include_suffixes, excludes=excludes
+    ):
+        relative_path = path.relative_to(root).as_posix()
+        content = path.read_bytes()
+        try:
+            content_text = content.decode("utf-8")
+            encoding = "utf-8"
+        except UnicodeDecodeError:
+            continue
+        content_hash = sha256_bytes(content)
+        uri = f"file://{relative_path}"
+        source_id = source_id_for_uri(uri)
+        snapshot = SourceSnapshot(
+            snapshot_id=snapshot_id_for_source(source_id, content_hash),
+            source_id=source_id,
+            content_hash=content_hash,
+            size_bytes=len(content),
+            observed_at=observed,
+            metadata={
+                "relative_path": relative_path,
+                "uri": uri,
+                "encoding": encoding,
+                "content_text": content_text,
+            },
+        )
+        scanned.append(
+            ScannedSnapshot(
+                snapshot=snapshot,
+                source_type="local_file",
+                uri=uri,
+                relative_path=relative_path,
+            )
+        )
+    return scanned

--- a/src/assay/derived/schema.sql
+++ b/src/assay/derived/schema.sql
@@ -1,0 +1,84 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS store_metadata (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sources (
+  source_id TEXT PRIMARY KEY,
+  source_type TEXT NOT NULL,
+  uri TEXT NOT NULL,
+  first_seen_at TEXT NOT NULL,
+  last_seen_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS source_snapshots (
+  snapshot_id TEXT PRIMARY KEY,
+  source_id TEXT NOT NULL,
+  content_hash TEXT NOT NULL,
+  size_bytes INTEGER NOT NULL,
+  observed_at TEXT NOT NULL,
+  metadata_json TEXT NOT NULL,
+  FOREIGN KEY (source_id) REFERENCES sources(source_id)
+);
+
+CREATE TABLE IF NOT EXISTS transforms (
+  transform_id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  version TEXT NOT NULL,
+  code_hash TEXT NOT NULL,
+  config_hash TEXT NOT NULL,
+  runtime_hash TEXT
+);
+
+CREATE TABLE IF NOT EXISTS derived_artifacts (
+  artifact_id TEXT PRIMARY KEY,
+  artifact_type TEXT NOT NULL,
+  source_snapshot_id TEXT,
+  transform_id TEXT NOT NULL,
+  output_hash TEXT NOT NULL,
+  receipt_id TEXT NOT NULL,
+  derivation_verification_level TEXT NOT NULL,
+  status TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  metadata_json TEXT NOT NULL,
+  FOREIGN KEY (source_snapshot_id) REFERENCES source_snapshots(snapshot_id),
+  FOREIGN KEY (transform_id) REFERENCES transforms(transform_id)
+);
+
+CREATE TABLE IF NOT EXISTS artifact_inputs (
+  artifact_id TEXT NOT NULL,
+  input_artifact_id TEXT NOT NULL,
+  input_role TEXT NOT NULL,
+  PRIMARY KEY (artifact_id, input_artifact_id, input_role)
+);
+
+CREATE TABLE IF NOT EXISTS receipts (
+  receipt_id TEXT PRIMARY KEY,
+  kind TEXT NOT NULL,
+  subject_id TEXT NOT NULL,
+  derivation_verification_level TEXT NOT NULL,
+  status TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  receipt_json TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS index_update_plans (
+  plan_id TEXT PRIMARY KEY,
+  previous_state_hash TEXT,
+  proposed_state_hash TEXT NOT NULL,
+  added_count INTEGER NOT NULL,
+  updated_count INTEGER NOT NULL,
+  deleted_count INTEGER NOT NULL,
+  created_at TEXT NOT NULL,
+  plan_json TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS artifact_tombstones (
+  artifact_id TEXT PRIMARY KEY,
+  reason TEXT NOT NULL,
+  tombstoned_at TEXT NOT NULL,
+  receipt_id TEXT NOT NULL
+);

--- a/src/assay/derived/store.py
+++ b/src/assay/derived/store.py
@@ -1,0 +1,654 @@
+"""SQLite store for Assay receipted derived context."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import contextmanager
+from importlib import resources
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional
+
+from assay.derived.models import (
+    ArtifactTombstone,
+    DERIVED_SCHEMA_VERSION,
+    DerivationReceipt,
+    DerivedArtifact,
+    IndexUpdatePlan,
+    RECEIPT_SCHEMA_VERSION,
+    Source,
+    SourceSnapshot,
+    TransformSpec,
+)
+from assay.derived.receipts import now_iso
+
+
+def encode_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def decode_json(value: str) -> Any:
+    return json.loads(value)
+
+
+class DerivedStore:
+    """Small SQLite adapter for committed derived-context state."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = Path(path)
+
+    def connect(self) -> sqlite3.Connection:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(self.path))
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+        return conn
+
+    def initialize(self) -> None:
+        schema = resources.files("assay.derived").joinpath("schema.sql").read_text()
+        with self.connect() as conn:
+            conn.executescript(schema)
+            self._ensure_schema_metadata(conn)
+
+    @contextmanager
+    def transaction(self) -> Iterator[sqlite3.Connection]:
+        self.initialize()
+        conn = self.connect()
+        try:
+            conn.execute("BEGIN")
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def put_plan(self, plan: IndexUpdatePlan) -> None:
+        self.initialize()
+        with self.connect() as conn:
+            self._insert_plan(conn, plan)
+
+    def apply_plan(
+        self,
+        plan: IndexUpdatePlan,
+        *,
+        fail_after_operations: Optional[int] = None,
+    ) -> None:
+        with self.transaction() as conn:
+            self._insert_plan(conn, plan)
+            applied = 0
+            for operation in plan.operations:
+                self._apply_operation(conn, operation)
+                applied += 1
+                if (
+                    fail_after_operations is not None
+                    and applied >= fail_after_operations
+                ):
+                    raise RuntimeError("injected derived-context apply failure")
+
+    def get_source(self, source_id: str) -> Optional[Source]:
+        self.initialize()
+        with self.connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM sources WHERE source_id = ?", (source_id,)
+            ).fetchone()
+        return _row_to_source(row) if row else None
+
+    def get_snapshot(self, snapshot_id: str) -> Optional[SourceSnapshot]:
+        self.initialize()
+        with self.connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM source_snapshots WHERE snapshot_id = ?",
+                (snapshot_id,),
+            ).fetchone()
+        return _row_to_snapshot(row) if row else None
+
+    def has_snapshot(self, snapshot_id: str) -> bool:
+        self.initialize()
+        with self.connect() as conn:
+            row = conn.execute(
+                "SELECT 1 FROM source_snapshots WHERE snapshot_id = ?",
+                (snapshot_id,),
+            ).fetchone()
+        return row is not None
+
+    def has_transform(self, transform_id: str) -> bool:
+        self.initialize()
+        with self.connect() as conn:
+            row = conn.execute(
+                "SELECT 1 FROM transforms WHERE transform_id = ?",
+                (transform_id,),
+            ).fetchone()
+        return row is not None
+
+    def get_transform(self, transform_id: str) -> Optional[TransformSpec]:
+        self.initialize()
+        with self.connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM transforms WHERE transform_id = ?", (transform_id,)
+            ).fetchone()
+        return _row_to_transform(row) if row else None
+
+    def get_artifact(self, artifact_id: str) -> Optional[DerivedArtifact]:
+        self.initialize()
+        with self.connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM derived_artifacts WHERE artifact_id = ?",
+                (artifact_id,),
+            ).fetchone()
+            if row is None:
+                return None
+            input_rows = conn.execute(
+                """
+                SELECT input_artifact_id
+                FROM artifact_inputs
+                WHERE artifact_id = ?
+                ORDER BY input_role, input_artifact_id
+                """,
+                (artifact_id,),
+            ).fetchall()
+        return _row_to_artifact(
+            row, [input_row["input_artifact_id"] for input_row in input_rows]
+        )
+
+    def get_receipt(self, receipt_id: str) -> Optional[DerivationReceipt]:
+        self.initialize()
+        with self.connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM receipts WHERE receipt_id = ?", (receipt_id,)
+            ).fetchone()
+        return _row_to_receipt(row) if row else None
+
+    def get_receipt_record(self, receipt_id: str) -> Optional[Dict[str, Any]]:
+        self.initialize()
+        with self.connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM receipts WHERE receipt_id = ?", (receipt_id,)
+            ).fetchone()
+        if row is None:
+            return None
+        return {
+            "receipt_id": row["receipt_id"],
+            "kind": row["kind"],
+            "subject_id": row["subject_id"],
+            "derivation_verification_level": row["derivation_verification_level"],
+            "status": row["status"],
+            "created_at": row["created_at"],
+            "receipt_json": row["receipt_json"],
+        }
+
+    def get_tombstone(self, artifact_id: str) -> Optional[ArtifactTombstone]:
+        self.initialize()
+        with self.connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM artifact_tombstones WHERE artifact_id = ?",
+                (artifact_id,),
+            ).fetchone()
+        return _row_to_tombstone(row) if row else None
+
+    def list_active_artifacts_with_sources(self) -> List[Dict[str, Any]]:
+        self.initialize()
+        with self.connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT
+                  da.*,
+                  ss.source_id AS source_id
+                FROM derived_artifacts da
+                LEFT JOIN source_snapshots ss
+                  ON da.source_snapshot_id = ss.snapshot_id
+                WHERE da.status = 'active'
+                ORDER BY da.artifact_id
+                """
+            ).fetchall()
+            input_rows = conn.execute(
+                """
+                SELECT artifact_id, input_artifact_id
+                FROM artifact_inputs
+                ORDER BY artifact_id, input_role, input_artifact_id
+                """
+            ).fetchall()
+        inputs_by_artifact: Dict[str, List[str]] = {}
+        for row in input_rows:
+            inputs_by_artifact.setdefault(row["artifact_id"], []).append(
+                row["input_artifact_id"]
+            )
+        records: List[Dict[str, Any]] = []
+        for row in rows:
+            artifact = _row_to_artifact(
+                row, inputs_by_artifact.get(row["artifact_id"], [])
+            )
+            records.append({"artifact": artifact, "source_id": row["source_id"]})
+        return records
+
+    def list_dependent_artifact_ids(self, artifact_id: str) -> List[str]:
+        self.initialize()
+        with self.connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT artifact_id
+                FROM artifact_inputs
+                WHERE input_artifact_id = ?
+                ORDER BY artifact_id
+                """,
+                (artifact_id,),
+            ).fetchall()
+        return [row["artifact_id"] for row in rows]
+
+    def artifact_is_admissible(self, artifact_id: str) -> bool:
+        return self._artifact_is_admissible(artifact_id, seen=[])
+
+    def get_metadata(self, key: str) -> Optional[str]:
+        self.initialize()
+        with self.connect() as conn:
+            row = conn.execute(
+                "SELECT value FROM store_metadata WHERE key = ?", (key,)
+            ).fetchone()
+        return row["value"] if row else None
+
+    def explain_artifact(self, artifact_id: str) -> Optional[Dict[str, Any]]:
+        artifact = self.get_artifact(artifact_id)
+        if artifact is None:
+            return None
+        snapshot = (
+            self.get_snapshot(artifact.source_snapshot_id)
+            if artifact.source_snapshot_id
+            else None
+        )
+        source = self.get_source(snapshot.source_id) if snapshot else None
+        transform = self.get_transform(artifact.transform_id)
+        receipt = self.get_receipt(artifact.receipt_id)
+        tombstone = self.get_tombstone(artifact_id)
+        return {
+            "artifact": artifact.to_dict(),
+            "source": source.to_dict() if source else None,
+            "source_snapshot": snapshot.to_dict() if snapshot else None,
+            "transform": transform.to_dict() if transform else None,
+            "receipt": receipt.to_dict() if receipt else None,
+            "tombstone": tombstone.to_dict() if tombstone else None,
+        }
+
+    def count_rows(self, table: str, *, status: Optional[str] = None) -> int:
+        allowed = {
+            "sources",
+            "source_snapshots",
+            "transforms",
+            "derived_artifacts",
+            "artifact_inputs",
+            "receipts",
+            "index_update_plans",
+            "artifact_tombstones",
+            "store_metadata",
+        }
+        if table not in allowed:
+            raise ValueError(f"unsupported table: {table}")
+        self.initialize()
+        with self.connect() as conn:
+            if status is None:
+                row = conn.execute(f"SELECT COUNT(*) AS n FROM {table}").fetchone()
+            else:
+                row = conn.execute(
+                    f"SELECT COUNT(*) AS n FROM {table} WHERE status = ?",
+                    (status,),
+                ).fetchone()
+        return int(row["n"])
+
+    def _insert_plan(self, conn: sqlite3.Connection, plan: IndexUpdatePlan) -> None:
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO index_update_plans (
+              plan_id,
+              previous_state_hash,
+              proposed_state_hash,
+              added_count,
+              updated_count,
+              deleted_count,
+              created_at,
+              plan_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                plan.plan_id,
+                plan.previous_state_hash,
+                plan.proposed_state_hash,
+                plan.added_count,
+                plan.updated_count,
+                plan.deleted_count,
+                plan.created_at,
+                encode_json(plan.to_dict()),
+            ),
+        )
+
+    def _ensure_schema_metadata(self, conn: sqlite3.Connection) -> None:
+        expected = {
+            "derived_schema_version": DERIVED_SCHEMA_VERSION,
+            "receipt_schema_version": RECEIPT_SCHEMA_VERSION,
+        }
+        updated_at = now_iso()
+        for key, value in expected.items():
+            row = conn.execute(
+                "SELECT value FROM store_metadata WHERE key = ?", (key,)
+            ).fetchone()
+            if row is None:
+                if self._has_unversioned_derived_state(conn):
+                    raise RuntimeError(
+                        "unversioned derived store contains committed state; "
+                        "explicit migration is required"
+                    )
+                conn.execute(
+                    """
+                    INSERT INTO store_metadata (key, value, updated_at)
+                    VALUES (?, ?, ?)
+                    """,
+                    (key, value, updated_at),
+                )
+            elif row["value"] != value:
+                raise RuntimeError(
+                    f"unsupported derived store metadata {key}={row['value']}; "
+                    f"expected {value}"
+                )
+
+    def _has_unversioned_derived_state(self, conn: sqlite3.Connection) -> bool:
+        tables = (
+            "sources",
+            "source_snapshots",
+            "transforms",
+            "derived_artifacts",
+            "receipts",
+            "index_update_plans",
+            "artifact_tombstones",
+        )
+        for table in tables:
+            row = conn.execute(f"SELECT COUNT(*) AS n FROM {table}").fetchone()
+            if int(row["n"]):
+                return True
+        return False
+
+    def _artifact_is_admissible(self, artifact_id: str, seen: List[str]) -> bool:
+        if artifact_id in seen:
+            return False
+        artifact = self.get_artifact(artifact_id)
+        if artifact is None or artifact.status != "active":
+            return False
+        if self.get_tombstone(artifact_id) is not None:
+            return False
+        next_seen = seen + [artifact_id]
+        for input_id in artifact.input_artifact_ids:
+            if not self._artifact_is_admissible(input_id, next_seen):
+                return False
+        return True
+
+    def _apply_operation(
+        self, conn: sqlite3.Connection, operation: Dict[str, Any]
+    ) -> None:
+        op_type = operation["type"]
+        if op_type == "upsert_source":
+            self._upsert_source(conn, operation["source"])
+        elif op_type == "add_snapshot":
+            self._insert_snapshot(conn, operation["snapshot"])
+        elif op_type == "add_transform":
+            self._insert_transform(conn, operation["transform"])
+        elif op_type == "add_artifact":
+            self._insert_artifact(conn, operation["artifact"])
+            for artifact_input in operation.get("inputs", []):
+                self._insert_artifact_input(conn, artifact_input)
+            self._insert_receipt(conn, operation["receipt"])
+        elif op_type == "stale_artifact":
+            self._mark_artifact_status(conn, operation["artifact_id"], "stale")
+            self._insert_receipt(conn, operation["receipt"])
+        elif op_type == "tombstone_artifact":
+            self._mark_artifact_status(conn, operation["artifact_id"], "tombstoned")
+            self._insert_tombstone(conn, operation["tombstone"])
+            self._insert_receipt(conn, operation["receipt"])
+        else:
+            raise ValueError(f"unsupported derived plan operation: {op_type}")
+
+    def _upsert_source(self, conn: sqlite3.Connection, data: Dict[str, Any]) -> None:
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO sources (
+              source_id,
+              source_type,
+              uri,
+              first_seen_at,
+              last_seen_at
+            )
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                data["source_id"],
+                data["source_type"],
+                data["uri"],
+                data["first_seen_at"],
+                data["last_seen_at"],
+            ),
+        )
+        conn.execute(
+            "UPDATE sources SET last_seen_at = ? WHERE source_id = ?",
+            (data["last_seen_at"], data["source_id"]),
+        )
+
+    def _insert_snapshot(self, conn: sqlite3.Connection, data: Dict[str, Any]) -> None:
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO source_snapshots (
+              snapshot_id,
+              source_id,
+              content_hash,
+              size_bytes,
+              observed_at,
+              metadata_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                data["snapshot_id"],
+                data["source_id"],
+                data["content_hash"],
+                data["size_bytes"],
+                data["observed_at"],
+                encode_json(data.get("metadata", {})),
+            ),
+        )
+
+    def _insert_transform(self, conn: sqlite3.Connection, data: Dict[str, Any]) -> None:
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO transforms (
+              transform_id,
+              name,
+              version,
+              code_hash,
+              config_hash,
+              runtime_hash
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                data["transform_id"],
+                data["name"],
+                data["version"],
+                data["code_hash"],
+                data["config_hash"],
+                data.get("runtime_hash"),
+            ),
+        )
+
+    def _insert_artifact(self, conn: sqlite3.Connection, data: Dict[str, Any]) -> None:
+        conn.execute(
+            """
+            INSERT INTO derived_artifacts (
+              artifact_id,
+              artifact_type,
+              source_snapshot_id,
+              transform_id,
+              output_hash,
+              receipt_id,
+              derivation_verification_level,
+              status,
+              created_at,
+              metadata_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(artifact_id) DO UPDATE SET
+              status = excluded.status,
+              receipt_id = excluded.receipt_id,
+              derivation_verification_level = excluded.derivation_verification_level,
+              metadata_json = excluded.metadata_json
+            """,
+            (
+                data["artifact_id"],
+                data["artifact_type"],
+                data.get("source_snapshot_id"),
+                data["transform_id"],
+                data["output_hash"],
+                data["receipt_id"],
+                data["derivation_verification_level"],
+                data["status"],
+                data["created_at"],
+                encode_json(data.get("metadata", {})),
+            ),
+        )
+
+    def _insert_artifact_input(
+        self, conn: sqlite3.Connection, data: Dict[str, Any]
+    ) -> None:
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO artifact_inputs (
+              artifact_id,
+              input_artifact_id,
+              input_role
+            )
+            VALUES (?, ?, ?)
+            """,
+            (data["artifact_id"], data["input_artifact_id"], data["input_role"]),
+        )
+
+    def _insert_receipt(self, conn: sqlite3.Connection, data: Dict[str, Any]) -> None:
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO receipts (
+              receipt_id,
+              kind,
+              subject_id,
+              derivation_verification_level,
+              status,
+              created_at,
+              receipt_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                data["receipt_id"],
+                data["kind"],
+                data["subject_id"],
+                data["derivation_verification_level"],
+                data["status"],
+                data["created_at"],
+                encode_json(data),
+            ),
+        )
+
+    def _insert_tombstone(self, conn: sqlite3.Connection, data: Dict[str, Any]) -> None:
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO artifact_tombstones (
+              artifact_id,
+              reason,
+              tombstoned_at,
+              receipt_id
+            )
+            VALUES (?, ?, ?, ?)
+            """,
+            (
+                data["artifact_id"],
+                data["reason"],
+                data["tombstoned_at"],
+                data["receipt_id"],
+            ),
+        )
+
+    def _mark_artifact_status(
+        self, conn: sqlite3.Connection, artifact_id: str, status: str
+    ) -> None:
+        conn.execute(
+            "UPDATE derived_artifacts SET status = ? WHERE artifact_id = ?",
+            (status, artifact_id),
+        )
+
+
+def _row_to_source(row: sqlite3.Row) -> Source:
+    return Source(
+        source_id=row["source_id"],
+        source_type=row["source_type"],
+        uri=row["uri"],
+        first_seen_at=row["first_seen_at"],
+        last_seen_at=row["last_seen_at"],
+    )
+
+
+def _row_to_snapshot(row: sqlite3.Row) -> SourceSnapshot:
+    return SourceSnapshot(
+        snapshot_id=row["snapshot_id"],
+        source_id=row["source_id"],
+        content_hash=row["content_hash"],
+        size_bytes=row["size_bytes"],
+        observed_at=row["observed_at"],
+        metadata=decode_json(row["metadata_json"]),
+    )
+
+
+def _row_to_transform(row: sqlite3.Row) -> TransformSpec:
+    return TransformSpec(
+        transform_id=row["transform_id"],
+        name=row["name"],
+        version=row["version"],
+        code_hash=row["code_hash"],
+        config_hash=row["config_hash"],
+        runtime_hash=row["runtime_hash"],
+    )
+
+
+def _row_to_artifact(row: sqlite3.Row, input_ids: List[str]) -> DerivedArtifact:
+    return DerivedArtifact(
+        artifact_id=row["artifact_id"],
+        artifact_type=row["artifact_type"],
+        source_snapshot_id=row["source_snapshot_id"],
+        input_artifact_ids=tuple(input_ids),
+        transform_id=row["transform_id"],
+        output_hash=row["output_hash"],
+        receipt_id=row["receipt_id"],
+        derivation_verification_level=row["derivation_verification_level"],
+        status=row["status"],
+        created_at=row["created_at"],
+        metadata=decode_json(row["metadata_json"]),
+    )
+
+
+def _row_to_receipt(row: sqlite3.Row) -> DerivationReceipt:
+    data = decode_json(row["receipt_json"])
+    return DerivationReceipt(
+        receipt_id=data["receipt_id"],
+        kind=data["kind"],
+        subject_id=data["subject_id"],
+        source_snapshot_ids=tuple(data.get("source_snapshot_ids", [])),
+        input_artifact_ids=tuple(data.get("input_artifact_ids", [])),
+        transform_id=data.get("transform_id", ""),
+        output_hash=data.get("output_hash", ""),
+        derivation_verification_level=data["derivation_verification_level"],
+        status=data["status"],
+        created_at=data["created_at"],
+        metadata=data.get("metadata", {}),
+    )
+
+
+def _row_to_tombstone(row: sqlite3.Row) -> ArtifactTombstone:
+    return ArtifactTombstone(
+        artifact_id=row["artifact_id"],
+        reason=row["reason"],
+        tombstoned_at=row["tombstoned_at"],
+        receipt_id=row["receipt_id"],
+    )

--- a/src/assay/derived/transforms.py
+++ b/src/assay/derived/transforms.py
@@ -1,0 +1,115 @@
+"""Deterministic transforms for receipted derived context."""
+
+from __future__ import annotations
+
+import inspect
+import platform
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from assay.derived.hashing import canonical_hash, stable_id
+from assay.derived.models import TransformSpec
+
+
+DEFAULT_CHUNKER_VERSION = "0.1.0"
+DEFAULT_MAX_LINES = 80
+
+
+@dataclass(frozen=True)
+class TextChunk:
+    chunk_index: int
+    start_line: int
+    end_line: int
+    text: str
+    output_hash: str
+
+    def output_payload(self) -> Dict[str, Any]:
+        return {
+            "artifact_type": "source_chunk",
+            "chunk_index": self.chunk_index,
+            "start_line": self.start_line,
+            "end_line": self.end_line,
+            "text": self.text,
+        }
+
+
+def chunk_lines(text: str, max_lines: int = DEFAULT_MAX_LINES) -> List[TextChunk]:
+    if max_lines < 1:
+        raise ValueError("max_lines must be >= 1")
+    lines = text.splitlines()
+    if text and text.endswith("\n"):
+        # splitlines() drops the final empty line. That is fine for line chunks:
+        # the text payload below preserves joined line content deterministically.
+        pass
+    if not lines:
+        return []
+
+    chunks: List[TextChunk] = []
+    for offset in range(0, len(lines), max_lines):
+        selected = lines[offset : offset + max_lines]
+        start_line = offset + 1
+        end_line = offset + len(selected)
+        chunk_text = "\n".join(selected)
+        payload = {
+            "artifact_type": "source_chunk",
+            "chunk_index": len(chunks),
+            "start_line": start_line,
+            "end_line": end_line,
+            "text": chunk_text,
+        }
+        chunks.append(
+            TextChunk(
+                chunk_index=len(chunks),
+                start_line=start_line,
+                end_line=end_line,
+                text=chunk_text,
+                output_hash=canonical_hash(payload),
+            )
+        )
+    return chunks
+
+
+def line_chunk_transform_spec(
+    *,
+    version: str = DEFAULT_CHUNKER_VERSION,
+    max_lines: int = DEFAULT_MAX_LINES,
+    code_hash_override: Optional[str] = None,
+    runtime_hash_override: Optional[str] = None,
+) -> TransformSpec:
+    config_hash = canonical_hash({"max_lines": max_lines})
+    if code_hash_override is None:
+        try:
+            source = inspect.getsource(chunk_lines)
+        except OSError:
+            source = "chunk_lines"
+        code_hash = canonical_hash({"function": "chunk_lines", "source": source})
+    else:
+        code_hash = code_hash_override
+
+    runtime_hash = runtime_hash_override
+    if runtime_hash is None:
+        runtime_hash = canonical_hash(
+            {
+                "python_implementation": platform.python_implementation(),
+                "python_version": platform.python_version(),
+            }
+        )
+
+    transform_id = stable_id(
+        "xfm",
+        {
+            "name": "line_chunker",
+            "version": version,
+            "code_hash": code_hash,
+            "config_hash": config_hash,
+            "runtime_hash": runtime_hash,
+        },
+    )
+    return TransformSpec(
+        transform_id=transform_id,
+        name="line_chunker",
+        version=version,
+        code_hash=code_hash,
+        config_hash=config_hash,
+        runtime_hash=runtime_hash,
+    )

--- a/src/assay/derived/verifier.py
+++ b/src/assay/derived/verifier.py
@@ -1,0 +1,349 @@
+"""Verification for receipted derived context."""
+
+from __future__ import annotations
+
+import json
+from json import JSONDecodeError
+from typing import Any, Dict, List, Optional
+
+from assay.derived.hashing import sha256_text
+from assay.derived.models import (
+    DERIVATION_LEVELS,
+    RECEIPT_KINDS,
+    RECEIPT_SCHEMA_VERSION,
+    DerivationReceipt,
+    DerivedArtifact,
+    VerificationResult,
+)
+from assay.derived.receipts import receipt_id_for_payload
+from assay.derived.store import DerivedStore
+from assay.derived.transforms import DEFAULT_MAX_LINES, chunk_lines
+
+
+REQUIRED_RECEIPT_FIELDS = (
+    "receipt_id",
+    "kind",
+    "subject_id",
+    "source_snapshot_ids",
+    "input_artifact_ids",
+    "transform_id",
+    "output_hash",
+    "derivation_verification_level",
+    "status",
+    "created_at",
+    "metadata",
+)
+
+
+def verify_receipt(store: DerivedStore, receipt_id: str) -> VerificationResult:
+    record = store.get_receipt_record(receipt_id)
+    if record is None:
+        return VerificationResult(
+            receipt_id=receipt_id,
+            subject_id="",
+            ok=False,
+            derivation_verification_level="DV0",
+            status="missing",
+            errors=("receipt not found",),
+        )
+
+    data, decode_errors = _decode_receipt_json(record["receipt_json"])
+    if decode_errors:
+        return _failed_record_result(receipt_id, record, decode_errors)
+
+    structural_errors = _validate_receipt_record(record, data)
+    receipt = _receipt_from_data(data)
+    if receipt is None:
+        return _failed_record_result(receipt_id, record, structural_errors)
+
+    structural_errors.extend(_validate_lineage(store, receipt))
+    if structural_errors:
+        return VerificationResult(
+            receipt_id=receipt_id,
+            subject_id=receipt.subject_id,
+            ok=False,
+            derivation_verification_level="DV0",
+            status="failed",
+            errors=tuple(structural_errors),
+            expected_output_hash=receipt.output_hash,
+        )
+
+    if receipt.kind == "derived.artifact.created":
+        return _verify_created_artifact(store, receipt)
+
+    if receipt.kind in {"derived.artifact.staled", "derived.artifact.tombstoned"}:
+        return _verify_structural_receipt(store, receipt)
+
+    return VerificationResult(
+        receipt_id=receipt.receipt_id,
+        subject_id=receipt.subject_id,
+        ok=False,
+        derivation_verification_level="DV0",
+        status="failed",
+        errors=(f"unknown receipt kind: {receipt.kind}",),
+        expected_output_hash=receipt.output_hash,
+    )
+
+
+def _verify_created_artifact(
+    store: DerivedStore, receipt: DerivationReceipt
+) -> VerificationResult:
+    errors: List[str] = []
+    artifact = store.get_artifact(receipt.subject_id)
+    if artifact is None:
+        errors.append("subject artifact not found")
+        return _result(receipt, errors)
+
+    if artifact.receipt_id != receipt.receipt_id:
+        errors.append("artifact receipt_id does not match receipt")
+    if artifact.output_hash != receipt.output_hash:
+        errors.append("artifact output_hash does not match receipt")
+    if artifact.transform_id != receipt.transform_id:
+        errors.append("artifact transform_id does not match receipt")
+    if (
+        artifact.source_snapshot_id is not None
+        and artifact.source_snapshot_id not in receipt.source_snapshot_ids
+    ):
+        errors.append("artifact source snapshot not present in receipt")
+    if tuple(artifact.input_artifact_ids) != tuple(receipt.input_artifact_ids):
+        errors.append("artifact input_artifact_ids do not match receipt")
+    _verify_claimed_transform(store, receipt, errors)
+
+    if artifact.artifact_type != "source_chunk":
+        return VerificationResult(
+            receipt_id=receipt.receipt_id,
+            subject_id=receipt.subject_id,
+            ok=not errors,
+            derivation_verification_level="DV1" if not errors else "DV0",
+            status="verified" if not errors else "failed",
+            errors=tuple(errors),
+            expected_output_hash=artifact.output_hash,
+            actual_output_hash=artifact.output_hash,
+        )
+
+    actual_output_hash = _recompute_artifact_output_hash(store, artifact, errors)
+    expected_output_hash = artifact.output_hash
+    if actual_output_hash and actual_output_hash != artifact.output_hash:
+        errors.append("recomputed output hash does not match artifact")
+
+    return VerificationResult(
+        receipt_id=receipt.receipt_id,
+        subject_id=receipt.subject_id,
+        ok=not errors,
+        derivation_verification_level="DV2" if not errors else "DV1",
+        status="verified" if not errors else "failed",
+        errors=tuple(errors),
+        expected_output_hash=expected_output_hash,
+        actual_output_hash=actual_output_hash,
+    )
+
+
+def _verify_structural_receipt(
+    store: DerivedStore, receipt: DerivationReceipt
+) -> VerificationResult:
+    errors: List[str] = []
+    artifact = store.get_artifact(receipt.subject_id)
+    if artifact is None:
+        errors.append("subject artifact not found")
+    elif artifact.artifact_id != receipt.subject_id:
+        errors.append("receipt subject does not match artifact")
+    elif artifact.output_hash != receipt.output_hash:
+        errors.append("artifact output_hash does not match receipt")
+    _verify_claimed_transform(store, receipt, errors)
+    return VerificationResult(
+        receipt_id=receipt.receipt_id,
+        subject_id=receipt.subject_id,
+        ok=not errors,
+        derivation_verification_level="DV1" if not errors else "DV0",
+        status="verified" if not errors else "failed",
+        errors=tuple(errors),
+        expected_output_hash=receipt.output_hash,
+        actual_output_hash=artifact.output_hash if artifact else None,
+    )
+
+
+def _recompute_artifact_output_hash(
+    store: DerivedStore, artifact: DerivedArtifact, errors: List[str]
+) -> Optional[str]:
+    if artifact.artifact_type != "source_chunk":
+        errors.append(
+            f"unsupported artifact_type for recompute: {artifact.artifact_type}"
+        )
+        return None
+    if not artifact.source_snapshot_id:
+        errors.append("artifact has no source_snapshot_id")
+        return None
+    snapshot = store.get_snapshot(artifact.source_snapshot_id)
+    if snapshot is None:
+        errors.append("source snapshot not found")
+        return None
+    content_text = snapshot.metadata.get("content_text")
+    if not isinstance(content_text, str):
+        errors.append("source snapshot does not contain recomputable content_text")
+        return None
+    if sha256_text(content_text) != snapshot.content_hash:
+        errors.append("source snapshot content_text hash does not match content_hash")
+        return None
+
+    transform = store.get_transform(artifact.transform_id)
+    if transform is None:
+        errors.append("transform not found")
+        return None
+    if transform.name != "line_chunker":
+        errors.append(f"unsupported transform for recompute: {transform.name}")
+        return None
+
+    transform_config = artifact.metadata.get("transform_config", {})
+    max_lines = int(transform_config.get("max_lines", DEFAULT_MAX_LINES))
+    chunk_index = int(artifact.metadata.get("chunk_index", -1))
+    chunks = chunk_lines(content_text, max_lines=max_lines)
+    if chunk_index < 0 or chunk_index >= len(chunks):
+        errors.append("artifact chunk_index is outside recomputed chunk range")
+        return None
+    return chunks[chunk_index].output_hash
+
+
+def _decode_receipt_json(raw: str) -> tuple[Dict[str, Any], List[str]]:
+    try:
+        data = json.loads(raw)
+    except JSONDecodeError as exc:
+        return {}, [f"receipt_json is malformed JSON: {exc.msg}"]
+    if not isinstance(data, dict):
+        return {}, ["receipt_json must decode to an object"]
+    return data, []
+
+
+def _validate_receipt_record(record: Dict[str, Any], data: Dict[str, Any]) -> List[str]:
+    errors: List[str] = []
+    missing = [field for field in REQUIRED_RECEIPT_FIELDS if field not in data]
+    if missing:
+        errors.append("receipt_json missing fields: " + ", ".join(sorted(missing)))
+        return errors
+
+    if data["receipt_id"] != record["receipt_id"]:
+        errors.append("receipt_json receipt_id does not match receipts row")
+    if data["kind"] != record["kind"]:
+        errors.append("receipt_json kind does not match receipts row")
+    if data["subject_id"] != record["subject_id"]:
+        errors.append("receipt_json subject_id does not match receipts row")
+    if data["derivation_verification_level"] != record["derivation_verification_level"]:
+        errors.append(
+            "receipt_json derivation_verification_level does not match receipts row"
+        )
+    if data["status"] != record["status"]:
+        errors.append("receipt_json status does not match receipts row")
+    if data["created_at"] != record["created_at"]:
+        errors.append("receipt_json created_at does not match receipts row")
+
+    if data["kind"] not in RECEIPT_KINDS:
+        errors.append(f"unknown receipt kind: {data['kind']}")
+    if data["derivation_verification_level"] not in DERIVATION_LEVELS:
+        errors.append(
+            "unknown derivation_verification_level: "
+            + str(data["derivation_verification_level"])
+        )
+
+    metadata = data["metadata"]
+    if not isinstance(metadata, dict):
+        errors.append("receipt metadata must be an object")
+    elif metadata.get("receipt_schema_version") != RECEIPT_SCHEMA_VERSION:
+        errors.append(
+            "unsupported receipt_schema_version: "
+            + str(metadata.get("receipt_schema_version"))
+        )
+
+    for list_field in ("source_snapshot_ids", "input_artifact_ids"):
+        if not isinstance(data[list_field], list) or not all(
+            isinstance(item, str) for item in data[list_field]
+        ):
+            errors.append(f"{list_field} must be a list of strings")
+
+    try:
+        recomputed_receipt_id = receipt_id_for_payload(data)
+    except Exception as exc:
+        errors.append(f"receipt_id could not be recomputed: {exc}")
+    else:
+        if recomputed_receipt_id != record["receipt_id"]:
+            errors.append("receipt_id does not match canonical receipt payload")
+    return errors
+
+
+def _receipt_from_data(data: Dict[str, Any]) -> Optional[DerivationReceipt]:
+    try:
+        return DerivationReceipt(
+            receipt_id=data["receipt_id"],
+            kind=data["kind"],
+            subject_id=data["subject_id"],
+            source_snapshot_ids=tuple(data["source_snapshot_ids"]),
+            input_artifact_ids=tuple(data["input_artifact_ids"]),
+            transform_id=data["transform_id"],
+            output_hash=data["output_hash"],
+            derivation_verification_level=data["derivation_verification_level"],
+            status=data["status"],
+            created_at=data["created_at"],
+            metadata=data["metadata"],
+        )
+    except (KeyError, TypeError):
+        return None
+
+
+def _validate_lineage(store: DerivedStore, receipt: DerivationReceipt) -> List[str]:
+    errors: List[str] = []
+    if store.get_artifact(receipt.subject_id) is None:
+        errors.append("subject artifact not found")
+    for snapshot_id in receipt.source_snapshot_ids:
+        if store.get_snapshot(snapshot_id) is None:
+            errors.append(f"source snapshot not found: {snapshot_id}")
+    for input_id in receipt.input_artifact_ids:
+        if store.get_artifact(input_id) is None:
+            errors.append(f"input artifact not found: {input_id}")
+        elif not store.artifact_is_admissible(input_id):
+            errors.append(f"input artifact is not admissible: {input_id}")
+    if store.get_transform(receipt.transform_id) is None:
+        errors.append("transform not found")
+    return errors
+
+
+def _verify_claimed_transform(
+    store: DerivedStore, receipt: DerivationReceipt, errors: List[str]
+) -> None:
+    claimed = receipt.metadata.get("transform")
+    if claimed is None:
+        return
+    transform = store.get_transform(receipt.transform_id)
+    if transform is None:
+        errors.append("transform not found")
+        return
+    actual = transform.to_dict()
+    for key in ("transform_id", "name", "version", "code_hash", "config_hash"):
+        if claimed.get(key) != actual.get(key):
+            errors.append(f"receipt transform {key} does not match committed transform")
+    if claimed.get("runtime_hash") != actual.get("runtime_hash"):
+        errors.append(
+            "receipt transform runtime_hash does not match committed transform"
+        )
+
+
+def _failed_record_result(
+    receipt_id: str, record: Dict[str, Any], errors: List[str]
+) -> VerificationResult:
+    return VerificationResult(
+        receipt_id=receipt_id,
+        subject_id=str(record.get("subject_id", "")),
+        ok=False,
+        derivation_verification_level="DV0",
+        status="failed",
+        errors=tuple(errors),
+    )
+
+
+def _result(receipt: DerivationReceipt, errors: List[str]) -> VerificationResult:
+    return VerificationResult(
+        receipt_id=receipt.receipt_id,
+        subject_id=receipt.subject_id,
+        ok=not errors,
+        derivation_verification_level="DV2" if not errors else "DV1",
+        status="verified" if not errors else "failed",
+        errors=tuple(errors),
+        expected_output_hash=receipt.output_hash,
+    )

--- a/tests/assay/test_derived_context.py
+++ b/tests/assay/test_derived_context.py
@@ -1,0 +1,559 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from assay.commands import assay_app
+from assay.derived.backends import DerivedBackend, NativeAssayBackend
+from assay.derived.hashing import canonical_hash, stable_id
+from assay.derived.models import (
+    DERIVED_SCHEMA_VERSION,
+    RECEIPT_SCHEMA_VERSION,
+    DerivedArtifact,
+    IndexUpdatePlan,
+)
+from assay.derived.planner import apply_derived_context, plan_derived_context
+from assay.derived.receipts import make_derivation_receipt
+from assay.derived.store import DerivedStore, decode_json, encode_json
+from assay.derived.transforms import line_chunk_transform_spec
+from assay.derived.verifier import verify_receipt
+
+
+def test_noop_rerun_creates_no_new_snapshots_or_artifacts(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    _write(root / "a.py", "print('a')\n")
+    store = _store(tmp_path)
+
+    first = apply_derived_context(root, store)
+    assert first.added_count == 1
+    snapshot_count = store.count_rows("source_snapshots")
+    artifact_count = store.count_rows("derived_artifacts")
+
+    second = apply_derived_context(root, store)
+
+    assert second.added_count == 0
+    assert second.updated_count == 0
+    assert second.deleted_count == 0
+    assert store.count_rows("source_snapshots") == snapshot_count
+    assert store.count_rows("derived_artifacts") == artifact_count
+
+
+def test_file_edit_invalidates_only_that_files_chunks(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    _write(root / "a.py", "print('a')\n")
+    _write(root / "b.py", "print('b')\n")
+    store = _store(tmp_path)
+
+    apply_derived_context(root, store)
+    before = _artifacts_by_path(store)
+    old_a = before["a.py"][0]["artifact_id"]
+    old_b = before["b.py"][0]["artifact_id"]
+
+    _write(root / "a.py", "print('a changed')\n")
+    plan = apply_derived_context(root, store)
+    statuses = _artifact_statuses(store)
+    after = _artifacts_by_path(store, status="active")
+
+    assert plan.added_count == 1
+    assert plan.updated_count == 1
+    assert plan.deleted_count == 0
+    assert statuses[old_a] == "stale"
+    assert statuses[old_b] == "active"
+    assert after["a.py"][0]["artifact_id"] != old_a
+    assert after["b.py"][0]["artifact_id"] == old_b
+
+
+def test_transform_version_change_invalidates_dependent_chunks(
+    tmp_path: Path,
+) -> None:
+    root = _repo(tmp_path)
+    _write(root / "a.py", "print('a')\n")
+    store = _store(tmp_path)
+
+    apply_derived_context(root, store)
+    old_artifact = _active_artifacts(store)[0]
+    new_transform = line_chunk_transform_spec(version="0.2.0")
+
+    plan = apply_derived_context(root, store, transform=new_transform)
+    statuses = _artifact_statuses(store)
+    active = _active_artifacts(store)
+
+    assert plan.added_count == 1
+    assert plan.updated_count == 1
+    assert statuses[old_artifact["artifact_id"]] == "stale"
+    assert active[0]["transform_id"] == new_transform.transform_id
+
+
+def test_deleted_file_creates_tombstones(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    _write(root / "a.py", "print('a')\n")
+    _write(root / "b.py", "print('b')\n")
+    store = _store(tmp_path)
+
+    apply_derived_context(root, store)
+    before = _artifacts_by_path(store)
+    old_a = before["a.py"][0]["artifact_id"]
+    old_b = before["b.py"][0]["artifact_id"]
+
+    (root / "a.py").unlink()
+    plan = apply_derived_context(root, store)
+    statuses = _artifact_statuses(store)
+
+    assert plan.deleted_count == 1
+    assert plan.updated_count == 0
+    assert statuses[old_a] == "tombstoned"
+    assert statuses[old_b] == "active"
+    assert store.count_rows("artifact_tombstones") == 1
+
+
+def test_explain_returns_complete_lineage(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    _write(root / "a.py", "print('a')\n")
+    store = _store(tmp_path)
+
+    apply_derived_context(root, store)
+    artifact = _active_artifacts(store)[0]
+    explanation = store.explain_artifact(artifact["artifact_id"])
+
+    assert explanation is not None
+    assert explanation["artifact"]["artifact_id"] == artifact["artifact_id"]
+    assert explanation["source"]["uri"] == "file://a.py"
+    assert explanation["source_snapshot"]["content_hash"].startswith("sha256:")
+    assert explanation["transform"]["name"] == "line_chunker"
+    assert explanation["receipt"]["subject_id"] == artifact["artifact_id"]
+    assert explanation["artifact"]["derivation_verification_level"] == "DV1"
+
+
+def test_verify_recomputes_deterministic_artifact(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    _write(root / "a.py", "print('a')\n")
+    store = _store(tmp_path)
+
+    apply_derived_context(root, store)
+    artifact = _active_artifacts(store)[0]
+    result = verify_receipt(store, artifact["receipt_id"])
+
+    assert result.ok
+    assert result.derivation_verification_level == "DV2"
+    assert result.expected_output_hash == result.actual_output_hash
+
+
+def test_verify_rejects_mutated_receipt_json(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    _write(root / "a.py", "print('a')\n")
+    store = _store(tmp_path)
+    apply_derived_context(root, store)
+    artifact = _active_artifacts(store)[0]
+
+    _mutate_receipt_json(
+        store,
+        artifact["receipt_id"],
+        lambda data: data["metadata"].update({"relative_path": "evil.py"}),
+    )
+    result = verify_receipt(store, artifact["receipt_id"])
+
+    assert not result.ok
+    assert any("canonical receipt payload" in error for error in result.errors)
+
+
+def test_verify_rejects_receipt_subject_mismatch(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    _write(root / "a.py", "print('a')\n")
+    store = _store(tmp_path)
+    apply_derived_context(root, store)
+    artifact = _active_artifacts(store)[0]
+
+    _mutate_receipt_json(
+        store,
+        artifact["receipt_id"],
+        lambda data: data.update({"subject_id": "art_fake"}),
+    )
+    result = verify_receipt(store, artifact["receipt_id"])
+
+    assert not result.ok
+    assert any("subject_id does not match receipts row" in e for e in result.errors)
+
+
+def test_verify_rejects_artifact_output_hash_mismatch(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    _write(root / "a.py", "print('a')\n")
+    store = _store(tmp_path)
+    apply_derived_context(root, store)
+    artifact = _active_artifacts(store)[0]
+
+    with store.connect() as conn:
+        conn.execute(
+            """
+            UPDATE derived_artifacts
+            SET output_hash = ?
+            WHERE artifact_id = ?
+            """,
+            ("sha256:" + "0" * 64, artifact["artifact_id"]),
+        )
+    result = verify_receipt(store, artifact["receipt_id"])
+
+    assert not result.ok
+    assert any("output_hash does not match receipt" in e for e in result.errors)
+
+
+def test_store_initializes_schema_version_metadata(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+
+    store.initialize()
+
+    assert store.get_metadata("derived_schema_version") == DERIVED_SCHEMA_VERSION
+    assert store.get_metadata("receipt_schema_version") == RECEIPT_SCHEMA_VERSION
+    assert store.count_rows("store_metadata") == 2
+
+
+def test_store_rejects_unversioned_committed_state(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    with store.connect() as conn:
+        conn.execute(
+            """
+            CREATE TABLE sources (
+              source_id TEXT PRIMARY KEY,
+              source_type TEXT NOT NULL,
+              uri TEXT NOT NULL,
+              first_seen_at TEXT NOT NULL,
+              last_seen_at TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO sources (
+              source_id,
+              source_type,
+              uri,
+              first_seen_at,
+              last_seen_at
+            )
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                "src_legacy",
+                "local_file",
+                "file://legacy.py",
+                "2026-01-01T00:00:00+00:00",
+                "2026-01-01T00:00:00+00:00",
+            ),
+        )
+
+    with pytest.raises(RuntimeError, match="unversioned derived store"):
+        store.initialize()
+
+
+def test_downstream_artifact_invalidates_when_input_artifact_tombstoned(
+    tmp_path: Path,
+) -> None:
+    root = _repo(tmp_path)
+    _write(root / "a.py", "print('a')\n")
+    store = _store(tmp_path)
+    apply_derived_context(root, store)
+    source_artifact_row = _active_artifacts(store)[0]
+    source_artifact = store.get_artifact(source_artifact_row["artifact_id"])
+    assert source_artifact is not None
+
+    dependent_artifact = _add_dependent_fixture_artifact(store, source_artifact)
+    assert store.artifact_is_admissible(dependent_artifact.artifact_id)
+    dependent_receipt = store.get_artifact(dependent_artifact.artifact_id).receipt_id
+    dependent_result = verify_receipt(store, dependent_receipt)
+    assert dependent_result.ok
+    assert dependent_result.derivation_verification_level == "DV1"
+
+    _tombstone_artifact(store, source_artifact)
+
+    assert store.get_artifact(dependent_artifact.artifact_id).status == "active"
+    assert not store.artifact_is_admissible(dependent_artifact.artifact_id)
+    invalidated_result = verify_receipt(store, dependent_receipt)
+    assert not invalidated_result.ok
+    assert any(
+        "input artifact is not admissible" in e for e in invalidated_result.errors
+    )
+
+
+def test_native_backend_satisfies_index_backend_protocol(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    _write(root / "a.py", "print('a')\n")
+    store = _store(tmp_path)
+    backend = NativeAssayBackend(store)
+
+    assert isinstance(backend, DerivedBackend)
+    assert len(backend.scan(root)) == 1
+    plan = backend.apply(root)
+    artifact_id = next(
+        op["artifact"]["artifact_id"]
+        for op in plan.operations
+        if op["type"] == "add_artifact"
+    )
+    receipt_id = store.get_artifact(artifact_id).receipt_id
+
+    assert backend.explain(artifact_id)["artifact"]["artifact_id"] == artifact_id
+    assert backend.verify(receipt_id).ok
+
+
+def test_failed_apply_rolls_back_without_partial_state(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    _write(root / "a.py", "print('a')\n")
+    store = _store(tmp_path)
+    plan = plan_derived_context(root, store)
+
+    with pytest.raises(RuntimeError):
+        store.apply_plan(plan, fail_after_operations=3)
+
+    assert store.count_rows("sources") == 0
+    assert store.count_rows("source_snapshots") == 0
+    assert store.count_rows("derived_artifacts") == 0
+    assert store.count_rows("receipts") == 0
+    assert store.count_rows("index_update_plans") == 0
+
+
+def test_top_level_derived_cli_apply_explain_verify(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    db = tmp_path / "derived.sqlite"
+    _write(root / "a.py", "print('a')\n")
+    runner = CliRunner()
+
+    apply_result = runner.invoke(
+        assay_app, ["derived", "apply", str(root), "--db", str(db)]
+    )
+    assert apply_result.exit_code == 0, apply_result.output
+    apply_payload = json.loads(apply_result.output)
+    artifact_id = next(
+        op["artifact_id"]
+        for op in apply_payload["plan"]["operations"]
+        if op["type"] == "add_artifact"
+    )
+    receipt_id = next(
+        op["receipt_id"]
+        for op in apply_payload["plan"]["operations"]
+        if op["type"] == "add_artifact"
+    )
+
+    explain_result = runner.invoke(
+        assay_app, ["derived", "explain", artifact_id, "--db", str(db)]
+    )
+    assert explain_result.exit_code == 0, explain_result.output
+    assert json.loads(explain_result.output)["explain"]["artifact"]["artifact_id"]
+
+    verify_result = runner.invoke(
+        assay_app, ["derived", "verify", receipt_id, "--db", str(db)]
+    )
+    assert verify_result.exit_code == 0, verify_result.output
+    assert json.loads(verify_result.output)["verification"]["ok"] is True
+
+
+def _repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    root.mkdir()
+    return root
+
+
+def _store(tmp_path: Path) -> DerivedStore:
+    return DerivedStore(tmp_path / "derived.sqlite")
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _mutate_receipt_json(store: DerivedStore, receipt_id: str, mutate) -> None:
+    record = store.get_receipt_record(receipt_id)
+    assert record is not None
+    data = json.loads(record["receipt_json"])
+    mutate(data)
+    with store.connect() as conn:
+        conn.execute(
+            "UPDATE receipts SET receipt_json = ? WHERE receipt_id = ?",
+            (encode_json(data), receipt_id),
+        )
+
+
+def _add_dependent_fixture_artifact(
+    store: DerivedStore, input_artifact
+) -> DerivedArtifact:
+    transform = store.get_transform(input_artifact.transform_id)
+    assert transform is not None
+    created_at = "2026-01-01T00:00:00+00:00"
+    output_hash = canonical_hash(
+        {
+            "artifact_type": "fixture_projection",
+            "input_artifact_id": input_artifact.artifact_id,
+        }
+    )
+    artifact_id = stable_id(
+        "art",
+        {
+            "artifact_type": "fixture_projection",
+            "input_artifact_id": input_artifact.artifact_id,
+            "transform_id": input_artifact.transform_id,
+            "output_hash": output_hash,
+        },
+    )
+    receipt = make_derivation_receipt(
+        kind="derived.artifact.created",
+        subject_id=artifact_id,
+        source_snapshot_ids=[],
+        input_artifact_ids=[input_artifact.artifact_id],
+        transform_id=input_artifact.transform_id,
+        output_hash=output_hash,
+        derivation_verification_level="DV1",
+        status="committed",
+        created_at=created_at,
+        metadata={
+            "artifact_type": "fixture_projection",
+            "transform": transform.to_dict(),
+        },
+    )
+    artifact = DerivedArtifact(
+        artifact_id=artifact_id,
+        artifact_type="fixture_projection",
+        source_snapshot_id=None,
+        input_artifact_ids=(input_artifact.artifact_id,),
+        transform_id=input_artifact.transform_id,
+        output_hash=output_hash,
+        receipt_id=receipt.receipt_id,
+        derivation_verification_level="DV1",
+        status="active",
+        created_at=created_at,
+        metadata={"fixture": True},
+    )
+    plan = IndexUpdatePlan(
+        plan_id=stable_id(
+            "dplan", {"operation": "add_fixture", "artifact_id": artifact_id}
+        ),
+        previous_state_hash=None,
+        proposed_state_hash=output_hash,
+        added_count=1,
+        updated_count=0,
+        deleted_count=0,
+        created_at=created_at,
+        root="fixture",
+        transform_id=input_artifact.transform_id,
+        operations=[
+            {
+                "type": "add_artifact",
+                "artifact": artifact.to_dict(),
+                "inputs": [
+                    {
+                        "artifact_id": artifact_id,
+                        "input_artifact_id": input_artifact.artifact_id,
+                        "input_role": "fixture_input",
+                    }
+                ],
+                "receipt": receipt.to_dict(),
+            }
+        ],
+    )
+    store.apply_plan(plan)
+    return artifact
+
+
+def _tombstone_artifact(store: DerivedStore, artifact) -> None:
+    created_at = "2026-01-01T00:00:01+00:00"
+    receipt = make_derivation_receipt(
+        kind="derived.artifact.tombstoned",
+        subject_id=artifact.artifact_id,
+        source_snapshot_ids=(
+            [artifact.source_snapshot_id] if artifact.source_snapshot_id else []
+        ),
+        input_artifact_ids=artifact.input_artifact_ids,
+        transform_id=artifact.transform_id,
+        output_hash=artifact.output_hash,
+        derivation_verification_level="DV1",
+        status="committed",
+        created_at=created_at,
+        metadata={"reason": "fixture_tombstone"},
+    )
+    plan = IndexUpdatePlan(
+        plan_id=stable_id(
+            "dplan",
+            {"operation": "tombstone_fixture", "artifact_id": artifact.artifact_id},
+        ),
+        previous_state_hash=None,
+        proposed_state_hash=artifact.output_hash,
+        added_count=0,
+        updated_count=0,
+        deleted_count=1,
+        created_at=created_at,
+        root="fixture",
+        transform_id=artifact.transform_id,
+        operations=[
+            {
+                "type": "tombstone_artifact",
+                "artifact_id": artifact.artifact_id,
+                "tombstone": {
+                    "artifact_id": artifact.artifact_id,
+                    "reason": "fixture_tombstone",
+                    "tombstoned_at": created_at,
+                    "receipt_id": receipt.receipt_id,
+                },
+                "receipt": receipt.to_dict(),
+            }
+        ],
+    )
+    store.apply_plan(plan)
+
+
+def _active_artifacts(store: DerivedStore):
+    return _artifact_rows(store, status="active")
+
+
+def _artifacts_by_path(store: DerivedStore, status: str = "active"):
+    rows = _artifact_rows(store, status=status)
+    by_path = {}
+    for row in rows:
+        by_path.setdefault(row["relative_path"], []).append(row)
+    return by_path
+
+
+def _artifact_statuses(store: DerivedStore):
+    return {
+        row["artifact_id"]: row["status"] for row in _artifact_rows(store, status=None)
+    }
+
+
+def _artifact_rows(store: DerivedStore, status=None):
+    store.initialize()
+    query = """
+        SELECT
+          da.artifact_id,
+          da.status,
+          da.receipt_id,
+          da.transform_id,
+          da.metadata_json,
+          ss.source_id,
+          ss.snapshot_id
+        FROM derived_artifacts da
+        JOIN source_snapshots ss
+          ON da.source_snapshot_id = ss.snapshot_id
+    """
+    params = ()
+    if status is not None:
+        query += " WHERE da.status = ?"
+        params = (status,)
+    query += " ORDER BY da.artifact_id"
+    with store.connect() as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(query, params).fetchall()
+    parsed = []
+    for row in rows:
+        metadata = decode_json(row["metadata_json"])
+        parsed.append(
+            {
+                "artifact_id": row["artifact_id"],
+                "status": row["status"],
+                "receipt_id": row["receipt_id"],
+                "transform_id": row["transform_id"],
+                "relative_path": metadata["relative_path"],
+                "source_id": row["source_id"],
+                "snapshot_id": row["snapshot_id"],
+            }
+        )
+    return parsed


### PR DESCRIPTION
## Summary

Adds a receipted `assay.derived` foundation for content-addressed derived context artifacts.

- introduces the `assay derived` CLI surface and storage/planning/verifier modules
- records content-addressed sources, derivation plans, canonical receipts, tombstones, and deterministic verification levels
- fails closed for unversioned stateful stores unless explicitly acknowledged
- documents the trust tier as T0/self-attested, not cosign T1
- documents `DerivedBackend` as pre-consumer foundation; CocoIndex authority remains deferred

## Verification

CONFIRMED locally:

- `git diff --cached --check`
- `PYTHONPATH=src python3 -m pytest tests/assay/test_derived_context.py -q` -> `15 passed`
- temp Python 3.11 dev venv, clean `HOME`/`ASSAY_HOME`: `PYTHONPATH=src python -m pytest -q` -> `3430 passed, 63 skipped, 1 xfailed, 18 warnings`

Prior base/context checks:

- post-#105/#106 main had clean-home parity: `3415 passed, 63 skipped, 1 xfailed`
- non-destructive rebase simulation of this derived delta over post-#105/#106 main: `3430 passed, 63 skipped, 1 xfailed`

## Review Scope

This is foundation work for derived-context receipts. It is intentionally not wired to CocoIndex and should not be reviewed as a T1 signed receipt path.

## Claim Boundary

This PR proves structural/canonical receipt integrity and deterministic derived-context behavior at T0. It does not claim external witness signing, production backend plurality, or downstream product integration yet.
