### PR TITLE
chore: prepare assay-ai 1.23.0 release

### DIFF
--- a/.github/workflows/release-truth.yml
+++ b/.github/workflows/release-truth.yml
@@ -73,7 +73,12 @@ jobs:
         run: |
           /tmp/assay-clean/bin/python -c "
           import pkgutil, json
-          schemas = ['pack_manifest.schema.json', 'attestation.schema.json', 'adc_v0.1.schema.json']
+          schemas = [
+            'pack_manifest.schema.json',
+            'attestation.schema.json',
+            'adc_v0.1.schema.json',
+            'verify_report.schema.json',
+          ]
           [json.loads(pkgutil.get_data('assay', f'schemas/{s}')) for s in schemas]
           print(f'OK: {len(schemas)} schemas loaded')
           "

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Assay Roadmap
 
-**As of**: v1.22.0 (April 2026)
+**As of**: v1.23.0 (May 2026)
 **Launch**: Feb 18, 2026
 
 ---

--- a/docs/release/external_witness_ritual.md
+++ b/docs/release/external_witness_ritual.md
@@ -33,15 +33,18 @@ source /tmp/assay-witness/bin/activate
 python -m pip install --upgrade pip
 
 # Install from public index only
-pip install assay-ai==1.17.0
+pip install assay-ai==1.23.0
 
 # Version check
 python -c "import assay; print(assay.__version__)"
-# Expected: 1.17.0
+# Expected: 1.23.0
 
 # CLI entrypoints
 assay --help
 assay passport --help
+assay verify-pack --help
+assay expose-schema verify_report --out /tmp/assay-witness-schemas
+python -m json.tool /tmp/assay-witness-schemas/verify_report.schema.json >/dev/null
 
 # Canonical proof corridor
 assay passport demo --output-dir /tmp/assay-witness-demo
@@ -51,7 +54,7 @@ assay passport demo --output-dir /tmp/assay-witness-demo
 
 ### Version
 ```
-1.17.0
+1.23.0
 ```
 
 ### passport --help
@@ -74,6 +77,8 @@ challenge, supersede, revoke, diff, demo.
 | Install | No errors | Any install error |
 | Version | Reports target version | Wrong version or 0.0.0-dev |
 | passport --help | Shows 12 commands | Missing commands or import error |
+| verify-pack --help | Shows `--json` and `--out` options | Missing public report options |
+| verify_report schema | Exports valid JSON schema | Missing or invalid schema |
 | Demo | Exits 0, 10 steps complete | Any step fails |
 | v1 signed | Has `signature` and `passport_id` | Missing fields |
 | v1 != v2 | Different `passport_id` values | Identical IDs |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "assay-ai"
-version = "1.22.0"
+version = "1.23.0"
 description = "AI evidence that's harder to fake and easier to verify"
 authors = [
     { name = "Tim Bhaserjian", email = "tim2208@gmail.com" }


### PR DESCRIPTION
## Summary
- bumps assay-ai to 1.23.0 for the public verify_report.json contract release
- extends release-truth to assert verify_report.schema.json is packaged
- updates the external witness ritual to verify the 1.23.0 CLI, verify-pack --json/--out, and exported verify_report schema

## Verification
- python3.11 -m compileall src tests
- python3.11 -m pytest -q tests/assay/test_proof_pack.py
- uv run --python 3.11 --with build python -m build --wheel
- fresh venv install of dist/assay_ai-1.23.0-py3-none-any.whl
- assay version
- assay verify-pack --help includes --json and --out
- assay expose-schema verify_report --out /tmp/assay-wheel-schemas
- python3.11 -m json.tool /tmp/assay-wheel-schemas/verify_report.schema.json
- git diff --check

## Release note
This PR does not publish a release. Publishing still requires an explicit GitHub Release for v1.23.0.