### PR TITLE
chore: prepare assay-ai 1.24.0 release

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Assay Roadmap
 
-**As of**: v1.23.0 (May 2026)
+**As of**: v1.24.0 (May 2026)
 **Launch**: Feb 18, 2026
 
 ---
@@ -43,7 +43,7 @@ when they're stable and don't require private infrastructure.
 | packet init, compile | Init draft + compile sealed compiled packet from questionnaire + proof packs | Shipped |
 | packet verify (--json) | Two-axis offline verification: integrity_verdict × completeness_verdict + admissibility | Shipped |
 | Subject binding + admissibility contract | Cryptographic subject scope, structured reason codes, fail-closed gate script | Shipped |
-| verify_report.json public contract | Portable verification judgment: integrity, claim, replay, trust, overall, evaluation profile, required channels, pack root | Shipped (v1.23.0) |
+| verify_report.json public contract | Portable verification judgment: integrity, claim, replay, trust, overall, evaluation profile, required channels, pack root | Shipped (v1.24.0) |
 
 ### Passport Lifecycle (v1.17.0)
 

--- a/docs/release/2026-05-08-verify-report-contract.md
+++ b/docs/release/2026-05-08-verify-report-contract.md
@@ -1,0 +1,22 @@
+# assay-ai 1.24.0 verify report contract note
+
+`assay-ai` 1.24.0 is the release line for the public
+`assay.verify_report.v0.1` contract.
+
+The buyer-facing artifact set is:
+
+- `pack_manifest.json`
+- `verify_report.json`
+- `verify_report.sigstore.json`
+
+The verify report keeps verdict channels separate:
+
+- `integrity_verdict`
+- `claim_verdict`
+- `replay_verdict`
+- `trust_verdict`
+- `overall_verdict`
+
+It also records the evaluation profile and channel requirements so
+`overall_verdict: PASS` can distinguish required checks that passed from
+optional channels that were not evaluated.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "assay-ai"
-version = "1.23.0"
+version = "1.24.0"
 description = "AI evidence that's harder to fake and easier to verify"
 authors = [
     { name = "Tim Bhaserjian", email = "tim2208@gmail.com" }


### PR DESCRIPTION
## Summary
- Bump `assay-ai` package metadata from `1.23.0` to `1.24.0`.
- Update the roadmap version note for the public `verify_report.json` contract.
- Add a short release note for the `assay.verify_report.v0.1` contract line.

## Why
`v1.23.0` already points to a commit before the merged public verify report contract. The next package release needs a non-conflicting version so downstream workflows can pin the actual contract-bearing release.

## Verification
- `uv run --with pytest --with tomli pytest -q tests/assay/test_messaging_drift.py --tb=short`
- `uv run --with build python -m build --wheel --outdir /tmp/assay-build.*`
- `git diff --check`

This PR does not publish to PyPI or create a GitHub release.
