### PR TITLE
feat: add public verify report contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,28 @@ proof_pack/
   receipt_pack.jsonl      # One receipt per tool call, model invocation, or policy check
   pack_manifest.json      # SHA-256 hashes of every file + Ed25519 signature
   pack_signature.sig      # Raw signature bytes
-  verify_report.json      # Machine-readable verification result
+  verify_report.json      # Machine-readable verification judgment
   verify_transcript.md    # Human-readable transcript
 ```
 
 Change one byte in any file. Verification fails.
+
+The public verification contract is `verify_report.json` plus
+`pack_manifest.json`. The report keeps separate verdict channels:
+
+- `integrity_verdict`: whether the evidence object is intact
+- `claim_verdict`: whether intact evidence satisfies the claim
+- `replay_verdict`: whether replay matched, diverged, or was not run
+- `trust_verdict`: whether signer/workflow policy was accepted
+- `overall_verdict`: buyer-readable collapse of those channels
+
+`overall_verdict=PASS` means every channel listed in `required_channels`
+passed for the declared `evaluation_profile`. Optional channels may still be
+`NOT_EVALUATED` or `NOT_RUN`; the report states that explicitly in
+`overall_reason`.
+
+Doctrine: **pack root proves the evidence object; ledger index proves
+accepted/citable position; scorecard explains interpretation.**
 
 ### Try more
 
@@ -90,6 +107,7 @@ assay scan . --report      # Find uninstrumented LLM call sites
 assay patch .              # Auto-insert SDK integration
 assay run -- python my.py  # Run + build signed proof pack
 assay verify-pack ./proof_pack_*/   # Verify offline
+assay verify-pack ./proof_pack_*/ --json --out verify_report.json
 ```
 
 > **Boundary:** Assay proves the evidence artifact has not been altered

--- a/examples/reports/honest_fail.verify_report.json
+++ b/examples/reports/honest_fail.verify_report.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": "assay.verify_report.v0.1",
+  "report_id": "vr_22222222222222222222",
+  "pack_id": "pack_example_honest_fail",
+  "run_id": "run_example_honest_fail",
+  "pack_root_sha256": "7777777777777777777777777777777777777777777777777777777777777777",
+  "pack_manifest_sha256": "8888888888888888888888888888888888888888888888888888888888888888",
+  "integrity_verdict": "PASS",
+  "claim_verdict": "HONEST_FAIL",
+  "replay_verdict": "MATCH",
+  "trust_verdict": "PASS",
+  "evaluation_profile": "integrity_claim_replay_trust_required",
+  "required_channels": ["integrity", "claim", "replay", "trust"],
+  "overall_verdict": "HONEST_FAIL",
+  "overall_reason": "claim_verdict=HONEST_FAIL",
+  "blocking_channel": "claim",
+  "verified_at": "2026-05-07T00:00:00Z",
+  "verifier": {
+    "name": "assay verify-pack",
+    "version": "0.1.0",
+    "policy_id": "assay.verify_policy.v0.1"
+  },
+  "expectations": {
+    "policy_id": "assay.verify_policy.v0.1",
+    "policy_sha256": "9999999999999999999999999999999999999999999999999999999999999999",
+    "claim_set_id": "claim_set_example_honest_fail",
+    "claim_set_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "verification_inputs_sha256": "7777777777777777777777777777777777777777777777777777777777777777",
+  "verifier_config_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "provenance": {
+    "source_repo": "Haserjian/assay",
+    "commit_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "workflow_ref": "Haserjian/assay/.github/workflows/assay.yml@refs/heads/main",
+    "run_id": "1234567891",
+    "event_name": "pull_request"
+  },
+  "evidence_refs": [
+    {
+      "kind": "pack_manifest",
+      "path": "pack_manifest.json",
+      "sha256": "8888888888888888888888888888888888888888888888888888888888888888"
+    },
+    {
+      "kind": "receipt_pack",
+      "path": "receipt_pack.jsonl",
+      "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    }
+  ],
+  "checks": [
+    {
+      "name": "manifest_schema",
+      "verdict": "PASS"
+    },
+    {
+      "name": "file_hashes",
+      "verdict": "PASS"
+    },
+    {
+      "name": "claim_check",
+      "verdict": "HONEST_FAIL"
+    }
+  ],
+  "errors": [],
+  "warnings": [],
+  "summary": {
+    "integrity": "Manifest, file hashes, and signatures verified.",
+    "claim": "Evidence was intact but did not satisfy the claim.",
+    "replay": "Replay matched prior trace.",
+    "trust": "Signer and workflow matched policy."
+  }
+}

--- a/examples/reports/pass.verify_report.json
+++ b/examples/reports/pass.verify_report.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": "assay.verify_report.v0.1",
+  "report_id": "vr_11111111111111111111",
+  "pack_id": "pack_example_pass",
+  "run_id": "run_example_pass",
+  "pack_root_sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+  "pack_manifest_sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+  "integrity_verdict": "PASS",
+  "claim_verdict": "PASS",
+  "replay_verdict": "MATCH",
+  "trust_verdict": "PASS",
+  "evaluation_profile": "integrity_claim_replay_trust_required",
+  "required_channels": ["integrity", "claim", "replay", "trust"],
+  "overall_verdict": "PASS",
+  "overall_reason": "required_channels_passed",
+  "blocking_channel": null,
+  "verified_at": "2026-05-07T00:00:00Z",
+  "verifier": {
+    "name": "assay verify-pack",
+    "version": "0.1.0",
+    "policy_id": "assay.verify_policy.v0.1"
+  },
+  "expectations": {
+    "policy_id": "assay.verify_policy.v0.1",
+    "policy_sha256": "3333333333333333333333333333333333333333333333333333333333333333",
+    "claim_set_id": "claim_set_example_pass",
+    "claim_set_hash": "4444444444444444444444444444444444444444444444444444444444444444"
+  },
+  "verification_inputs_sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+  "verifier_config_sha256": "5555555555555555555555555555555555555555555555555555555555555555",
+  "provenance": {
+    "source_repo": "Haserjian/assay",
+    "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "workflow_ref": "Haserjian/assay/.github/workflows/assay.yml@refs/heads/main",
+    "run_id": "1234567890",
+    "event_name": "pull_request"
+  },
+  "evidence_refs": [
+    {
+      "kind": "pack_manifest",
+      "path": "pack_manifest.json",
+      "sha256": "2222222222222222222222222222222222222222222222222222222222222222"
+    },
+    {
+      "kind": "receipt_pack",
+      "path": "receipt_pack.jsonl",
+      "sha256": "6666666666666666666666666666666666666666666666666666666666666666"
+    }
+  ],
+  "checks": [
+    {
+      "name": "manifest_schema",
+      "verdict": "PASS"
+    },
+    {
+      "name": "file_hashes",
+      "verdict": "PASS"
+    },
+    {
+      "name": "claim_check",
+      "verdict": "PASS"
+    }
+  ],
+  "errors": [],
+  "warnings": [],
+  "summary": {
+    "integrity": "Manifest, file hashes, and signatures verified.",
+    "claim": "Evidence satisfied the evaluated claim set.",
+    "replay": "Replay matched prior trace.",
+    "trust": "Signer and workflow matched policy."
+  }
+}

--- a/examples/reports/tampered.verify_report.json
+++ b/examples/reports/tampered.verify_report.json
@@ -1,0 +1,79 @@
+{
+  "schema_version": "assay.verify_report.v0.1",
+  "report_id": "vr_33333333333333333333",
+  "pack_id": "pack_example_tampered",
+  "run_id": "run_example_tampered",
+  "pack_root_sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  "pack_manifest_sha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  "integrity_verdict": "TAMPERED",
+  "claim_verdict": "NOT_EVALUATED",
+  "replay_verdict": "NOT_RUN",
+  "trust_verdict": "NOT_EVALUATED",
+  "evaluation_profile": "integrity_required",
+  "required_channels": ["integrity"],
+  "overall_verdict": "TAMPERED",
+  "overall_reason": "integrity_verdict=TAMPERED",
+  "blocking_channel": "integrity",
+  "verified_at": "2026-05-07T00:00:00Z",
+  "verifier": {
+    "name": "assay verify-pack",
+    "version": "0.1.0",
+    "policy_id": "assay.verify_policy.v0.1"
+  },
+  "expectations": {
+    "policy_id": "assay.verify_policy.v0.1",
+    "policy_sha256": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "claim_set_id": "claim_set_example_tampered",
+    "claim_set_hash": "0000000000000000000000000000000000000000000000000000000000000000"
+  },
+  "verification_inputs_sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  "verifier_config_sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+  "provenance": {
+    "source_repo": "Haserjian/assay",
+    "commit_sha": "cccccccccccccccccccccccccccccccccccccccc",
+    "workflow_ref": "Haserjian/assay/.github/workflows/assay.yml@refs/heads/main",
+    "run_id": "1234567892",
+    "event_name": "pull_request"
+  },
+  "evidence_refs": [
+    {
+      "kind": "pack_manifest",
+      "path": "pack_manifest.json",
+      "sha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+    },
+    {
+      "kind": "receipt_pack",
+      "path": "receipt_pack.jsonl",
+      "sha256": "2222222222222222222222222222222222222222222222222222222222222222"
+    }
+  ],
+  "checks": [
+    {
+      "name": "manifest_schema",
+      "verdict": "PASS"
+    },
+    {
+      "name": "file_hashes",
+      "verdict": "TAMPERED",
+      "detail": "Hash mismatch for receipt_pack.jsonl."
+    },
+    {
+      "name": "claim_check",
+      "verdict": "NOT_EVALUATED"
+    }
+  ],
+  "errors": [
+    {
+      "code": "E_MANIFEST_TAMPER",
+      "message": "Hash mismatch for receipt_pack.jsonl.",
+      "field": "receipt_pack.jsonl"
+    }
+  ],
+  "warnings": [],
+  "summary": {
+    "integrity": "Evidence object integrity failed.",
+    "claim": "No claim set was evaluated.",
+    "replay": "Replay was not run.",
+    "trust": "Trust policy was not evaluated."
+  }
+}

--- a/src/assay/commands.py
+++ b/src/assay/commands.py
@@ -19,6 +19,7 @@ Commands:
   assay demo-challenge- CTF-style good + tampered pack pair
   assay demo-pack     - Build + verify a demo pack
   assay proof-pack    - Build a signed Proof Pack from an existing trace
+  assay expose-schema - Export bundled JSON schemas
   assay lock init     - Create a lockfile with sane defaults
   assay lock write    - Write a lockfile with explicit card list
   assay lock check    - Validate an existing lockfile
@@ -3192,6 +3193,7 @@ def proof_pack_cmd(
                 "status": "ok",
                 "pack_id": att.get("pack_id"),
                 "trace_id": trace_id,
+                "pack_root_sha256": manifest.get("pack_root_sha256"),
                 "output_dir": str(result_dir),
                 "receipt_integrity": att.get("receipt_integrity"),
                 "claim_check": att.get("claim_check"),
@@ -3224,6 +3226,60 @@ def proof_pack_cmd(
 
     console.print()
     console.print(f"Next: [bold]assay verify-pack {result_dir}[/]")
+
+
+@assay_app.command("expose-schema", rich_help_panel="Build & Verify")
+def expose_schema_cmd(
+    name: str = typer.Argument(
+        ..., help="Schema name to export: pack_manifest or verify_report"
+    ),
+    out: str = typer.Option(
+        "docs/schemas",
+        "--out",
+        "-o",
+        help="Output directory for the exported schema",
+    ),
+    output_json: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Export a bundled Assay JSON schema into a docs directory."""
+    from pathlib import Path
+    import shutil
+
+    schema_files = {
+        "pack_manifest": "pack_manifest.schema.json",
+        "verify_report": "verify_report.schema.json",
+    }
+    if name not in schema_files:
+        msg = f"unknown schema: {name}"
+        if output_json:
+            _output_json(
+                {
+                    "command": "expose-schema",
+                    "status": "error",
+                    "error": msg,
+                    "available": sorted(schema_files),
+                },
+                exit_code=3,
+            )
+        console.print(f"[red]Error:[/] {msg}")
+        raise typer.Exit(3)
+
+    schema_dir = Path(__file__).resolve().parent / "schemas"
+    src = schema_dir / schema_files[name]
+    dst = Path(out) / schema_files[name]
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src, dst)
+
+    if output_json:
+        _output_json(
+            {
+                "command": "expose-schema",
+                "status": "ok",
+                "schema": name,
+                "path": str(dst),
+            }
+        )
+    console.print(str(dst))
 
 
 @assay_app.command("verify-pack", rich_help_panel="Build & Verify")
@@ -3283,6 +3339,11 @@ def verify_pack_cmd(
         None,
         "--badge",
         help="Write an SVG verification badge to this path.",
+    ),
+    report_out: Optional[str] = typer.Option(
+        None,
+        "--out",
+        help="Write the public verify_report.json judgment envelope to this path.",
     ),
     trust_target: Optional[str] = typer.Option(
         None,
@@ -3730,6 +3791,57 @@ def verify_pack_cmd(
     except Exception:
         pass  # Posture display is best-effort
 
+    # Public verification judgment envelope. This is the buyer-facing contract
+    # that separates evidence integrity, claim success, replay, and trust.
+    from datetime import datetime as _dt
+    from datetime import timezone as _tz
+
+    from assay.manifest_schema import validate_verify_report
+    from assay.verify_report import build_verify_report, sha256_file
+
+    _verifier_config_sha256 = None
+    if lock:
+        _lock_path = Path(lock)
+        if _lock_path.exists():
+            _verifier_config_sha256 = sha256_file(_lock_path)
+
+    verify_report = build_verify_report(
+        verify_result=result,
+        verified_at=_dt.now(_tz.utc).isoformat(),
+        verifier_name="assay verify-pack",
+        verifier_version=str(att.get("verifier_version") or "unknown"),
+        manifest=manifest,
+        pack_dir=pack_path,
+        claim_check=claim_check,
+        trust_eval=trust_eval,
+        verifier_config_sha256=_verifier_config_sha256,
+    )
+    _report_schema_errors = validate_verify_report(verify_report)
+    if _report_schema_errors:
+        if output_json:
+            _output_json(
+                {
+                    "command": "verify-pack",
+                    "status": "error",
+                    "error": "verify_report_schema_validation_failed",
+                    "details": _report_schema_errors,
+                },
+                exit_code=2,
+            )
+        console.print("[red]Verify report schema validation failed:[/]")
+        for se in _report_schema_errors[:10]:
+            console.print(f"  {se}")
+        raise typer.Exit(2)
+
+    if report_out:
+        report_path = Path(report_out)
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(
+            json.dumps(verify_report, indent=2, default=str) + "\n",
+            encoding="utf-8",
+        )
+        _artifact_paths["verify_report"] = str(report_path)
+
     if output_json:
         from assay.verification_status import classify_verdict
 
@@ -3747,7 +3859,7 @@ def verify_pack_cmd(
             "status": overall_status,
             "verdict": _verdict,
             "claim_check": claim_check,
-            **result.to_dict(),
+            **verify_report,
         }
         if max_age_hours is not None:
             out["max_age_hours"] = max_age_hours
@@ -5373,6 +5485,7 @@ def run_cmd(
                 "exit_code": exit_code,
                 "trace_id": trace_id,
                 "pack_id": att.get("pack_id"),
+                "pack_root_sha256": manifest.get("pack_root_sha256"),
                 "signer_id": signer_id,
                 "output_dir": str(result_dir),
                 "receipt_integrity": att.get("receipt_integrity"),

--- a/src/assay/manifest_schema.py
+++ b/src/assay/manifest_schema.py
@@ -31,6 +31,7 @@ _SCHEMA_DIR = Path(__file__).resolve().parent / "schemas"
 
 _manifest_validator = None
 _attestation_validator = None
+_verify_report_validator = None
 
 _RFC3339_DATETIME_RE = re.compile(
     r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$"
@@ -67,27 +68,34 @@ def _check_date_time(value: Any) -> bool:
 
 def _load_validators() -> tuple:
     """Load and cache schema validators with $ref resolution."""
-    global _manifest_validator, _attestation_validator
+    global _manifest_validator, _attestation_validator, _verify_report_validator
     if _manifest_validator is not None:
-        return _manifest_validator, _attestation_validator
+        return _manifest_validator, _attestation_validator, _verify_report_validator
 
     att_path = _SCHEMA_DIR / "attestation.schema.json"
     manifest_path = _SCHEMA_DIR / "pack_manifest.schema.json"
+    verify_report_path = _SCHEMA_DIR / "verify_report.schema.json"
 
-    if not att_path.exists() or not manifest_path.exists():
+    if not att_path.exists() or not manifest_path.exists() or not verify_report_path.exists():
         raise FileNotFoundError(
             f"Schema files not found in {_SCHEMA_DIR}. "
-            f"Expected attestation.schema.json and pack_manifest.schema.json. "
+            "Expected attestation.schema.json, pack_manifest.schema.json, "
+            "and verify_report.schema.json. "
             f"This usually means the package was installed incorrectly."
         )
 
     att_schema = json.loads(att_path.read_text())
     manifest_schema = json.loads(manifest_path.read_text())
+    verify_report_schema = json.loads(verify_report_path.read_text())
 
     # Build registry for $ref resolution between schemas
     registry = referencing.Registry().with_resources([
         (att_schema["$id"], referencing.Resource.from_contents(att_schema)),
         (manifest_schema["$id"], referencing.Resource.from_contents(manifest_schema)),
+        (
+            verify_report_schema["$id"],
+            referencing.Resource.from_contents(verify_report_schema),
+        ),
     ])
 
     _manifest_validator = Draft202012Validator(
@@ -96,8 +104,11 @@ def _load_validators() -> tuple:
     _attestation_validator = Draft202012Validator(
         att_schema, registry=registry, format_checker=_format_checker
     )
+    _verify_report_validator = Draft202012Validator(
+        verify_report_schema, registry=registry, format_checker=_format_checker
+    )
 
-    return _manifest_validator, _attestation_validator
+    return _manifest_validator, _attestation_validator, _verify_report_validator
 
 
 # ---------------------------------------------------------------------------
@@ -110,7 +121,7 @@ def validate_manifest(manifest: Dict[str, Any]) -> List[str]:
     Returns a list of error messages (empty = valid).
     Raises FileNotFoundError if schemas are missing (fail closed).
     """
-    validator, _ = _load_validators()
+    validator, _, _ = _load_validators()
 
     errors = []
     for error in sorted(validator.iter_errors(manifest), key=lambda e: list(e.path)):
@@ -125,7 +136,7 @@ def validate_attestation(attestation: Dict[str, Any]) -> List[str]:
     Returns a list of error messages (empty = valid).
     Raises FileNotFoundError if schemas are missing (fail closed).
     """
-    _, validator = _load_validators()
+    _, validator, _ = _load_validators()
 
     errors = []
     for error in sorted(validator.iter_errors(attestation), key=lambda e: list(e.path)):
@@ -134,4 +145,20 @@ def validate_attestation(attestation: Dict[str, Any]) -> List[str]:
     return errors
 
 
-__all__ = ["parse_rfc3339_datetime", "validate_manifest", "validate_attestation"]
+def validate_verify_report(report: Dict[str, Any]) -> List[str]:
+    """Validate a public verify_report.json against its JSON schema."""
+    _, _, validator = _load_validators()
+
+    errors = []
+    for error in sorted(validator.iter_errors(report), key=lambda e: list(e.path)):
+        path = ".".join(str(p) for p in error.absolute_path) or "(root)"
+        errors.append(f"{path}: {error.message}")
+    return errors
+
+
+__all__ = [
+    "parse_rfc3339_datetime",
+    "validate_manifest",
+    "validate_attestation",
+    "validate_verify_report",
+]

--- a/src/assay/proof_pack.py
+++ b/src/assay/proof_pack.py
@@ -43,6 +43,7 @@ from assay.integrity import (
     verify_receipt_pack,
 )
 from assay.keystore import DEFAULT_SIGNER_ID, AssayKeyStore, get_default_keystore
+from assay.verify_report import build_verify_report
 
 try:
     from assay import __version__ as _assay_version
@@ -629,20 +630,9 @@ class ProofPack:
                 suite_hash=self.suite_hash,
             )
 
-        # 3. Build verify_report.json
-        report: Dict[str, Any] = {
-            "pack_id": pack_id,
-            "run_id": self.run_id,
-            **verify_result.to_dict(),
-            "verified_at": build_ts,
-            "verifier_version": _assay_version,
-        }
-        if claim_result is not None:
-            report["claim_verification"] = claim_result.to_dict()
-        report_bytes = json.dumps(report, indent=2).encode("utf-8")
-        (staging_dir / "verify_report.json").write_bytes(report_bytes)
-
-        # 4. Build attestation object
+        # 3. Build attestation object. The pack root is the JCS hash of this
+        # attestation, so it can be referenced by the verification report
+        # without creating a hash cycle with pack_manifest.json.
         timestamps: List[str] = []
         for entry in sorted_entries:
             ts = entry.get("timestamp") or entry.get("_stored_at")
@@ -687,6 +677,38 @@ class ProofPack:
             "superseded_by": self.superseded_by,
         }
 
+        attestation_bytes = jcs_canonicalize(attestation)
+        attestation_sha256 = _sha256_hex(attestation_bytes)
+        pack_root_sha256 = attestation_sha256
+
+        # 4. Build verify_report.json. pack_manifest_sha256 is intentionally
+        # null inside the hash-covered report: the final manifest includes the
+        # report hash, so the report cannot also include the final manifest hash.
+        report = build_verify_report(
+            verify_result=verify_result,
+            claim_result=claim_result,
+            verified_at=build_ts,
+            verifier_name="assay",
+            verifier_version=_assay_version,
+            pack_id=pack_id,
+            run_id=self.run_id,
+            pack_root_sha256=pack_root_sha256,
+            pack_manifest_sha256=None,
+            receipt_pack_sha256=_sha256_hex(receipt_pack_bytes),
+            policy_sha256=self.policy_hash,
+            claim_set_id=self.claim_set_id,
+            claim_set_hash=self.claim_set_hash,
+        )
+        from assay.manifest_schema import validate_verify_report
+
+        report_errors = validate_verify_report(report)
+        if report_errors:
+            raise ValueError(
+                f"Built verify report fails schema validation: {report_errors[0]}"
+            )
+        report_bytes = json.dumps(report, indent=2).encode("utf-8")
+        (staging_dir / "verify_report.json").write_bytes(report_bytes)
+
         # 5. Build verify_transcript.md
         transcript = _generate_transcript(
             pack_id,
@@ -700,9 +722,6 @@ class ProofPack:
         (staging_dir / "verify_transcript.md").write_bytes(transcript_bytes)
 
         # 6. Build unsigned manifest
-        attestation_bytes = jcs_canonicalize(attestation)
-        attestation_sha256 = _sha256_hex(attestation_bytes)
-
         files_list = [
             {
                 "path": "receipt_pack.jsonl",
@@ -786,7 +805,6 @@ class ProofPack:
         # 8. Create signed manifest.
         # D12: pack_root_sha256 = attestation_sha256, making the attestation
         # the single immutable identifier for the evidence unit.
-        pack_root_sha256 = attestation_sha256
         signed_manifest = {
             **unsigned_manifest,
             "signature": signature_b64,

--- a/src/assay/schemas/verify_report.schema.json
+++ b/src/assay/schemas/verify_report.schema.json
@@ -1,0 +1,178 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://assay.local/schemas/verify_report.schema.json",
+  "title": "Assay Verify Report",
+  "description": "Public verification judgment envelope for an Assay proof pack. Compatibility fields from legacy VerifyResult output may also be present.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema_version",
+    "report_id",
+    "pack_root_sha256",
+    "pack_manifest_sha256",
+    "integrity_verdict",
+    "claim_verdict",
+    "replay_verdict",
+    "trust_verdict",
+    "evaluation_profile",
+    "required_channels",
+    "overall_verdict",
+    "verified_at",
+    "verifier",
+    "evidence_refs",
+    "summary"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "assay.verify_report.v0.1"
+    },
+    "report_id": {
+      "type": "string",
+      "pattern": "^vr_[a-f0-9]{20}$"
+    },
+    "pack_id": {
+      "type": ["string", "null"]
+    },
+    "run_id": {
+      "type": ["string", "null"]
+    },
+    "pack_root_sha256": {
+      "$ref": "#/$defs/sha256_nullable"
+    },
+    "pack_manifest_sha256": {
+      "$ref": "#/$defs/sha256_nullable"
+    },
+    "integrity_verdict": {
+      "enum": ["PASS", "TAMPERED"]
+    },
+    "claim_verdict": {
+      "enum": ["PASS", "HONEST_FAIL", "NOT_EVALUATED"]
+    },
+    "replay_verdict": {
+      "enum": ["MATCH", "DIVERGE", "NOT_RUN"]
+    },
+    "trust_verdict": {
+      "enum": ["PASS", "UNTRUSTED", "NOT_EVALUATED"]
+    },
+    "evaluation_profile": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Compact name for the verifier profile implied by the channels required to determine overall_verdict."
+    },
+    "required_channels": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "enum": ["integrity", "claim", "replay", "trust"]
+      },
+      "description": "Verdict channels required for this evaluation profile. PASS means these required channels passed; other channels may be optional or not evaluated."
+    },
+    "overall_verdict": {
+      "enum": ["PASS", "HONEST_FAIL", "TAMPERED", "UNTRUSTED", "REPLAY_DIVERGED"]
+    },
+    "overall_reason": {
+      "type": "string",
+      "minLength": 1
+    },
+    "blocking_channel": {
+      "type": ["string", "null"],
+      "enum": ["integrity", "claim", "replay", "trust", null]
+    },
+    "verified_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "verifier": {
+      "type": "object",
+      "required": ["name", "version", "policy_id"],
+      "additionalProperties": true,
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "version": {"type": "string", "minLength": 1},
+        "policy_id": {"type": "string", "minLength": 1}
+      }
+    },
+    "expectations": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "policy_id": {"type": ["string", "null"]},
+        "policy_sha256": {"$ref": "#/$defs/sha256_nullable"},
+        "claim_set_id": {"type": ["string", "null"]},
+        "claim_set_hash": {"$ref": "#/$defs/sha256_nullable"}
+      }
+    },
+    "verification_inputs_sha256": {
+      "$ref": "#/$defs/sha256_nullable"
+    },
+    "verifier_config_sha256": {
+      "$ref": "#/$defs/sha256_nullable"
+    },
+    "provenance": {
+      "type": "object"
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["kind", "path", "sha256"],
+        "additionalProperties": false,
+        "properties": {
+          "kind": {
+            "enum": ["pack_manifest", "receipt_pack", "verify_report", "other"]
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "sha256": {
+            "$ref": "#/$defs/sha256_nullable"
+          }
+        }
+      }
+    },
+    "checks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "verdict"],
+        "additionalProperties": true,
+        "properties": {
+          "name": {"type": "string", "minLength": 1},
+          "verdict": {"type": "string", "minLength": 1},
+          "detail": {"type": ["string", "null"]}
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": ["integrity", "claim", "replay", "trust"],
+      "additionalProperties": false,
+      "properties": {
+        "integrity": {"type": "string"},
+        "claim": {"type": "string"},
+        "replay": {"type": "string"},
+        "trust": {"type": "string"}
+      }
+    },
+    "errors": {
+      "type": "array"
+    },
+    "warnings": {
+      "type": "array"
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "sha256_nullable": {
+      "anyOf": [
+        {"$ref": "#/$defs/sha256"},
+        {"type": "null"}
+      ]
+    }
+  }
+}

--- a/src/assay/verify_report.py
+++ b/src/assay/verify_report.py
@@ -1,0 +1,302 @@
+"""Public verification report contract for Assay proof packs."""
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from assay._receipts.jcs import canonicalize as jcs_canonicalize
+
+VERIFY_REPORT_SCHEMA_VERSION = "assay.verify_report.v0.1"
+DEFAULT_VERIFY_POLICY_ID = "assay.verify_policy.v0.1"
+_PUBLIC_REPLAY_VERDICTS = {"MATCH", "DIVERGE", "NOT_RUN"}
+_ALL_CHANNELS = ("integrity", "claim", "replay", "trust")
+
+
+def sha256_file(path: Path) -> str:
+    """Return SHA-256 of a file's raw bytes."""
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _legacy_claim_check(claim_check: Optional[str]) -> str:
+    value = str(claim_check or "N/A").upper()
+    if value == "PASS":
+        return "PASS"
+    if value == "FAIL":
+        return "HONEST_FAIL"
+    return "NOT_EVALUATED"
+
+
+def _trust_verdict(trust_eval: Optional[Any]) -> str:
+    if trust_eval is None:
+        return "NOT_EVALUATED"
+    authorization = getattr(trust_eval, "authorization", None)
+    acceptance = getattr(trust_eval, "acceptance", None)
+    auth_status = getattr(authorization, "status", None)
+    decision = getattr(acceptance, "decision", None)
+    if auth_status in {"unrecognized", "revoked"} or decision == "reject":
+        return "UNTRUSTED"
+    if decision == "accept" or auth_status == "authorized":
+        return "PASS"
+    return "NOT_EVALUATED"
+
+
+def _replay_verdict(value: str) -> str:
+    verdict = str(value or "NOT_RUN").upper()
+    if verdict in _PUBLIC_REPLAY_VERDICTS:
+        return verdict
+    return "NOT_RUN"
+
+
+def _overall_verdict(
+    *,
+    integrity_verdict: str,
+    claim_verdict: str,
+    replay_verdict: str,
+    trust_verdict: str,
+) -> tuple[str, Optional[str], str]:
+    if integrity_verdict == "TAMPERED":
+        return "TAMPERED", "integrity", "integrity_verdict=TAMPERED"
+    if trust_verdict == "UNTRUSTED":
+        return "UNTRUSTED", "trust", "trust_verdict=UNTRUSTED"
+    if replay_verdict == "DIVERGE":
+        return "REPLAY_DIVERGED", "replay", "replay_verdict=DIVERGE"
+    if claim_verdict == "HONEST_FAIL":
+        return "HONEST_FAIL", "claim", "claim_verdict=HONEST_FAIL"
+    return "PASS", None, "all_required_channels_passed"
+
+
+def _required_channels(
+    *,
+    claim_verdict: str,
+    replay_verdict: str,
+    trust_verdict: str,
+) -> tuple[str, ...]:
+    channels = ["integrity"]
+    if claim_verdict != "NOT_EVALUATED":
+        channels.append("claim")
+    if replay_verdict != "NOT_RUN":
+        channels.append("replay")
+    if trust_verdict != "NOT_EVALUATED":
+        channels.append("trust")
+    return tuple(channels)
+
+
+def _evaluation_profile(required_channels: tuple[str, ...]) -> str:
+    return "_".join(required_channels) + "_required"
+
+
+def _pass_reason(*, required_channels: tuple[str, ...]) -> str:
+    optional_not_evaluated = tuple(
+        channel for channel in _ALL_CHANNELS if channel not in required_channels
+    )
+    if not optional_not_evaluated:
+        return "required_channels_passed"
+    return (
+        "required_channels_passed; optional_channels_not_evaluated="
+        + ",".join(optional_not_evaluated)
+    )
+
+
+def _report_id(seed: Dict[str, Any]) -> str:
+    return "vr_" + _sha256_hex(jcs_canonicalize(seed))[:20]
+
+
+def _evidence_ref(kind: str, path: str, sha256: Optional[str]) -> Dict[str, Any]:
+    return {"kind": kind, "path": path, "sha256": sha256}
+
+
+def _check_row(name: str, verdict: str, *, detail: Optional[str] = None) -> Dict[str, Any]:
+    row: Dict[str, Any] = {"name": name, "verdict": verdict}
+    if detail:
+        row["detail"] = detail
+    return row
+
+
+def _stage_verdict(stage_dict: Dict[str, Any]) -> str:
+    if "passed" in stage_dict:
+        return "PASS" if stage_dict.get("passed") else "TAMPERED"
+    status = str(stage_dict.get("status") or "").lower()
+    if status == "ok":
+        return "PASS"
+    if status == "skipped":
+        return "NOT_EVALUATED"
+    return "TAMPERED"
+
+
+def build_verify_report(
+    *,
+    verify_result: Any,
+    verified_at: str,
+    verifier_name: str,
+    verifier_version: str,
+    manifest: Optional[Dict[str, Any]] = None,
+    pack_dir: Optional[Path] = None,
+    claim_result: Optional[Any] = None,
+    claim_check: Optional[str] = None,
+    pack_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+    pack_root_sha256: Optional[str] = None,
+    pack_manifest_sha256: Optional[str] = None,
+    receipt_pack_sha256: Optional[str] = None,
+    policy_id: str = DEFAULT_VERIFY_POLICY_ID,
+    policy_sha256: Optional[str] = None,
+    claim_set_id: Optional[str] = None,
+    claim_set_hash: Optional[str] = None,
+    replay_verdict: str = "NOT_RUN",
+    trust_eval: Optional[Any] = None,
+    verifier_config_sha256: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build the public verify_report.json judgment envelope.
+
+    The report preserves the legacy VerifyResult fields at top level for
+    compatibility while adding separate verdict channels for consumers.
+    """
+    manifest = manifest or {}
+    attestation = manifest.get("attestation", {}) if manifest else {}
+    pack_dir = Path(pack_dir) if pack_dir is not None else None
+
+    pack_id = pack_id or attestation.get("pack_id") or manifest.get("pack_id")
+    run_id = run_id or attestation.get("run_id")
+    pack_root_sha256 = pack_root_sha256 or manifest.get("pack_root_sha256")
+    policy_sha256 = policy_sha256 or attestation.get("policy_hash")
+    claim_set_id = claim_set_id or attestation.get("claim_set_id")
+    claim_set_hash = claim_set_hash or attestation.get("claim_set_hash")
+
+    if pack_manifest_sha256 is None and pack_dir is not None:
+        manifest_path = pack_dir / "pack_manifest.json"
+        if manifest_path.exists():
+            pack_manifest_sha256 = sha256_file(manifest_path)
+
+    if receipt_pack_sha256 is None and pack_dir is not None:
+        receipt_path = pack_dir / "receipt_pack.jsonl"
+        if receipt_path.exists():
+            receipt_pack_sha256 = sha256_file(receipt_path)
+
+    if claim_result is not None:
+        claim_verdict = "PASS" if getattr(claim_result, "passed", False) else "HONEST_FAIL"
+    else:
+        claim_verdict = _legacy_claim_check(claim_check or attestation.get("claim_check"))
+
+    replay_verdict = _replay_verdict(replay_verdict)
+    integrity_verdict = "PASS" if verify_result.passed else "TAMPERED"
+    trust_verdict = _trust_verdict(trust_eval)
+    required_channels = _required_channels(
+        claim_verdict=claim_verdict,
+        replay_verdict=replay_verdict,
+        trust_verdict=trust_verdict,
+    )
+    evaluation_profile = _evaluation_profile(required_channels)
+    overall, blocking_channel, overall_reason = _overall_verdict(
+        integrity_verdict=integrity_verdict,
+        claim_verdict=claim_verdict,
+        replay_verdict=replay_verdict,
+        trust_verdict=trust_verdict,
+    )
+    if overall == "PASS":
+        overall_reason = _pass_reason(required_channels=required_channels)
+
+    evidence_refs = [
+        _evidence_ref("pack_manifest", "pack_manifest.json", pack_manifest_sha256),
+        _evidence_ref("receipt_pack", "receipt_pack.jsonl", receipt_pack_sha256),
+    ]
+
+    checks = []
+    stages = list(getattr(verify_result, "stages", []) or [])
+    if stages:
+        for stage in stages:
+            stage_dict = stage.to_dict() if hasattr(stage, "to_dict") else dict(stage)
+            checks.append(
+                _check_row(
+                    str(stage_dict.get("stage") or stage_dict.get("name") or "unknown"),
+                    _stage_verdict(stage_dict),
+                    detail=stage_dict.get("reason"),
+                )
+            )
+    else:
+        checks.append(_check_row("receipt_pack_integrity", integrity_verdict))
+
+    checks.append(_check_row("claim_check", claim_verdict))
+    checks.append(_check_row("replay", replay_verdict))
+    checks.append(_check_row("trust", trust_verdict))
+
+    summary = {
+        "integrity": (
+            "Manifest, file hashes, and signatures verified."
+            if integrity_verdict == "PASS"
+            else "Evidence object integrity failed."
+        ),
+        "claim": {
+            "PASS": "Evidence satisfied the evaluated claim set.",
+            "HONEST_FAIL": "Evidence was intact but did not satisfy the claim set.",
+            "NOT_EVALUATED": "No claim set was evaluated.",
+        }[claim_verdict],
+        "replay": {
+            "MATCH": "Replay matched prior trace.",
+            "DIVERGE": "Replay diverged from prior trace.",
+            "NOT_RUN": "Replay was not run.",
+            "N/A": "Replay was not requested.",
+        }.get(replay_verdict, f"Replay verdict: {replay_verdict}."),
+        "trust": {
+            "PASS": "Signer and policy trust checks passed.",
+            "UNTRUSTED": "Signer or workflow trust checks failed.",
+            "NOT_EVALUATED": "Trust policy was not evaluated.",
+        }[trust_verdict],
+    }
+
+    legacy = verify_result.to_dict()
+    report: Dict[str, Any] = {
+        "schema_version": VERIFY_REPORT_SCHEMA_VERSION,
+        "report_id": _report_id(
+            {
+                "pack_root_sha256": pack_root_sha256,
+                "verified_at": verified_at,
+                "integrity_verdict": integrity_verdict,
+                "claim_verdict": claim_verdict,
+                "replay_verdict": replay_verdict,
+                "trust_verdict": trust_verdict,
+                "verifier_version": verifier_version,
+            }
+        ),
+        "pack_id": pack_id,
+        "run_id": run_id,
+        "pack_root_sha256": pack_root_sha256,
+        "pack_manifest_sha256": pack_manifest_sha256,
+        "integrity_verdict": integrity_verdict,
+        "claim_verdict": claim_verdict,
+        "replay_verdict": replay_verdict,
+        "trust_verdict": trust_verdict,
+        "evaluation_profile": evaluation_profile,
+        "required_channels": list(required_channels),
+        "overall_verdict": overall,
+        "overall_reason": overall_reason,
+        "blocking_channel": blocking_channel,
+        "verified_at": verified_at,
+        "verifier": {
+            "name": verifier_name,
+            "version": verifier_version,
+            "policy_id": policy_id,
+        },
+        "expectations": {
+            "policy_id": policy_id,
+            "policy_sha256": policy_sha256,
+            "claim_set_id": claim_set_id,
+            "claim_set_hash": claim_set_hash,
+        },
+        "verification_inputs_sha256": pack_root_sha256,
+        "verifier_config_sha256": verifier_config_sha256,
+        "provenance": attestation.get("ci_binding") or {},
+        "evidence_refs": evidence_refs,
+        "checks": checks,
+        "summary": summary,
+        "errors": [e.to_dict() for e in verify_result.errors],
+        "warnings": list(verify_result.warnings),
+        **legacy,
+    }
+    if claim_result is not None:
+        report["claim_verification"] = claim_result.to_dict()
+    return report

--- a/tests/assay/test_proof_pack.py
+++ b/tests/assay/test_proof_pack.py
@@ -11,6 +11,7 @@ import hashlib
 import json
 import uuid
 from datetime import datetime, timezone
+from pathlib import Path
 
 import pytest
 from typer.testing import CliRunner
@@ -38,6 +39,7 @@ from assay.integrity import (
     verify_receipt,
     verify_receipt_pack,
 )
+from assay.manifest_schema import validate_verify_report
 from assay.commands import assay_app
 from assay.keystore import AssayKeyStore
 from assay.proof_pack import (
@@ -57,6 +59,7 @@ from assay.run_cards import (
 )
 
 runner = CliRunner()
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 # ---------------------------------------------------------------------------
@@ -1754,6 +1757,209 @@ class TestClaimWiring:
         assert cv["n_passed"] == 1
         assert len(cv["results"]) == 1
         assert cv["results"][0]["claim_id"] == "c1"
+
+    def test_verify_report_public_contract_pass(
+        self, tmp_path, tmp_keys, sample_receipts
+    ):
+        """verify_report.json exposes separate public verdict channels."""
+        claims = [
+            ClaimSpec(
+                claim_id="c1",
+                description="check",
+                check="receipt_count_ge",
+                params={"min_count": 1},
+            ),
+        ]
+        pack = ProofPack(
+            run_id="test_report_contract_pass",
+            entries=sample_receipts,
+            signer_id="test-signer",
+            claims=claims,
+        )
+        out = pack.build(tmp_path / "pack", keystore=tmp_keys)
+        manifest = json.loads((out / "pack_manifest.json").read_text())
+        report = json.loads((out / "verify_report.json").read_text())
+
+        assert validate_verify_report(report) == []
+        assert report["schema_version"] == "assay.verify_report.v0.1"
+        assert report["pack_root_sha256"] == manifest["pack_root_sha256"]
+        assert report["integrity_verdict"] == "PASS"
+        assert report["claim_verdict"] == "PASS"
+        assert report["replay_verdict"] == "NOT_RUN"
+        assert report["trust_verdict"] == "NOT_EVALUATED"
+        assert report["evaluation_profile"] == "integrity_claim_required"
+        assert report["required_channels"] == ["integrity", "claim"]
+        assert report["overall_verdict"] == "PASS"
+        assert report["overall_reason"] == (
+            "required_channels_passed; optional_channels_not_evaluated=replay,trust"
+        )
+        assert report["blocking_channel"] is None
+        assert report["passed"] is True  # legacy compatibility field
+        assert all(
+            row["verdict"] == "PASS"
+            for row in report["checks"]
+            if row["name"] not in {"claim_check", "replay", "trust"}
+        )
+        assert not (out / "receipt.json").exists()
+
+    def test_verify_report_public_contract_honest_fail(
+        self, tmp_path, tmp_keys, sample_receipts
+    ):
+        """Intact evidence with failing claims reports HONEST_FAIL, not tamper."""
+        claims = [
+            ClaimSpec(
+                claim_id="c1",
+                description="too many receipts required",
+                check="receipt_count_ge",
+                params={"min_count": 999},
+            ),
+        ]
+        pack = ProofPack(
+            run_id="test_report_contract_honest_fail",
+            entries=sample_receipts,
+            signer_id="test-signer",
+            claims=claims,
+        )
+        out = pack.build(tmp_path / "pack", keystore=tmp_keys)
+        report = json.loads((out / "verify_report.json").read_text())
+
+        assert validate_verify_report(report) == []
+        assert report["integrity_verdict"] == "PASS"
+        assert report["claim_verdict"] == "HONEST_FAIL"
+        assert report["overall_verdict"] == "HONEST_FAIL"
+        assert report["blocking_channel"] == "claim"
+        assert report["overall_reason"] == "claim_verdict=HONEST_FAIL"
+
+    def test_verify_pack_json_reports_tampered(
+        self, tmp_path, tmp_keys, sample_receipts, monkeypatch
+    ):
+        """CLI JSON keeps tamper distinct from honest claim failure."""
+        monkeypatch.setenv("ASSAY_KEYS_DIR", str(tmp_path / "keys"))
+        pack = ProofPack(
+            run_id="test_report_contract_tampered",
+            entries=sample_receipts,
+            signer_id="test-signer",
+        )
+        out = pack.build(tmp_path / "pack", keystore=tmp_keys)
+        report_path = out / "verify_report.json"
+        report_path.write_text(report_path.read_text() + "\n")
+
+        result = runner.invoke(assay_app, ["verify-pack", str(out), "--json"])
+
+        assert result.exit_code == 2
+        payload = json.loads(result.output)
+        assert validate_verify_report(payload) == []
+        assert payload["integrity_verdict"] == "TAMPERED"
+        assert payload["claim_verdict"] == "NOT_EVALUATED"
+        assert payload["overall_verdict"] == "TAMPERED"
+        assert payload["blocking_channel"] == "integrity"
+
+    def test_verify_pack_out_writes_public_report(
+        self, tmp_path, tmp_keys, sample_receipts
+    ):
+        """--out writes a pure public verify_report.json artifact."""
+        pack = ProofPack(
+            run_id="test_report_out",
+            entries=sample_receipts,
+            signer_id="test-signer",
+        )
+        out = pack.build(tmp_path / "pack", keystore=tmp_keys)
+        report_out = tmp_path / "verify_report.json"
+
+        result = runner.invoke(
+            assay_app,
+            ["verify-pack", str(out), "--json", "--out", str(report_out)],
+        )
+
+        assert result.exit_code == 0
+        assert report_out.exists()
+        report = json.loads(report_out.read_text())
+        manifest_sha256 = hashlib.sha256(
+            (out / "pack_manifest.json").read_bytes()
+        ).hexdigest()
+        assert validate_verify_report(report) == []
+        assert report["pack_manifest_sha256"] == manifest_sha256
+        assert report["integrity_verdict"] == "PASS"
+        assert report["overall_verdict"] == "PASS"
+        assert "command" not in report
+
+    def test_verify_report_pass_declares_required_channels_when_optional_not_run(
+        self, tmp_path, tmp_keys, sample_receipts
+    ):
+        """PASS is scoped to required channels, not unevaluated optional channels."""
+        pack = ProofPack(
+            run_id="test_report_integrity_only_pass",
+            entries=sample_receipts,
+            signer_id="test-signer",
+        )
+        out = pack.build(tmp_path / "pack", keystore=tmp_keys)
+        report_out = tmp_path / "verify_report.json"
+
+        result = runner.invoke(
+            assay_app,
+            ["verify-pack", str(out), "--json", "--out", str(report_out)],
+        )
+
+        assert result.exit_code == 0
+        report = json.loads(report_out.read_text())
+        assert validate_verify_report(report) == []
+        assert report["integrity_verdict"] == "PASS"
+        assert report["claim_verdict"] == "NOT_EVALUATED"
+        assert report["replay_verdict"] == "NOT_RUN"
+        assert report["trust_verdict"] == "NOT_EVALUATED"
+        assert report["overall_verdict"] == "PASS"
+        assert report["evaluation_profile"] == "integrity_required"
+        assert report["required_channels"] == ["integrity"]
+        assert report["overall_reason"] == (
+            "required_channels_passed; "
+            "optional_channels_not_evaluated=claim,replay,trust"
+        )
+
+    def test_expose_schema_exports_public_contracts(self, tmp_path):
+        """expose-schema makes pack and verify-report contracts retrievable."""
+        for schema_name, file_name in (
+            ("pack_manifest", "pack_manifest.schema.json"),
+            ("verify_report", "verify_report.schema.json"),
+        ):
+            result = runner.invoke(
+                assay_app,
+                ["expose-schema", schema_name, "--out", str(tmp_path)],
+            )
+
+            assert result.exit_code == 0
+            assert (tmp_path / file_name).exists()
+
+        verify_schema = json.loads((tmp_path / "verify_report.schema.json").read_text())
+        assert "evaluation_profile" in verify_schema["required"]
+        assert "required_channels" in verify_schema["required"]
+        assert verify_schema["properties"]["replay_verdict"]["enum"] == [
+            "MATCH",
+            "DIVERGE",
+            "NOT_RUN",
+        ]
+
+    def test_example_verify_reports_validate(self):
+        """Published PASS/HONEST_FAIL/TAMPERED samples match the schema."""
+        examples = sorted((REPO_ROOT / "examples" / "reports").glob("*.json"))
+        assert {p.name for p in examples} == {
+            "pass.verify_report.json",
+            "honest_fail.verify_report.json",
+            "tampered.verify_report.json",
+        }
+        by_name = {}
+        for path in examples:
+            report = json.loads(path.read_text())
+            assert validate_verify_report(report) == []
+            by_name[path.name] = report
+
+        assert by_name["pass.verify_report.json"]["overall_verdict"] == "PASS"
+        assert (
+            by_name["honest_fail.verify_report.json"]["overall_verdict"]
+            == "HONEST_FAIL"
+        )
+        assert by_name["honest_fail.verify_report.json"]["blocking_channel"] == "claim"
+        assert by_name["tampered.verify_report.json"]["overall_verdict"] == "TAMPERED"
+        assert by_name["tampered.verify_report.json"]["blocking_channel"] == "integrity"
 
     def test_no_claim_results_in_report_without_claims(
         self, tmp_path, tmp_keys, sample_receipts


### PR DESCRIPTION
## Summary
Adds the first public Assay verification judgment contract: `verify_report.json`.

This PR makes verification output buyer-readable and machine-readable without collapsing distinct failure modes into one generic verdict.

Public artifacts:
- `pack_manifest.json`
- `verify_report.json`
- sample PASS / HONEST_FAIL / TAMPERED reports

Public verdict channels:
- `integrity_verdict`: `PASS` / `TAMPERED`
- `claim_verdict`: `PASS` / `HONEST_FAIL` / `NOT_EVALUATED`
- `replay_verdict`: `MATCH` / `DIVERGE` / `NOT_RUN`
- `trust_verdict`: `PASS` / `UNTRUSTED` / `NOT_EVALUATED`
- `overall_verdict`: `PASS` / `HONEST_FAIL` / `TAMPERED` / `UNTRUSTED` / `REPLAY_DIVERGED`

PASS semantics are explicit: `overall_verdict=PASS` means the channels listed in `required_channels` passed for the declared `evaluation_profile`. Optional channels may still be `NOT_EVALUATED` or `NOT_RUN`, and `overall_reason` states that.

Doctrine preserved:

> Pack root proves the evidence object. Ledger index proves accepted/citable position. Scorecard explains interpretation.

## Changes
- Adds `src/assay/verify_report.py`.
- Adds `src/assay/schemas/verify_report.schema.json`.
- Adds `assay verify-pack --json --out verify_report.json`.
- Adds `assay expose-schema verify_report`.
- Exposes `pack_root_sha256` in relevant JSON paths.
- Adds `evaluation_profile` and `required_channels` to scope PASS.
- Adds sample public reports under `examples/reports/`.
- Adds focused tests for PASS, HONEST_FAIL, TAMPERED, schema export, report validation, and PASS-with-optional-channels semantics.

## Verification
- `python3.11 -m compileall src tests`
- `python3.11 -m pytest -q tests/assay/test_proof_pack.py`
- `git diff --check`
- Smoke-generated PASS / HONEST_FAIL / TAMPERED reports with `verify-pack --json --out`

Focused result:

```text
131 passed, 1 xfailed
```

## Notes
This PR should land before the GitHub Action PR. The action consumes this CLI/report contract.
