### PR TITLE
docs: add assay-ai 1.23.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.23.0] - 2026-05-08
+
+### Added
+
+- **Public `verify_report.json` contract** — `assay verify-pack --json
+  --out verify_report.json` now emits a portable verification judgment with
+  separate verdict channels for integrity, claim, replay, trust, and overall
+  result.
+- **Evaluation profile semantics** — reports include `evaluation_profile` and
+  `required_channels` so `overall_verdict=PASS` means the required channels
+  passed, while optional channels may still be `NOT_EVALUATED` or `NOT_RUN`.
+- **Pack root exposure** — public reports include `pack_root_sha256` and
+  `pack_manifest_sha256` so a buyer can bind the judgment back to the evidence
+  object.
+- **Retrievable schema** — `assay expose-schema verify_report --out <dir>`
+  exports the bundled `verify_report.schema.json` contract.
+
+### Changed
+
+- **Release truth now checks the public report schema** — the release matrix
+  verifies that `verify_report.schema.json` is packaged alongside the existing
+  proof-pack schemas.
+- **README now names the buyer-facing report contract** — the quick path shows
+  how to write `verify_report.json` as a standalone artifact.
+
+### Notes
+
+- This release does not make Assay a production authorization system and does
+  not independently witness signer identity. It makes the verification judgment
+  more portable and explicit.
+
 ## [1.20.1] - 2026-04-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ assay score               # evidence readiness (0-100, A-F)
 
 | Command | Purpose |
 |---------|---------|
-| `assay verify-pack` | Verify integrity + claims (the 4 exit codes) |
+| `assay verify-pack` | Verify integrity + claims; write portable `verify_report.json` with `--json --out` |
 | `assay explain` | Plain-English summary of an evidence pack |
 | `assay analyze` | Cost, latency, error breakdown from pack or `--history` |
 | `assay diff` | Compare packs: claims, cost, latency (`--against-previous`, `--why`) |

--- a/docs/README_quickstart.md
+++ b/docs/README_quickstart.md
@@ -62,6 +62,17 @@ What happens under the hood:
 3. Assay packages those receipts into `proof_pack_<trace_id>/`
 4. the manifest is signed and the pack can be verified offline
 
+For a portable buyer-facing judgment, write the public verification report:
+
+```bash
+assay verify-pack ./proof_pack_*/ --json --out verify_report.json
+```
+
+The report separates `integrity_verdict`, `claim_verdict`,
+`replay_verdict`, `trust_verdict`, and `overall_verdict`. A `PASS` overall
+verdict applies to the report's declared `required_channels`; optional channels
+may still be `NOT_EVALUATED` or `NOT_RUN`.
+
 ## See It Work (No API Key Required)
 
 ```bash

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -43,6 +43,7 @@ when they're stable and don't require private infrastructure.
 | packet init, compile | Init draft + compile sealed compiled packet from questionnaire + proof packs | Shipped |
 | packet verify (--json) | Two-axis offline verification: integrity_verdict × completeness_verdict + admissibility | Shipped |
 | Subject binding + admissibility contract | Cryptographic subject scope, structured reason codes, fail-closed gate script | Shipped |
+| verify_report.json public contract | Portable verification judgment: integrity, claim, replay, trust, overall, evaluation profile, required channels, pack root | Shipped (v1.23.0) |
 
 ### Passport Lifecycle (v1.17.0)
 


### PR DESCRIPTION
## Summary
- adds changelog notes for the 1.23.0 public verify_report.json contract
- adds the portable report command to the quickstart
- adds the v1.23.0 report contract surface to the roadmap
- clarifies verify-pack command reference wording

## Why
Before publishing v1.23.0, the release should explain the buyer-facing contract rather than relying on merged PR memory.

## Verification
- git diff --check
- python3.11 -m compileall src tests
- python3.11 -m pytest -q tests/assay/test_passport_release_invariants.py::TestVersionSurface tests/assay/test_proof_pack.py::TestClaimWiring::test_verify_report_public_contract_pass tests/assay/test_proof_pack.py::TestClaimWiring::test_verify_report_public_contract_honest_fail tests/assay/test_proof_pack.py::TestClaimWiring::test_verify_pack_out_writes_public_report tests/assay/test_proof_pack.py::TestClaimWiring::test_verify_report_pass_declares_required_channels_when_optional_not_run tests/assay/test_proof_pack.py::TestClaimWiring::test_expose_schema_exports_public_contracts tests/assay/test_proof_pack.py::TestClaimWiring::test_example_verify_reports_validate

## Release note
Docs-only. Does not publish v1.23.0.