### PR TITLE
docs: add no-code verification gate walkthrough

### DIFF
--- a/docs/evidence-sprint-one-pager.md
+++ b/docs/evidence-sprint-one-pager.md
@@ -74,6 +74,14 @@ evidence.
 Stronger witnessing, independent anchoring, ledger acceptance, or scorecard
 interpretation are later maturity layers, not assumed in the base sprint.
 
+## Optional CI Integration
+
+If the review target lives in GitHub, the sprint can add an Assay verification
+workflow that emits `pack_manifest.json`, `verify_report.json`, and
+`verify_report.sigstore.json` as review artifacts. The CI integration is scoped
+to producing a repeatable verification packet; it does not imply production
+authorization or legal compliance.
+
 ## Example Artifact List
 
 ```text

--- a/docs/examples/verification-gate-v0/START-HERE.md
+++ b/docs/examples/verification-gate-v0/START-HERE.md
@@ -1,0 +1,117 @@
+# Start Here: Verification Gate v0
+
+You do not need to read code or JSON to understand this sample.
+
+## One-Minute Version
+
+This sample checks whether a GitHub workflow signed a verification report about
+a specific evidence pack. The sample passed the integrity check. It did not
+evaluate claim correctness, replay, or trust policy.
+
+This sample answers one question:
+
+Can someone verify that a GitHub workflow produced a signed verification
+judgment about a specific evidence pack?
+
+## The Three Objects
+
+| Human Name | Technical File | Meaning |
+|---|---|---|
+| Evidence Box | `proof-pack/pack_manifest.json` | The thing being checked. |
+| Inspection Note / Verification Report | `signed-report/verify_report.json` | What verification decided. |
+| Signature Proof | `signed-report/verify_report.sigstore.json` | Who signed the decision. |
+
+The Inspection Note is the verification report.
+
+## Run One Command
+
+From the repository root:
+
+```bash
+bash scripts/verify_verification_gate_sample.sh
+```
+
+Expected result:
+
+```text
+Result: VERIFIED OK
+```
+
+If you see extra technical output from `cosign`, that is normal. The important
+final line is `Result: VERIFIED OK`.
+
+Expected output summary:
+
+```text
+Result: VERIFIED OK
+Integrity: PASS
+Claim correctness: NOT_EVALUATED
+Replay: NOT_RUN
+Trust policy: NOT_EVALUATED
+```
+
+## What "Verified OK" Means
+
+It means:
+
+- The Inspection Note / Verification Report refers to the same Evidence Box.
+- The Evidence Box passed the required integrity check.
+- The Inspection Note / Verification Report was signed by the expected GitHub
+  Actions workflow.
+
+Important: `overall_verdict=PASS` only means the required integrity check
+passed. It does not mean every possible check was run.
+
+## What Passed
+
+- Integrity: `PASS`
+
+In plain English: the evidence pack matched its manifest, and the signed
+judgment points to that same pack.
+
+## What Did Not Run
+
+- Claim correctness: `NOT_EVALUATED`
+- Replay: `NOT_RUN`
+- Trust policy: `NOT_EVALUATED`
+
+In plain English: this sample does not judge whether a claim is true, does not
+rerun behavior, and does not apply a trust policy.
+
+## Do Not Infer
+
+Do not infer that this sample proves:
+
+- legal compliance
+- production approval
+- full claim correctness
+- replay equivalence
+- trust-policy approval
+- ledger acceptance
+- scorecard interpretation
+
+## Correct One-Sentence Summary
+
+This sample proves that the evidence pack passed integrity verification and
+that the verification judgment was signed by the expected GitHub workflow.
+
+## If You Are Reviewing This For Tim
+
+Send back:
+
+- I got `Result: VERIFIED OK` / I did not get `Result: VERIFIED OK`.
+- I think the Evidence Box is:
+- I think the Inspection Note / Verification Report is:
+- I think the Signature Proof is:
+- I understand integrity passed while claim/replay/trust were not evaluated:
+  yes/no
+- Confusing part:
+
+## Questions To Answer Back
+
+1. What is the Evidence Box?
+2. What is the Inspection Note / Verification Report?
+3. What is the Signature Proof?
+4. Which channel passed?
+5. Which channels were not evaluated?
+6. What should not be inferred from this sample?

--- a/docs/examples/verification-gate-v0/reviewer-packet.md
+++ b/docs/examples/verification-gate-v0/reviewer-packet.md
@@ -4,6 +4,12 @@ This packet summarizes the committed Verification Gate v0 sample for a
 reviewer. It is a worked example of the Reviewer Packet Lite template, not a
 claim of production authorization or legal compliance.
 
+Plain English: this sample is a signed inspection note, also called a
+verification report, for an evidence box. It proves the evidence box passed an
+integrity check and that the inspection note was signed by the expected GitHub
+workflow. It does not prove the software is secure, compliant,
+production-approved, or fully evaluated.
+
 ## Packet Metadata
 
 - Packet title: Verification Gate v0 signed report sample
@@ -60,6 +66,19 @@ judgment.
 | `unevaluated_channels` | `claim`, `replay`, `trust` |
 | `overall_reason` | `required_channels_passed; optional_channels_not_evaluated=claim,replay,trust` |
 
+## Verdict Channels
+
+| Channel | Result | Plain English |
+|---|---|---|
+| Integrity | `PASS` | The evidence pack matched its manifest. |
+| Claim | `NOT_EVALUATED` | This sample did not judge whether a claim was true. |
+| Replay | `NOT_RUN` | This sample did not rerun behavior. |
+| Trust | `NOT_EVALUATED` | This sample did not apply a trust policy. |
+| Overall | `PASS` | The required integrity channel passed. |
+
+Important: overall `PASS` only means the required integrity check passed. It
+does not mean every possible check was run.
+
 ## Scope: What This Covers
 
 - The committed sample report and manifest name the same pack root.
@@ -81,6 +100,15 @@ judgment.
 - Scorecard interpretation.
 - Upstream data authenticity beyond included evidence.
 
+## Do Not Say / Say This Instead
+
+| Do Not Say | Say This Instead |
+|---|---|
+| This proves the AI was right. | This proves the signed report passed the integrity-required verification profile. |
+| This proves the repo is secure. | This sample does not evaluate repository security. |
+| This proves compliance. | This sample is not a legal or compliance certification. |
+| Every claim passed. | Claim, replay, and trust channels were not evaluated in this sample. |
+
 ## Honest Failures / Missing Evidence
 
 | Item | Type | Explanation | Next Evidence Needed |
@@ -98,6 +126,14 @@ judgment.
   - `proof-pack/pack_manifest.json`
   - `signed-report/verify_report.json`
   - `signed-report/verify_report.sigstore.json`
+
+## What Would Make This Fail?
+
+- Changing the signed public report after signing.
+- Supplying a Sigstore bundle that does not match the report.
+- Verifying against the wrong GitHub Actions identity.
+- Changing proof-pack files so they no longer match `pack_manifest.json`.
+- Removing a file listed in the proof-pack manifest.
 
 ## How To Verify Locally
 

--- a/docs/examples/verification-gate-v0/verification-card.txt
+++ b/docs/examples/verification-gate-v0/verification-card.txt
@@ -1,0 +1,41 @@
+ASSAY VERIFICATION CARD
+Sample: Verification Gate v0
+Result: VERIFIED OK
+
+Evidence object:
+  proof-pack/pack_manifest.json
+
+Inspection Note / Verification Report:
+  signed-report/verify_report.json
+
+Signature proof:
+  signed-report/verify_report.sigstore.json
+
+Pack root:
+  88444482656580c864b9b879d877e82a05359c5f3970ec385b64f7777f73a053
+
+Signed by:
+  GitHub Actions workflow lineage.yml on Assay PR #116
+  https://github.com/Haserjian/assay/.github/workflows/lineage.yml@refs/pull/116/merge
+
+Evaluated channel:
+  integrity: PASS
+
+Overall result:
+  PASS for the integrity_required profile
+  This means the required integrity check passed.
+  It does not mean every possible check was run.
+
+Not evaluated:
+  claim correctness: NOT_EVALUATED
+  replay: NOT_RUN
+  trust policy: NOT_EVALUATED
+
+What this proves:
+  The evidence pack passed integrity verification.
+  The verification judgment was signed by the expected GitHub workflow.
+
+What this does not prove:
+  It does not prove legal compliance, production approval, full claim
+  correctness, replay equivalence, trust-policy approval, ledger acceptance, or
+  scorecard interpretation.

--- a/docs/verification-gate-v0-external-checklist.md
+++ b/docs/verification-gate-v0-external-checklist.md
@@ -25,6 +25,12 @@ gh auth status
 
 ## Option A: Verify The Committed Sample
 
+For a no-code introduction, read:
+
+```text
+docs/examples/verification-gate-v0/START-HERE.md
+```
+
 From the repository root:
 
 ```bash
@@ -34,7 +40,7 @@ bash scripts/verify_verification_gate_sample.sh
 Expected result:
 
 ```text
-Verified OK
+Result: VERIFIED OK
 ```
 
 The script also prints the report's verdict channels and confirms that

--- a/docs/verification-gate-v0-friction-log.md
+++ b/docs/verification-gate-v0-friction-log.md
@@ -1,0 +1,73 @@
+# Verification Gate v0 Friction Log
+
+Use this log when a reviewer tries the Verification Gate v0 sample. Capture
+what happened before explaining the packet verbally. The goal is to turn real
+confusion into a docs, script, terminology, artifact-layout, install, or product
+claim fix.
+
+## Review Session
+
+- Reviewer:
+- Date:
+- Repository revision:
+- Environment:
+- Shell:
+- `jq` version:
+- `cosign` version:
+- `python3` version:
+
+## Command Attempted
+
+```bash
+
+```
+
+## Result
+
+- Did the command complete?
+- Final output or error:
+- Was `Verified OK` reached?
+
+## Failure Or Confusion
+
+Describe the first point where the reviewer got stuck.
+
+-
+
+## Reviewer Interpretation
+
+What did the reviewer think the artifact proved?
+
+-
+
+What did the reviewer think the artifact did not prove?
+
+-
+
+## Six-Question Check
+
+| Question | Reviewer Answer | Correct / Needs Follow-Up |
+|---|---|---|
+| What is the evidence object? |  |  |
+| What is the verification judgment? |  |  |
+| What identity signed it? |  |  |
+| Which channels were evaluated? |  |  |
+| Which channels were not evaluated? |  |  |
+| What should not be inferred? |  |  |
+
+## Fix Category
+
+Choose one or more:
+
+- Docs
+- Script
+- Terminology
+- Artifact layout
+- Tool install
+- Product claim
+
+## Follow-Up
+
+- Proposed fix:
+- Owner:
+- Done when:

--- a/docs/verification-gate-v0-friction-log.md
+++ b/docs/verification-gate-v0-friction-log.md
@@ -26,7 +26,7 @@ claim fix.
 
 - Did the command complete?
 - Final output or error:
-- Was `Verified OK` reached?
+- Was `Result: VERIFIED OK` reached?
 
 ## Failure Or Confusion
 

--- a/docs/verification-gate-v0-handoff-note.md
+++ b/docs/verification-gate-v0-handoff-note.md
@@ -1,0 +1,74 @@
+# Verification Gate v0 Handoff Note
+
+Assay Verification Gate v0 is a signed verification judgment for one evidence
+pack. The committed sample lets you verify the judgment locally without relying
+on a dashboard or on the original GitHub Actions artifact still being retained.
+The purpose of this check is to confirm what the artifact proves and what it
+does not prove.
+
+## Verify The Sample
+
+If you are new to the packet, start here:
+
+```text
+docs/examples/verification-gate-v0/START-HERE.md
+```
+
+From the repository root:
+
+```bash
+bash scripts/verify_verification_gate_sample.sh
+```
+
+Expected result:
+
+```text
+Result: VERIFIED OK
+```
+
+## Files Involved
+
+```text
+docs/examples/verification-gate-v0/
+  proof-pack/
+    pack_manifest.json
+    pack_signature.sig
+    receipt_pack.jsonl
+    verify_report.json
+    verify_transcript.md
+  signed-report/
+    verify.stdout.json
+    verify_report.json
+    verify_report.sigstore.json
+```
+
+- `proof-pack/pack_manifest.json` is the evidence object manifest.
+- `signed-report/verify_report.json` is the public verification judgment.
+- `signed-report/verify_report.sigstore.json` is the provenance bundle for
+  the judgment signature.
+
+## What This Proves
+
+- The signed public report and proof-pack manifest bind to the same
+  `pack_root_sha256`.
+- The proof-pack directory contains every file named by its manifest.
+- The public report signature verifies against the expected GitHub Actions
+  workflow identity for PR `#116`.
+- The required integrity channel passed.
+
+## What This Does Not Prove
+
+- It does not prove production authorization.
+- It does not prove legal compliance.
+- It does not prove ledger acceptance or scorecard interpretation.
+- It does not prove full claim, replay, or trust-policy evaluation.
+- It does not prove upstream data authenticity beyond the included evidence.
+
+## Questions To Answer Back
+
+1. What is the Evidence Box?
+2. What is the Inspection Note / Verification Report?
+3. What is the Signature Proof?
+4. Which channel passed?
+5. Which channels were not evaluated?
+6. What should not be inferred from this sample?

--- a/scripts/demo_tamper_verification_gate_sample.sh
+++ b/scripts/demo_tamper_verification_gate_sample.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SOURCE_DIR="$ROOT_DIR/docs/examples/verification-gate-v0"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+for command in jq cosign python3; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    echo "missing required command: $command" >&2
+    exit 127
+  fi
+done
+
+cp -R "$SOURCE_DIR" "$TMP_ROOT/verification-gate-v0"
+
+REPORT="$TMP_ROOT/verification-gate-v0/signed-report/verify_report.json"
+BUNDLE="$TMP_ROOT/verification-gate-v0/signed-report/verify_report.sigstore.json"
+IDENTITY="https://github.com/Haserjian/assay/.github/workflows/lineage.yml@refs/pull/116/merge"
+ISSUER="https://token.actions.githubusercontent.com"
+
+echo "Clean sample:"
+cosign verify-blob "$REPORT" \
+  --bundle "$BUNDLE" \
+  --certificate-identity "$IDENTITY" \
+  --certificate-oidc-issuer "$ISSUER"
+echo "Clean sample result: VERIFIED OK"
+
+python3 - "$REPORT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+data = json.loads(path.read_text())
+data["tamper_demo_note"] = "This field was added after signing."
+path.write_text(json.dumps(data, indent=2) + "\n")
+PY
+
+echo
+echo "Tampered sample:"
+if cosign verify-blob "$REPORT" \
+  --bundle "$BUNDLE" \
+  --certificate-identity "$IDENTITY" \
+  --certificate-oidc-issuer "$ISSUER"; then
+  echo "Tampered sample unexpectedly verified." >&2
+  exit 1
+else
+  echo "Tampered sample result: REJECTED"
+fi

--- a/scripts/demo_tamper_verification_gate_sample.sh
+++ b/scripts/demo_tamper_verification_gate_sample.sh
@@ -6,7 +6,7 @@ SOURCE_DIR="$ROOT_DIR/docs/examples/verification-gate-v0"
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
-for command in jq cosign python3; do
+for command in cosign python3; do
   if ! command -v "$command" >/dev/null 2>&1; then
     echo "missing required command: $command" >&2
     exit 127

--- a/scripts/verify_verification_gate_sample.sh
+++ b/scripts/verify_verification_gate_sample.sh
@@ -24,7 +24,7 @@ for path in "$REPORT" "$BUNDLE" "$MANIFEST"; do
 done
 
 echo "Assay Verification Gate v0 sample"
-echo "This verifies the signed public report and checks it binds to the proof-pack manifest."
+echo "This verifies the signed public report, checks it binds to the proof-pack manifest, and asserts the report verdict."
 echo
 echo "Verdict channels:"
 jq '{
@@ -62,8 +62,9 @@ if report_root != manifest_root:
 PY
 
 echo
-echo "Checking proof-pack manifest file set..."
+echo "Checking proof-pack manifest file set and hashes..."
 python3 - "$SAMPLE_DIR/proof-pack" <<'PY'
+import hashlib
 import json
 import sys
 from pathlib import Path
@@ -77,11 +78,35 @@ missing = [
 ]
 if missing:
     raise SystemExit("missing proof-pack file(s): " + ", ".join(missing))
+
+hash_failures = []
+for file_info in manifest["files"]:
+    path = pack_dir / file_info["path"]
+    actual = hashlib.sha256(path.read_bytes()).hexdigest()
+    expected = file_info["sha256"]
+    if actual != expected:
+        hash_failures.append(f"{file_info['path']}: expected {expected}, got {actual}")
+
+if hash_failures:
+    raise SystemExit("proof-pack file hash mismatch: " + "; ".join(hash_failures))
+
 print("proof_pack_files = " + ", ".join(manifest["expected_files"]))
 PY
 
 echo
-echo "Verifying Sigstore bundle..."
+echo "Checking report verdict..."
+jq -e '
+  (.passed == true) and
+  (.overall_verdict == "PASS") and
+  (.integrity_verdict == "PASS") and
+  (.evaluation_profile == "integrity_required")
+' "$REPORT" >/dev/null || {
+  echo "verification report verdict is not PASS for integrity_required profile" >&2
+  exit 1
+}
+
+echo
+echo "Verifying Sigstore bundle and expected signer identity..."
 cosign verify-blob "$REPORT" \
   --bundle "$BUNDLE" \
   --certificate-identity "$IDENTITY" \

--- a/scripts/verify_verification_gate_sample.sh
+++ b/scripts/verify_verification_gate_sample.sh
@@ -86,3 +86,29 @@ cosign verify-blob "$REPORT" \
   --bundle "$BUNDLE" \
   --certificate-identity "$IDENTITY" \
   --certificate-oidc-issuer "$ISSUER"
+
+echo
+echo "Result: VERIFIED OK"
+echo
+echo "Human summary:"
+echo "  Evidence Box: $MANIFEST"
+echo "  Inspection Note / Verification Report: $REPORT"
+echo "  Signature Proof: $BUNDLE"
+echo "  Integrity: $(jq -r '.integrity_verdict' "$REPORT")"
+echo "  Claim correctness: $(jq -r '.claim_verdict' "$REPORT")"
+echo "  Replay: $(jq -r '.replay_verdict' "$REPORT")"
+echo "  Trust policy: $(jq -r '.trust_verdict' "$REPORT")"
+echo "  Overall: $(jq -r '.overall_verdict' "$REPORT") for $(jq -r '.evaluation_profile' "$REPORT") profile"
+echo "    This means the required integrity check passed."
+echo "    It does not mean every possible check was run."
+echo "  Signed by expected GitHub Actions identity:"
+echo "    $IDENTITY"
+echo
+echo "Plain English:"
+echo "  This proves the public verification report is intact, refers to the"
+echo "  right evidence pack, and was signed by the expected GitHub workflow."
+echo
+echo "Do NOT infer:"
+echo "  legal compliance, production approval, full claim correctness,"
+echo "  replay equivalence, trust-policy approval, ledger acceptance, or"
+echo "  scorecard interpretation."


### PR DESCRIPTION
Adds a no-code START-HERE page, verification card, clearer script output, and tamper demo for Verification Gate v0.

What changed:
- Adds a no-code reviewer entrypoint that explains Evidence Box, Inspection Note / Verification Report, and Signature Proof.
- Adds a forwardable verification card.
- Updates the sample verification script to end with a human-readable VERIFIED OK summary.
- Adds a tamper demo showing clean verification succeeds and a modified signed report is rejected.
- Adds handoff/friction-log docs for the first external reviewer loop.

Validation:
- git diff --check
- bash scripts/verify_verification_gate_sample.sh
- bash scripts/demo_tamper_verification_gate_sample.sh

Scope:
- Docs and sample scripts only.
- No ledger, repo manifest, OAE/EWP, LEM, scorecard, release, or runtime semantics changes.