### PR TITLE
docs: polish verification gate cold reviewer path

### DIFF
--- a/docs/examples/verification-gate-v0/START-HERE.md
+++ b/docs/examples/verification-gate-v0/START-HERE.md
@@ -42,6 +42,10 @@ Install `cosign` using the current Sigstore instructions for your platform:
 https://docs.sigstore.dev/cosign/system_config/installation/
 ```
 
+On Linux, that usually means downloading the latest `cosign-linux-amd64` or
+matching architecture binary from Sigstore's release instructions, making it
+executable, and putting it somewhere on your `PATH`.
+
 Check your tools:
 
 ```bash
@@ -51,6 +55,8 @@ python3 --version
 ```
 
 If one of these commands is missing, install it first.
+
+## What This Sample Answers
 
 This sample answers one question:
 
@@ -72,6 +78,8 @@ There are two signatures in this sample:
   Verification Report.
 
 This walkthrough focuses on the Sigstore-signed public Verification Report.
+The proof pack's Ed25519 signature is part of the artifact, but this script
+does not exercise that signature.
 
 ## Run One Command
 
@@ -98,7 +106,10 @@ Integrity: PASS
 Claim correctness: NOT_EVALUATED
 Replay: NOT_RUN
 Trust policy: NOT_EVALUATED
+Overall: PASS for integrity_required profile
 ```
+
+The script prints more detail than this. These are the lines to look for first.
 
 ## What "Verified OK" Means
 
@@ -108,8 +119,10 @@ It means:
 - The Evidence Box passed the required integrity check.
 - The Verification Report was signed by the expected GitHub Actions workflow.
 
-The workflow identity includes `github.com/Haserjian/assay`, so the check is
-tied to this repository's workflow, not just any GitHub workflow.
+The workflow identity must match the expected
+`https://github.com/Haserjian/assay/.github/workflows/...` identity. This is
+an exact identity check, not a substring search; a workflow from another repo
+or fork would not satisfy the command.
 
 Important: `overall_verdict=PASS` only means the required integrity check
 passed. It does not mean every possible check was run.
@@ -178,8 +191,4 @@ public name is Verification Report.
 This sample is part of an Evidence Sprint: a fixed-scope pilot that turns one
 AI/software claim set into a reviewer-ready evidence packet.
 
-See:
-
-```text
-docs/evidence-sprint-one-pager.md
-```
+See [Evidence Sprint one-pager](../../evidence-sprint-one-pager.md).

--- a/docs/examples/verification-gate-v0/START-HERE.md
+++ b/docs/examples/verification-gate-v0/START-HERE.md
@@ -1,4 +1,6 @@
-# Start Here: Verification Gate v0
+# Signed Verification Report - Sample
+
+Internal milestone name: Verification Gate v0.
 
 You do not need to read code or JSON to understand this sample.
 
@@ -7,6 +9,48 @@ You do not need to read code or JSON to understand this sample.
 This sample checks whether a GitHub workflow signed a verification report about
 a specific evidence pack. The sample passed the integrity check. It did not
 evaluate claim correctness, replay, or trust policy.
+
+Correct summary:
+
+> The evidence pack passed integrity verification, and the verification report
+> was signed by the expected GitHub workflow.
+
+## Before You Start
+
+You need three command-line tools:
+
+- `jq` - reads JSON
+- `cosign` - verifies the signature
+- `python3` - already installed on most Macs
+
+On macOS with Homebrew:
+
+```bash
+brew install jq cosign
+```
+
+On Ubuntu/Debian:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y jq python3
+```
+
+Install `cosign` using the current Sigstore instructions for your platform:
+
+```text
+https://docs.sigstore.dev/cosign/system_config/installation/
+```
+
+Check your tools:
+
+```bash
+jq --version
+cosign version
+python3 --version
+```
+
+If one of these commands is missing, install it first.
 
 This sample answers one question:
 
@@ -18,10 +62,16 @@ judgment about a specific evidence pack?
 | Human Name | Technical File | Meaning |
 |---|---|---|
 | Evidence Box | `proof-pack/pack_manifest.json` | The thing being checked. |
-| Inspection Note / Verification Report | `signed-report/verify_report.json` | What verification decided. |
+| Verification Report | `signed-report/verify_report.json` | What verification decided. |
 | Signature Proof | `signed-report/verify_report.sigstore.json` | Who signed the decision. |
 
-The Inspection Note is the verification report.
+There are two signatures in this sample:
+
+- `proof-pack/pack_signature.sig` belongs to the proof pack itself.
+- `signed-report/verify_report.sigstore.json` belongs to the public
+  Verification Report.
+
+This walkthrough focuses on the Sigstore-signed public Verification Report.
 
 ## Run One Command
 
@@ -54,10 +104,12 @@ Trust policy: NOT_EVALUATED
 
 It means:
 
-- The Inspection Note / Verification Report refers to the same Evidence Box.
+- The Verification Report refers to the same Evidence Box.
 - The Evidence Box passed the required integrity check.
-- The Inspection Note / Verification Report was signed by the expected GitHub
-  Actions workflow.
+- The Verification Report was signed by the expected GitHub Actions workflow.
+
+The workflow identity includes `github.com/Haserjian/assay`, so the check is
+tied to this repository's workflow, not just any GitHub workflow.
 
 Important: `overall_verdict=PASS` only means the required integrity check
 passed. It does not mean every possible check was run.
@@ -95,13 +147,13 @@ Do not infer that this sample proves:
 This sample proves that the evidence pack passed integrity verification and
 that the verification judgment was signed by the expected GitHub workflow.
 
-## If You Are Reviewing This For Tim
+## If You Are Reviewing This Sample
 
 Send back:
 
 - I got `Result: VERIFIED OK` / I did not get `Result: VERIFIED OK`.
 - I think the Evidence Box is:
-- I think the Inspection Note / Verification Report is:
+- I think the Verification Report is:
 - I think the Signature Proof is:
 - I understand integrity passed while claim/replay/trust were not evaluated:
   yes/no
@@ -110,8 +162,24 @@ Send back:
 ## Questions To Answer Back
 
 1. What is the Evidence Box?
-2. What is the Inspection Note / Verification Report?
+2. What is the Verification Report?
 3. What is the Signature Proof?
 4. Which channel passed?
 5. Which channels were not evaluated?
 6. What should not be inferred from this sample?
+
+## Glossary
+
+Some internal notes used the phrase "Inspection Note." In this sample, the
+public name is Verification Report.
+
+## Want This For Your Own Repo?
+
+This sample is part of an Evidence Sprint: a fixed-scope pilot that turns one
+AI/software claim set into a reviewer-ready evidence packet.
+
+See:
+
+```text
+docs/evidence-sprint-one-pager.md
+```

--- a/docs/examples/verification-gate-v0/reviewer-packet.md
+++ b/docs/examples/verification-gate-v0/reviewer-packet.md
@@ -1,14 +1,14 @@
-# Reviewer Packet Lite: Verification Gate v0 Sample
+# Reviewer Packet - Worked Example: Signed Verification Report
 
 This packet summarizes the committed Verification Gate v0 sample for a
 reviewer. It is a worked example of the Reviewer Packet Lite template, not a
 claim of production authorization or legal compliance.
 
-Plain English: this sample is a signed inspection note, also called a
-verification report, for an evidence box. It proves the evidence box passed an
-integrity check and that the inspection note was signed by the expected GitHub
-workflow. It does not prove the software is secure, compliant,
-production-approved, or fully evaluated.
+Plain English: this sample is a signed Verification Report for an Evidence
+Box. It proves the Evidence Box passed an integrity check and that the
+Verification Report was signed by the expected GitHub workflow. It does not
+prove the software is secure, compliant, production-approved, or fully
+evaluated.
 
 ## Packet Metadata
 
@@ -50,6 +50,14 @@ production-approved, or fully evaluated.
 
 `signed-report/verify_report.sigstore.json` is the provenance of that public
 judgment.
+
+There are two signatures in this sample. `proof-pack/pack_signature.sig`
+belongs to the proof pack itself. `signed-report/verify_report.sigstore.json`
+belongs to the public Verification Report.
+
+The expected GitHub workflow identity includes `github.com/Haserjian/assay`, so
+the report signature is tied to this repository's workflow, not just any GitHub
+workflow.
 
 | Field | Value |
 |---|---|
@@ -186,3 +194,12 @@ that some valid signer signed the report.
 | `proof-pack/receipt_pack.jsonl` | `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` |
 | `proof-pack/verify_report.json` | `1ace3f4aae77aaa5c34272a5ab9c4fde3921673936aec186052547f513b5da75` |
 | `proof-pack/verify_transcript.md` | `d2ba93896ba683fc51159a3bed158f8f65f2923f710f91b35c87120cd1ab4fc2` |
+
+## Glossary
+
+- Evidence Box: the proof pack named by `proof-pack/pack_manifest.json`.
+- Verification Report: the signed public judgment in
+  `signed-report/verify_report.json`.
+- Signature Proof: the Sigstore bundle in
+  `signed-report/verify_report.sigstore.json`.
+- Inspection Note: older/internal wording for Verification Report.

--- a/docs/examples/verification-gate-v0/reviewer-packet.md
+++ b/docs/examples/verification-gate-v0/reviewer-packet.md
@@ -55,9 +55,14 @@ There are two signatures in this sample. `proof-pack/pack_signature.sig`
 belongs to the proof pack itself. `signed-report/verify_report.sigstore.json`
 belongs to the public Verification Report.
 
-The expected GitHub workflow identity includes `github.com/Haserjian/assay`, so
-the report signature is tied to this repository's workflow, not just any GitHub
-workflow.
+The sample script verifies the Sigstore signature on the public Verification
+Report. The proof pack's Ed25519 signature, `proof-pack/pack_signature.sig`, is
+part of the artifact but is not exercised by that script.
+
+The expected GitHub workflow identity must match the expected
+`https://github.com/Haserjian/assay/.github/workflows/...` identity. This is
+an exact identity check, not a substring search; a workflow from another repo
+or fork would not satisfy the command.
 
 | Field | Value |
 |---|---|

--- a/docs/examples/verification-gate-v0/verification-card.txt
+++ b/docs/examples/verification-gate-v0/verification-card.txt
@@ -1,11 +1,12 @@
 ASSAY VERIFICATION CARD
-Sample: Verification Gate v0
+Sample: Signed Verification Report
+Internal milestone: Verification Gate v0
 Result: VERIFIED OK
 
 Evidence object:
   proof-pack/pack_manifest.json
 
-Inspection Note / Verification Report:
+Verification Report:
   signed-report/verify_report.json
 
 Signature proof:

--- a/docs/verification-gate-v0-handoff-note.md
+++ b/docs/verification-gate-v0-handoff-note.md
@@ -67,7 +67,7 @@ docs/examples/verification-gate-v0/
 ## Questions To Answer Back
 
 1. What is the Evidence Box?
-2. What is the Inspection Note / Verification Report?
+2. What is the Verification Report?
 3. What is the Signature Proof?
 4. Which channel passed?
 5. Which channels were not evaluated?

--- a/scripts/demo_tamper_verification_gate_sample.sh
+++ b/scripts/demo_tamper_verification_gate_sample.sh
@@ -5,6 +5,14 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SOURCE_DIR="$ROOT_DIR/docs/examples/verification-gate-v0"
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
+VERBOSE=0
+
+if [[ "${1:-}" == "--verbose" ]]; then
+  VERBOSE=1
+elif [[ $# -gt 0 ]]; then
+  echo "usage: $0 [--verbose]" >&2
+  exit 2
+fi
 
 for command in cosign python3; do
   if ! command -v "$command" >/dev/null 2>&1; then
@@ -21,10 +29,17 @@ IDENTITY="https://github.com/Haserjian/assay/.github/workflows/lineage.yml@refs/
 ISSUER="https://token.actions.githubusercontent.com"
 
 echo "Clean sample:"
-cosign verify-blob "$REPORT" \
-  --bundle "$BUNDLE" \
-  --certificate-identity "$IDENTITY" \
-  --certificate-oidc-issuer "$ISSUER"
+if [[ "$VERBOSE" -eq 1 ]]; then
+  cosign verify-blob "$REPORT" \
+    --bundle "$BUNDLE" \
+    --certificate-identity "$IDENTITY" \
+    --certificate-oidc-issuer "$ISSUER"
+else
+  cosign verify-blob "$REPORT" \
+    --bundle "$BUNDLE" \
+    --certificate-identity "$IDENTITY" \
+    --certificate-oidc-issuer "$ISSUER" >/dev/null 2>&1
+fi
 echo "Clean sample result: VERIFIED OK"
 
 python3 - "$REPORT" <<'PY'
@@ -40,12 +55,30 @@ PY
 
 echo
 echo "Tampered sample:"
-if cosign verify-blob "$REPORT" \
-  --bundle "$BUNDLE" \
-  --certificate-identity "$IDENTITY" \
-  --certificate-oidc-issuer "$ISSUER"; then
+if [[ "$VERBOSE" -eq 1 ]]; then
+  if cosign verify-blob "$REPORT" \
+    --bundle "$BUNDLE" \
+    --certificate-identity "$IDENTITY" \
+    --certificate-oidc-issuer "$ISSUER"; then
+    status=0
+  else
+    status=$?
+  fi
+else
+  if cosign verify-blob "$REPORT" \
+    --bundle "$BUNDLE" \
+    --certificate-identity "$IDENTITY" \
+    --certificate-oidc-issuer "$ISSUER" >/dev/null 2>&1; then
+    status=0
+  else
+    status=$?
+  fi
+fi
+
+if [[ "$status" -eq 0 ]]; then
   echo "Tampered sample unexpectedly verified." >&2
   exit 1
 else
   echo "Tampered sample result: REJECTED"
+  echo "Reason: signature did not match the tampered report; this is expected."
 fi

--- a/scripts/verify_verification_gate_sample.sh
+++ b/scripts/verify_verification_gate_sample.sh
@@ -117,7 +117,7 @@ echo "Result: VERIFIED OK"
 echo
 echo "Human summary:"
 echo "  Evidence Box: $MANIFEST"
-echo "  Inspection Note / Verification Report: $REPORT"
+echo "  Verification Report: $REPORT"
 echo "  Signature Proof: $BUNDLE"
 echo "  Integrity: $(jq -r '.integrity_verdict' "$REPORT")"
 echo "  Claim correctness: $(jq -r '.claim_verdict' "$REPORT")"


### PR DESCRIPTION
Polishes the no-code Verification Gate sample before external handoff.

Changes:
- Renames the external entrypoint to Signed Verification Report - Sample while keeping Verification Gate v0 as the internal milestone.
- Adds up-front prerequisites and install/check guidance for jq, cosign, and python3.
- Uses Verification Report as the canonical human-facing name, with Inspection Note kept only as glossary/internal wording.
- Adds repo-bound identity and two-signature notes for security-skeptic clarity.
- Makes the tamper demo calm by default and keeps raw cosign output behind --verbose.
- Keeps the existing integrity-required scope and conservative non-claims.

Validation:
- git diff --check
- bash scripts/verify_verification_gate_sample.sh
- bash scripts/demo_tamper_verification_gate_sample.sh
- bash scripts/demo_tamper_verification_gate_sample.sh --verbose

Scope:
- Docs and sample script UX only.
- No runtime verification semantics, package versioning, ledger, repo manifest, scorecard, LEM, OAE, or EWP work.