### PR TITLE
docs: clarify verification gate channel terms

### DIFF
--- a/docs/examples/verification-gate-v0/START-HERE.md
+++ b/docs/examples/verification-gate-v0/START-HERE.md
@@ -84,6 +84,10 @@ This sample answers one question:
 Can someone verify that a GitHub workflow produced a signed verification
 judgment about a specific evidence pack?
 
+A verdict channel is one kind of check. This sample shows four channels:
+Integrity, Claim correctness, Replay, and Trust policy. Only Integrity is
+required for this sample.
+
 GitHub and Sigstore can prove an artifact was produced by a workflow. Assay
 adds the reviewer packet around that proof: the evidence object, the
 verification judgment, separate verdict channels, scope language, and explicit
@@ -95,7 +99,7 @@ caveats about what did and did not run.
 |---|---|---|
 | Evidence Box | `proof-pack/pack_manifest.json` | The thing being checked. |
 | Verification Report | `signed-report/verify_report.json` | What verification decided. |
-| Signature Proof | `signed-report/verify_report.sigstore.json` | Who signed the decision. |
+| Signature Proof | `signed-report/verify_report.sigstore.json` | Who signed the public Verification Report. This is not `proof-pack/pack_signature.sig`. |
 
 ## Why Does The Identity Mention PR #116?
 
@@ -167,9 +171,8 @@ It means:
 - Cosign verified the report against the Sigstore bundle, including the
   transparency-log material carried by the bundle.
 
-A verdict channel is one kind of check. In this sample, the only required
-channel is Integrity. Claim correctness, replay, and trust policy are visible
-so reviewers can see they did not run.
+Claim correctness, replay, and trust policy are visible so reviewers can see
+they did not run.
 
 The certificate identity must exactly match:
 
@@ -226,6 +229,9 @@ In plain English: this sample does not judge whether a claim is true, does not
 rerun behavior, and does not apply a trust policy. That is normal for this
 integrity-only sample; a stricter packet would need those channels turned on
 and documented.
+
+`NOT_EVALUATED` and `NOT_RUN` both mean the channel did not contribute to the
+sample passing. Replay says `NOT_RUN` because no replay was attempted.
 
 ## Do Not Infer
 

--- a/docs/examples/verification-gate-v0/reviewer-packet.md
+++ b/docs/examples/verification-gate-v0/reviewer-packet.md
@@ -14,6 +14,10 @@ It also says nothing about whether any model, eval, or claim inside the
 Evidence Box is true. In this sample, claim correctness is explicitly
 `NOT_EVALUATED`.
 
+A verdict channel is one kind of check. This sample shows four channels:
+Integrity, Claim, Replay, and Trust. Only Integrity is required for this
+sample.
+
 ## Packet Metadata
 
 - Packet title: Verification Gate v0 signed report sample
@@ -31,7 +35,7 @@ Evidence Box is true. In this sample, claim correctness is explicitly
 | claim-001 | The PR workflow emitted a portable `verify_report.json` for one evidence pack. | Supported by sample artifact | The committed sample includes a complete `proof-pack/` and a signed public report under `signed-report/`. |
 | claim-002 | The public report and proof-pack manifest bind to the same pack root. | Passed | Both files name `88444482656580c864b9b879d877e82a05359c5f3970ec385b64f7777f73a053`. |
 | claim-003 | The public report signature verifies against the expected GitHub Actions workflow identity. | Passed | `cosign verify-blob` returns `Verified OK` for the PR `#116` workflow identity. |
-| claim-004 | Claim, replay, and trust-policy channels were evaluated. | Not evaluated | The sample explicitly reports `NOT_EVALUATED` / `NOT_RUN` for those channels. |
+| claim-004 | Claim, replay, and trust-policy channels were not evaluated. | Not evaluated | The sample explicitly reports `NOT_EVALUATED` / `NOT_RUN` for those channels. |
 
 ## Evidence Included
 
@@ -44,7 +48,7 @@ Evidence Box is true. In this sample, claim correctness is explicitly
 | evidence-005 | `proof-pack/receipt_pack.jsonl` | proof-pack integrity | Empty receipt pack for this zero-receipt sample. |
 | evidence-006 | `proof-pack/verify_report.json` | proof-pack integrity | Hash-covered report inside the proof pack. |
 | evidence-007 | `proof-pack/verify_transcript.md` | proof-pack integrity | Human-readable transcript inside the proof pack. |
-| evidence-008 | `proof-pack/pack_signature.sig` | proof-pack integrity | Detached Ed25519 proof-pack signature. |
+| evidence-008 | `proof-pack/pack_signature.sig` | proof-pack integrity | Detached Ed25519 proof-pack signature; not the Signature Proof for the public report. |
 
 ## Verification Result
 
@@ -55,9 +59,10 @@ Evidence Box is true. In this sample, claim correctness is explicitly
 `signed-report/verify_report.sigstore.json` is the provenance of that public
 judgment.
 
-There are two signatures in this sample. `proof-pack/pack_signature.sig`
-belongs to the proof pack itself. `signed-report/verify_report.sigstore.json`
-belongs to the public Verification Report.
+There are two signatures in this sample. The Signature Proof in this
+walkthrough is `signed-report/verify_report.sigstore.json`, which belongs to
+the public Verification Report. `proof-pack/pack_signature.sig` belongs to the
+proof pack itself.
 
 The sample script verifies the Sigstore signature on the public Verification
 Report and checks proof-pack manifest hashes. The tamper demo also uses
@@ -106,9 +111,8 @@ report to point at another pack would break the Sigstore signature.
 
 ## Verdict Channels
 
-A verdict channel is one kind of check. In this sample, only Integrity is
-required. Claim, replay, and trust are visible so reviewers can see they did
-not run.
+In this sample, only Integrity is required. Claim, replay, and trust are
+visible so reviewers can see they did not run.
 
 | Channel | Result | Plain English |
 |---|---|---|
@@ -117,6 +121,9 @@ not run.
 | Replay | `NOT_RUN` | This sample did not rerun behavior. |
 | Trust | `NOT_EVALUATED` | This sample did not apply a trust policy. |
 | Overall | `PASS` | The required integrity channel passed. |
+
+`NOT_EVALUATED` and `NOT_RUN` both mean the channel did not contribute to the
+sample passing. Replay says `NOT_RUN` because no replay was attempted.
 
 Important: overall `PASS` only means the required integrity check passed for
 the `integrity_required` profile. It does not mean every possible check was

--- a/docs/examples/verification-gate-v0/verification-card.txt
+++ b/docs/examples/verification-gate-v0/verification-card.txt
@@ -11,6 +11,7 @@ Verification Report:
 
 Signature proof:
   signed-report/verify_report.sigstore.json
+  Not proof-pack/pack_signature.sig
 
 Pack root:
   88444482656580c864b9b879d877e82a05359c5f3970ec385b64f7777f73a053
@@ -33,6 +34,8 @@ Not evaluated:
   claim correctness: NOT_EVALUATED
   replay: NOT_RUN
   trust policy: NOT_EVALUATED
+  NOT_EVALUATED and NOT_RUN both mean the channel did not contribute to this
+  sample passing.
 
 What this proves:
   The evidence pack passed integrity verification.

--- a/docs/verification-gate-v0-external-checklist.md
+++ b/docs/verification-gate-v0-external-checklist.md
@@ -74,13 +74,13 @@ Expected result:
 Result: INTEGRITY VERIFIED
 ```
 
-The script also prints the report's verdict channels and confirms that
-`signed-report/verify_report.json` and `proof-pack/pack_manifest.json` name the same
-`pack_root_sha256`.
-
 A verdict channel is one kind of check. In this sample, only Integrity is
 required. Claim, replay, and trust are visible so reviewers can see they did
 not run.
+
+The script also prints the report's verdict channels and confirms that
+`signed-report/verify_report.json` and `proof-pack/pack_manifest.json` name the same
+`pack_root_sha256`.
 
 Optional tamper check:
 
@@ -198,6 +198,8 @@ search. A workflow from another repo or fork would not satisfy this command.
 4. The Integrity verdict channel was evaluated and passed for the
    `integrity_required` profile.
 5. Claim, replay, and trust channels were not evaluated in this sample.
+   `NOT_EVALUATED` and `NOT_RUN` both mean the channel did not contribute to
+   the sample passing; replay says `NOT_RUN` because no replay was attempted.
 6. The sample does not prove production authorization, legal compliance,
    ledger acceptance, scorecard interpretation, full claim evaluation, replay
    evaluation, or trust-policy evaluation.

--- a/docs/verification-gate-v0-handoff-note.md
+++ b/docs/verification-gate-v0-handoff-note.md
@@ -47,6 +47,10 @@ docs/examples/verification-gate-v0/
 - `signed-report/verify_report.sigstore.json` is the provenance bundle for
   the judgment signature.
 
+A verdict channel is one kind of check. This sample shows four channels:
+Integrity, Claim, Replay, and Trust. Only Integrity is required for this
+sample.
+
 ## What This Proves
 
 - The signed public report and proof-pack manifest bind to the same
@@ -56,9 +60,9 @@ docs/examples/verification-gate-v0/
   workflow identity for PR `#116`.
 - The required integrity channel passed.
 
-A verdict channel is one kind of check. In this sample, only Integrity is
-required. Claim, replay, and trust-policy channels are visible so reviewers can
-see they did not run.
+Claim, replay, and trust-policy channels are visible so reviewers can see they
+did not run. `NOT_EVALUATED` and `NOT_RUN` both mean the channel did not
+contribute to the sample passing.
 
 The sample is tied to the historical PR `#116` workflow identity:
 


### PR DESCRIPTION
## Summary\n- define verdict channels before reviewer questions use the term\n- clarify that NOT_EVALUATED and NOT_RUN both mean the channel did not contribute to this integrity-only sample passing\n- distinguish the public Signature Proof from proof-pack/pack_signature.sig\n- fix the worked example claim row so claim/replay/trust are explicitly not evaluated\n\n## Validation\n- git diff --check\n- bash scripts/verify_verification_gate_sample.sh\n- bash scripts/demo_tamper_verification_gate_sample.sh