### PR TITLE
ci: generate signed verify report from checkout

### DIFF
--- a/.github/workflows/lineage.yml
+++ b/.github/workflows/lineage.yml
@@ -62,8 +62,10 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install assay
-        run: pip install "assay-ai==1.23.0"
+      - name: Install assay from checkout
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
 
       - name: Build proof pack
         run: |
@@ -86,6 +88,9 @@ jobs:
           require-claim-pass: "false"
           comment-on-pr: "false"
           upload-artifact: "false"
+
+      - name: Restore checkout Assay for public report
+        run: python -m pip install -e .
 
       - name: Write public verify report
         run: |


### PR DESCRIPTION
## Summary
- Install Assay from the PR checkout before building the CI proof pack.
- Reinstall the checkout after assay-verify-action runs, so the uploaded signed verify_report.json is generated by the code under review rather than the package version installed by the composite action.

## Why
The verification gate artifact should prove the public verify_report.json contract implemented in this checkout. The action can still smoke-test the public package path, but the final signed report artifact must come from the checkout contract.

## Verification
- Parsed .github/workflows/lineage.yml with PyYAML
- git diff --check