### PR TITLE
docs: refine Assay PR Gate v0.1 plan

### DIFF
--- a/docs/adr/ADR-pr-gate-trust-root.md
+++ b/docs/adr/ADR-pr-gate-trust-root.md
@@ -1,0 +1,75 @@
+# ADR: PR Gate Trust Root
+
+## Status
+
+Proposed.
+
+## Context
+
+Verification Gate v0 used a historical proof sample whose Sigstore identity
+was tied to a pull request merge ref. That is acceptable for a frozen sample,
+but PR Gate needs a stable expected signer identity that reviewers can
+understand and verifiers can enforce.
+
+GitHub Actions exposes workflow, run, ref, SHA, actor, and related context
+fields. GitHub artifact attestations and Sigstore-based signing already provide
+strong provenance plumbing. PR Gate should use that plumbing while adding
+Assay's review semantics: verdict channels, caveats, policy result, and
+recommended action.
+
+## Decision
+
+The intended dogfood signer identity is:
+
+```text
+Haserjian/assay/.github/workflows/assay-pr-gate.yml@refs/heads/main
+```
+
+The public Verification Report must be signed by the expected workflow
+identity for the run being trusted.
+
+The PR Gate verifier must fail if:
+
+- the Verification Report is tampered with
+- the evidence pack does not match the report's pack root
+- the expected signer identity does not match
+- the policy hash is missing or mismatched, unless the packet explicitly
+  downgrades to `manual_triage`
+
+## Buyer-Facing Language
+
+Use:
+
+```text
+Signed by expected GitHub workflow.
+```
+
+Do not lead with:
+
+```text
+OIDC
+Fulcio
+Rekor
+keyless signing
+```
+
+Those are technical appendix concepts. The reviewer-facing contract is the
+expected workflow identity and the local verification result.
+
+## Consequences
+
+- PR Gate needs a stable workflow on `main`.
+- Historical sample identities remain valid for their frozen artifacts but are
+  not reproducible build targets.
+- Consumer repositories need a way to configure expected signer identities.
+- Private repository support may require hosted or enterprise-specific storage
+  and signing policy decisions later.
+
+## References
+
+- GitHub Actions contexts:
+  <https://docs.github.com/en/actions/reference/workflows-and-actions/contexts>
+- GitHub artifact attestations:
+  <https://docs.github.com/actions/concepts/security/artifact-attestations>
+- Sigstore signing overview:
+  <https://docs.sigstore.dev/cosign/signing/overview/>

--- a/docs/adr/ADR-pr-gate-two-lane-github-security.md
+++ b/docs/adr/ADR-pr-gate-two-lane-github-security.md
@@ -1,0 +1,85 @@
+# ADR: PR Gate Two-Lane GitHub Security
+
+## Status
+
+Proposed.
+
+## Context
+
+PR Gate needs to inspect pull request facts and post a review decision. Public
+and fork-friendly repositories introduce a security boundary: untrusted pull
+request code must not run in a privileged workflow that can write comments,
+access secrets, or request signing identity.
+
+GitHub secure-use guidance warns that `pull_request_target` and `workflow_run`
+can expose repositories when combined with checkout of untrusted pull request
+code. GitHub Security Lab's pwn-request guidance recommends separating
+untrusted PR processing from privileged publication paths.
+
+## Decision
+
+PR Gate will support two modes.
+
+### Dogfood Mode
+
+Use a single same-repo workflow while developing on controlled branches:
+
+```text
+pull_request workflow
+read PR metadata
+evaluate policy
+emit packet
+sign report
+post comment
+```
+
+This is acceptable only for controlled dogfood where the trust boundary is
+explicit.
+
+### Production Mode
+
+Use a two-lane model.
+
+Lane A, untrusted collector:
+
+- trigger: `pull_request`
+- permissions: read-only
+- no secrets
+- no privileged token
+- no signing identity
+- collect PR metadata and observed check evidence
+- upload unsigned or minimally signed capture artifact
+
+Lane B, trusted signer and publisher:
+
+- trigger: trusted event such as `workflow_run` or an equivalent controlled
+  same-repo event
+- permissions: write PR comments and request OIDC signing identity
+- never checks out untrusted PR code
+- validates capture artifact shape
+- evaluates policy
+- emits and signs the public Verification Report
+- uploads packet artifacts
+- posts or updates the PR comment
+
+## Consequences
+
+- Dogfood can move quickly.
+- Production mode adds complexity but preserves the security boundary.
+- The signer/publisher must treat collector artifacts as untrusted input until
+  validated.
+- PR title, branch names, file paths, and other GitHub context values must not
+  be interpolated directly into shell commands.
+
+## Non-Goals
+
+- This ADR does not define a full sandbox for running untrusted PR code.
+- This ADR does not define hosted storage.
+- This ADR does not define enterprise deployment.
+
+## References
+
+- GitHub secure-use guidance:
+  <https://docs.github.com/en/enterprise-server@3.16/actions/reference/security/secure-use>
+- GitHub Security Lab pwn-request guidance:
+  <https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/>

--- a/docs/examples/pr-gate-v0/assay-policy.yml
+++ b/docs/examples/pr-gate-v0/assay-policy.yml
@@ -1,0 +1,38 @@
+profile: coding_pr_v0
+
+risk_paths:
+  - "auth/**"
+  - "billing/**"
+  - ".github/workflows/**"
+  - "infra/**"
+  - "pyproject.toml"
+  - "package-lock.json"
+  - "requirements*.txt"
+
+required_checks:
+  - "tests"
+
+rules:
+  integrity_failed:
+    decision: BLOCK
+    recommended_action: block_integrity_failed
+
+  untrusted_signer:
+    decision: BLOCK
+    recommended_action: block_untrusted_signer
+
+  required_check_missing:
+    decision: NEEDS_REVIEW
+    recommended_action: rerun_required_check
+
+  required_check_failed:
+    decision: BLOCK
+    recommended_action: block_missing_evidence
+
+  risk_path_touched:
+    decision: NEEDS_REVIEW
+    recommended_action: require_human_approval
+
+default:
+  decision: PASS
+  recommended_action: proceed

--- a/docs/product/assay-pr-gate-comment-v0.md
+++ b/docs/product/assay-pr-gate-comment-v0.md
@@ -1,0 +1,162 @@
+# Assay PR Gate Comment v0
+
+The PR comment is not the product. The signed review decision is the product.
+The PR comment is the required delivery surface because it appears at the pull
+request review moment.
+
+This document defines the first rendered comment contract.
+
+## Goals
+
+- Show the review decision without requiring a dashboard.
+- Make the evidence binding visible in the comment body.
+- Preserve verdict-channel discipline.
+- Avoid implying the code is secure, correct, or production-approved.
+- Link to the signed evidence pack and Verification Report.
+
+## Required Fields
+
+Every Assay PR Gate comment must include:
+
+- overall decision
+- recommended action
+- reason
+- subject repo, PR, head commit, and diff hash
+- verdict channels
+- Evidence Box
+- Verification Report
+- Signature Proof
+- Do Not Infer footer
+- expected signer identity
+
+## Canonical NEEDS_REVIEW Comment
+
+```text
+Assay PR Gate: NEEDS_REVIEW
+
+Recommended action: require_human_approval
+Reason: touched risk path auth/**
+
+Subject:
+- repo: Haserjian/assay
+- PR: #123
+- head commit: abc123
+- diff hash: sha256:...
+
+Verdict channels:
+- Integrity: PASS
+- Claim: PASS - observed check "tests" concluded success for commit abc123
+- Replay: NOT_RUN
+- Trust policy: NEEDS_REVIEW - touched auth/session.py
+
+Evidence:
+- Evidence Box: proof-pack/pack_manifest.json
+- Verification Report: signed-report/verify_report.json
+- Signature Proof: signed-report/verify_report.sigstore.json
+
+Do not infer:
+- code is secure
+- all possible tests passed
+- AI made a good design decision
+- replay was performed
+- production approval was granted
+
+Signed by expected workflow:
+Haserjian/assay/.github/workflows/assay-pr-gate.yml@refs/heads/main
+```
+
+## Decision Rendering
+
+Use exactly these labels:
+
+```text
+PASS - proceed to normal review
+NEEDS_REVIEW
+BLOCK
+ERROR
+```
+
+Do not render `PASS` as "safe to merge." `PASS` only means Assay found no
+policy reason to stop normal review.
+
+## Recommended Action Rendering
+
+Use exactly these action identifiers:
+
+```text
+proceed
+require_human_approval
+request_codeowner_review
+rerun_required_check
+block_missing_evidence
+block_integrity_failed
+block_untrusted_signer
+manual_triage
+```
+
+Each action can have a human sentence next to it, but the identifier itself
+must remain stable.
+
+## Claim Wording
+
+Do not write:
+
+```text
+Tests passed.
+```
+
+Write:
+
+```text
+Observed check "tests" concluded success for commit abc123.
+```
+
+or:
+
+```text
+Observed command "pytest" exited 0 in workflow run 123456 for commit abc123.
+```
+
+The claim must name the observed check or command, the result, and the commit.
+
+## Evidence Wording
+
+Use the three-object model:
+
+| Human name | Meaning |
+|---|---|
+| Evidence Box | The evidence pack being reviewed. |
+| Verification Report | What Assay decided about the evidence. |
+| Signature Proof | Who signed the public Verification Report. |
+
+Do not require readers to learn Sigstore, Cosign, or pack internals from the
+comment. Those belong in linked technical details.
+
+## Snapshot Cases
+
+The eventual renderer should have stable snapshots for:
+
+- `PASS`
+- `NEEDS_REVIEW`
+- `BLOCK`
+- `ERROR`
+
+Minimum planned snapshot paths:
+
+```text
+tests/pr_gate/snapshots/comment_pass.md
+tests/pr_gate/snapshots/comment_needs_review.md
+tests/pr_gate/snapshots/comment_block.md
+tests/pr_gate/snapshots/comment_error.md
+```
+
+## Non-Claims
+
+The comment must not claim:
+
+- the code is secure
+- all relevant tests passed
+- AI made a good design decision
+- replay was performed
+- production approval was granted
+- legal or compliance approval was granted

--- a/docs/product/assay-pr-gate-policy-v0.md
+++ b/docs/product/assay-pr-gate-policy-v0.md
@@ -1,0 +1,132 @@
+# Assay PR Gate Policy v0
+
+This document defines the first PR Gate policy profile:
+
+```text
+coding_pr_v0
+```
+
+The policy is intentionally small. Its job is to map captured pull request
+facts to a stable review decision and recommended action.
+
+## Decision Enum
+
+```text
+PASS
+NEEDS_REVIEW
+BLOCK
+ERROR
+```
+
+`PASS` means Assay found no policy reason to stop normal review. It does not
+mean the PR should be merged automatically.
+
+## Recommended Action Enum
+
+```text
+proceed
+require_human_approval
+request_codeowner_review
+rerun_required_check
+block_missing_evidence
+block_integrity_failed
+block_untrusted_signer
+manual_triage
+```
+
+No free-form action identifiers in v0.
+
+## Initial Rules
+
+Rules are evaluated from most severe to least severe.
+
+| Rule | Decision | Recommended action |
+|---|---|---|
+| `integrity_failed` | `BLOCK` | `block_integrity_failed` |
+| `untrusted_signer` | `BLOCK` | `block_untrusted_signer` |
+| `required_check_failed` | `BLOCK` | `block_missing_evidence` |
+| `required_check_missing` | `NEEDS_REVIEW` | `rerun_required_check` |
+| `risk_path_touched` | `NEEDS_REVIEW` | `require_human_approval` |
+| default | `PASS` | `proceed` |
+
+## Risk Paths
+
+Initial risk paths:
+
+```yaml
+risk_paths:
+  - "auth/**"
+  - "billing/**"
+  - ".github/workflows/**"
+  - "infra/**"
+  - "pyproject.toml"
+  - "package-lock.json"
+  - "requirements*.txt"
+```
+
+These are example defaults. Consumer repos must be able to override them.
+
+## Required Checks
+
+Initial required checks:
+
+```yaml
+required_checks:
+  - "tests"
+```
+
+The first bounded claim is only:
+
+```text
+Observed check "<name>" concluded "<conclusion>" for commit "<sha>".
+```
+
+It is not:
+
+```text
+All tests passed.
+```
+
+## Output Shape
+
+Policy evaluation should produce:
+
+```json
+{
+  "overall_decision": "NEEDS_REVIEW",
+  "recommended_action": "require_human_approval",
+  "reasons": [
+    {
+      "rule": "risk_path_touched",
+      "path": "auth/session.py",
+      "matched_pattern": "auth/**"
+    }
+  ],
+  "channels": {
+    "integrity": "PASS",
+    "claim": "PASS",
+    "replay": "NOT_RUN",
+    "trust_policy": "NEEDS_REVIEW"
+  }
+}
+```
+
+## Acceptance Tests
+
+The policy evaluator must cover:
+
+- clean PR
+- risk path touched
+- required check missing
+- required check failed
+- integrity failed
+- untrusted signer
+- multiple reasons with deterministic ordering
+
+## Example Policy
+
+The concrete example file lives at:
+
+```text
+docs/examples/pr-gate-v0/assay-policy.yml
+```

--- a/docs/product/assay-pr-gate-v0.md
+++ b/docs/product/assay-pr-gate-v0.md
@@ -1,154 +1,190 @@
-# Assay PR Gate v0
+# Assay PR Gate v0.1 Plan
 
-Assay PR Gate gives AI-assisted pull requests a signed review packet showing
-what changed, what checks ran, what passed, what did not run, and whether
-policy requires human review.
+Assay PR Gate produces a signed review decision for pull requests, binding
+evidence, policy, verdict channels, caveats, and recommended action to a
+specific commit.
 
 This is a product planning note. It does not claim that PR Gate is implemented
-today. The current implemented base is the Verification Gate v0 integrity
-sample: evidence pack, Verification Report, Sigstore Signature Proof, verdict
-channels, and conservative scope language.
+today. The current implemented base is Verification Gate v0: evidence pack,
+Verification Report, Sigstore Signature Proof, verdict channels, and
+conservative scope language.
 
-## Product Bet
+## Product Thesis
 
-Stop selling the primitive:
+The PR comment is not the product. The signed review decision is the product.
+The PR comment is where the product becomes visible.
 
-> Verify this signed artifact.
+Do not define Assay as a better PR comment. That puts it next to ordinary CI
+annotations. Define Assay PR Gate as a signed, scoped, policy-backed review
+decision bound to a PR commit.
 
-Sell the review moment:
+Buyer-facing sentence:
 
-> Before we merge AI-assisted code, we require an Assay Review Packet.
+> Before risky or AI-assisted code is merged, Assay produces a signed Review
+> Packet showing what changed, what was checked, what did not run, and what the
+> reviewer should do next.
 
-The buyer does not pay for signed JSON. The buyer pays for confidence that
-AI-assisted work can be reviewed, approved, escalated, audited, or defended
-without trusting a dashboard, screenshot, or verbal claim.
+Short positioning:
 
-## First Wedge
+> Signed review decisions for high-velocity PRs.
 
-Start with GitHub pull request review for AI-assisted code.
+AI-assisted pull requests are the beachhead because they create urgency. The
+substrate should also work for non-AI high-risk PRs where reviewer attention is
+the bottleneck.
 
-This wedge has a concrete buyer, workflow, and decision:
+## Product Contract
 
-| Item | v0 choice |
-|---|---|
-| Buyer | Engineering lead or security-minded team |
-| Workflow | GitHub pull request review |
-| Decision | Merge normally, require human approval, or block |
-| Artifact | Signed Assay Review Packet |
-| Pain | AI-assisted code is hard to trust blindly |
+Input:
 
-Do not start with generic AI governance. Do not start with dashboards. The
-first product surface is the pull request comment because it appears at the
-decision point.
+- repository
+- PR number
+- base SHA
+- head SHA
+- merge or ref SHA when applicable
+- changed files
+- diff hash
+- workflow and run identity
+- observed check results
+- policy profile
+- risk path matches
 
-## User Story
+Output:
 
-As an engineering lead, when an AI-assisted pull request is opened or updated,
-I want a signed review packet so I can see what happened, what evidence was
-captured, what checks ran, and whether policy says this needs human attention.
+- Assay Review Packet
+- evidence pack
+- Verification Report
+- Signature Proof
+- PR-visible review decision
+- local or CLI verifier result
 
-## Product Surface
+Primary user:
 
-The first surface is a GitHub PR comment.
+> Security-minded engineering lead at a 20-500 person software team using
+> GitHub and AI coding tools.
 
-Example:
+First policy:
+
+> AI-assisted PRs are allowed, but risky paths require a signed Assay Review
+> Packet and human approval.
+
+## Decision Vocabulary
+
+Keep the decision surface finite.
 
 ```text
-Assay PR Gate: NEEDS_REVIEW
-
-Profile: coding_pr_v0
-Recommended action: require human approval before merge
-
-Integrity: PASS
-Claim: PASS - observed CI check exited 0 for commit abc123
-Replay: NOT_RUN
-Trust policy: NEEDS_REVIEW - touched auth/**
-
-Evidence captured:
-- repo: Haserjian/example
-- PR: #42
-- commit: abc123
-- changed files: 4
-- risk paths touched: auth/session.py
-- signer: expected GitHub Actions workflow
-
-View signed review packet: <link>
-Download Verification Report: <link>
+overall_decision:
+  PASS
+  NEEDS_REVIEW
+  BLOCK
+  ERROR
 ```
 
-The wording must stay bounded. `Claim: PASS` for v0 means a specific observed
-claim was supported by captured evidence. It must not mean "the code is good"
-or "all relevant tests passed."
+`PASS` does not mean "merge automatically." It means Assay found no policy
+reason to stop normal review.
 
-## Decision Model
+Render it as:
 
-PR Gate should make the next action explicit:
-
-```json
-{
-  "overall_verdict": "NEEDS_REVIEW",
-  "recommended_action": "require_human_approval",
-  "blocking_reason": "touched_risk_path"
-}
+```text
+PASS - proceed to normal review
 ```
 
-The decision fields are product-facing summaries. They do not replace the
-underlying verdict channels; they make the review moment legible.
+Recommended actions are also fixed. Do not allow free-form action strings.
+Free-form action strings cannot aggregate, compare, dashboard, audit, or price.
+
+```text
+recommended_action:
+  proceed
+  require_human_approval
+  request_codeowner_review
+  rerun_required_check
+  block_missing_evidence
+  block_integrity_failed
+  block_untrusted_signer
+  manual_triage
+```
 
 ## Verdict Channels
 
-Use the existing Verification Gate channel discipline, but connect it to PR
-review decisions.
-
-| Channel | v0 meaning |
-|---|---|
-| Integrity | Evidence pack and Verification Report are intact and bound together. |
-| Claim | A narrow PR claim is checked against captured evidence. |
-| Replay | Not run in v0. Do not fake replay. |
-| Trust policy | Repo policy maps facts to PASS, NEEDS_REVIEW, or BLOCK. |
-
-For the first PR Gate demo:
+For PR Gate v0.1:
 
 ```text
-Integrity: PASS
-Claim: PASS - observed CI check exited 0 for commit abc123
+Integrity: PASS / FAIL
+Claim: PASS / FAIL / NOT_EVALUATED
 Replay: NOT_RUN
-Trust policy: NEEDS_REVIEW - touched auth/**
+Trust policy: PASS / NEEDS_REVIEW / BLOCK
 ```
 
-## Bounded Claim Gate
+Keep replay as `NOT_RUN`. Do not fake replay.
 
-The first claim gate should be painfully concrete.
-
-Good v0 claim:
+The first bounded claim should be brutally conservative:
 
 ```text
-Observed CI check exited 0 for commit abc123.
+Observed GitHub check run "<name>" had conclusion "<success|failure|...>" for commit "<sha>".
 ```
 
-Evidence required:
+If Assay itself runs a command:
 
-- CI job or check identifier
-- command or check name
-- exit code or check conclusion
-- commit SHA
-- timestamp
-- output or output hash when available
+```text
+Observed command "<cmd>" exited "<code>" inside workflow run "<run_id>" for commit "<sha>".
+```
 
-Avoid:
+Do not write:
 
 ```text
 Tests passed.
 ```
 
-That phrasing can imply all relevant tests passed. PR Gate v0 should only
-claim that a specific observed check passed for a specific commit.
+That phrase implies too much. The Assay claim is only that a specific observed
+check or command had a specific result for a specific commit.
 
-## Trust Policy Gate
+## Comment Contract
 
-Trust policy is the first money gate because it tells a reviewer what to do.
+The PR comment is the product face. It must show the binding in the comment
+body, not only in linked docs.
 
-Initial policy shape:
+Canonical shape:
+
+```text
+Assay PR Gate: NEEDS_REVIEW
+
+Recommended action: require_human_approval
+Reason: touched risk path auth/**
+
+Subject:
+- repo: Haserjian/assay
+- PR: #123
+- head commit: abc123
+- diff hash: sha256:...
+
+Verdict channels:
+- Integrity: PASS
+- Claim: PASS - observed check "tests" concluded success for commit abc123
+- Replay: NOT_RUN
+- Trust policy: NEEDS_REVIEW - touched auth/session.py
+
+Evidence:
+- Evidence Box: proof-pack/pack_manifest.json
+- Verification Report: signed-report/verify_report.json
+- Signature Proof: signed-report/verify_report.sigstore.json
+
+Do not infer:
+- code is secure
+- all possible tests passed
+- AI made a good design decision
+- replay was performed
+- production approval was granted
+
+Signed by expected workflow:
+Haserjian/assay/.github/workflows/assay-pr-gate.yml@refs/heads/main
+```
+
+Detailed rendering rules live in:
+
+- `docs/product/assay-pr-gate-comment-v0.md`
+
+## Policy Contract
+
+Initial policy profile:
 
 ```yaml
 profile: coding_pr_v0
@@ -157,147 +193,427 @@ risk_paths:
   - "auth/**"
   - "billing/**"
   - ".github/workflows/**"
+  - "infra/**"
+  - "pyproject.toml"
+  - "package-lock.json"
+  - "requirements*.txt"
+
+required_checks:
+  - "tests"
 
 rules:
-  tests_missing:
-    verdict: NEEDS_REVIEW
-    action: require_human_approval
+  integrity_failed:
+    decision: BLOCK
+    recommended_action: block_integrity_failed
+
+  untrusted_signer:
+    decision: BLOCK
+    recommended_action: block_untrusted_signer
+
+  required_check_missing:
+    decision: NEEDS_REVIEW
+    recommended_action: rerun_required_check
+
+  required_check_failed:
+    decision: BLOCK
+    recommended_action: block_missing_evidence
 
   risk_path_touched:
-    verdict: NEEDS_REVIEW
-    action: require_human_approval
+    decision: NEEDS_REVIEW
+    recommended_action: require_human_approval
 
-  report_signature_invalid:
-    verdict: BLOCK
-    action: do_not_merge
-
-  evidence_integrity_failed:
-    verdict: BLOCK
-    action: do_not_merge
+default:
+  decision: PASS
+  recommended_action: proceed
 ```
 
-This policy is intentionally small. It should be easy for a reviewer to
-explain why a PR received PASS, NEEDS_REVIEW, or BLOCK.
+Detailed policy semantics live in:
 
-## Evidence Captured
+- `docs/product/assay-pr-gate-policy-v0.md`
+- `docs/examples/pr-gate-v0/assay-policy.yml`
 
-PR Gate v0 should capture the boring facts needed for review:
+## GitHub Security Model
 
-- repository
-- PR number
-- branch or ref
-- commit SHA
-- changed files
-- diff hash
-- risk path matches
-- actor and workflow identity
-- relevant CI check names and conclusions
-- observed command, exit code, and output hash when available
-- policy profile and policy hash
-- timestamps
+Do not accidentally create the thing Assay is meant to defend against.
 
-Do not make users manually assemble this evidence. The packet should be
-generated as a side effect of the normal pull request workflow.
+The dogfood path can start with a simple same-repo workflow. Production shape
+needs a two-lane model:
 
-## MVP Flow
+Lane A, untrusted collector:
+
+- trigger: `pull_request`
+- permissions: read-only
+- no secrets
+- no privileged token
+- collect PR metadata and check evidence
+- upload unsigned or minimally signed capture artifact
+
+Lane B, trusted signer and publisher:
+
+- trigger: trusted event such as `workflow_run` or a controlled same-repo path
+- permissions: write PR comment and request OIDC signing identity
+- never checks out untrusted PR code
+- validates capture artifact shape
+- evaluates, signs, publishes, and comments
+
+Security ADRs:
+
+- `docs/adr/ADR-pr-gate-two-lane-github-security.md`
+- `docs/adr/ADR-pr-gate-trust-root.md`
+
+## Evidence Object
+
+PR Gate evidence should be separate from generic pack internals.
+
+Suggested shape:
+
+```json
+{
+  "schema_version": "assay.pr_gate.evidence.v0.1",
+  "subject": {
+    "repo": "Haserjian/assay",
+    "pr_number": 123,
+    "base_sha": "...",
+    "head_sha": "...",
+    "diff_sha256": "sha256:..."
+  },
+  "capture": {
+    "provider": "github_actions",
+    "workflow_ref": "...",
+    "workflow_sha": "...",
+    "run_id": "...",
+    "run_attempt": "...",
+    "actor": "..."
+  },
+  "changed_files": [
+    {
+      "path": "auth/session.py",
+      "status": "modified",
+      "sha256_after": "..."
+    }
+  ],
+  "observed_checks": [
+    {
+      "name": "tests",
+      "provider": "github_checks",
+      "head_sha": "...",
+      "conclusion": "success",
+      "observed_at": "..."
+    }
+  ],
+  "policy": {
+    "profile": "coding_pr_v0",
+    "policy_sha256": "..."
+  }
+}
+```
+
+Acceptance condition:
+
+> This object can be hashed, included in an evidence pack, and referenced by
+> the Verification Report.
+
+## Milestones
+
+### Milestone 0: Product Constitution
+
+Create and keep current:
+
+- `docs/product/assay-pr-gate-v0.md`
+- `docs/product/assay-pr-gate-comment-v0.md`
+- `docs/product/assay-pr-gate-policy-v0.md`
+- `docs/adr/ADR-pr-gate-trust-root.md`
+- `docs/adr/ADR-pr-gate-two-lane-github-security.md`
+
+Acceptance condition:
+
+> A reviewer can read the docs and understand exactly what PR Gate claims and
+> does not claim.
+
+### Milestone 1: Policy Profile
+
+Create:
+
+- `docs/examples/pr-gate-v0/assay-policy.yml`
+
+Acceptance condition:
+
+> Given changed files and observed checks, the evaluator returns deterministic
+> PASS, NEEDS_REVIEW, BLOCK, or ERROR.
+
+### Milestone 2: Capture Adapter
+
+Planned module:
 
 ```text
-1. Developer or agent opens/updates a PR.
-2. GitHub Action runs.
-3. Assay captures PR metadata, changed files, risk path matches, and observed checks.
-4. Assay applies coding_pr_v0 policy.
-5. Assay emits proof-pack/.
-6. Assay emits signed-report/verify_report.json.
-7. Assay signs the public Verification Report.
-8. Assay uploads the packet as a workflow artifact.
-9. Assay posts or updates a PR comment.
-10. Reviewer reads the comment and opens the signed review packet if needed.
+assay/pr_gate/github_capture.py
 ```
 
-## Demo Scenario
+Planned CLI:
 
-Use a deliberately obvious PR:
+```bash
+assay pr-gate capture \
+  --repo "$GITHUB_REPOSITORY" \
+  --pr "$PR_NUMBER" \
+  --head-sha "$GITHUB_SHA" \
+  --out .assay/pr-gate/evidence.json
+```
+
+Acceptance condition:
+
+> Running capture on a PR produces stable JSON and a deterministic diff hash.
+
+### Milestone 3: Policy Evaluator
+
+Planned module:
 
 ```text
-AI-assisted change modifies auth/session.py.
-CI check exits 0 for the commit.
-Assay records changed files and the observed check result.
-Policy flags auth/** as high-risk.
-PR comment says NEEDS_REVIEW.
-Evidence pack and signed Verification Report are attached.
-Tampering breaks verification.
+assay/pr_gate/policy.py
 ```
 
-This demo should make the review value visible in seconds:
+Planned CLI:
+
+```bash
+assay pr-gate evaluate \
+  --evidence .assay/pr-gate/evidence.json \
+  --policy docs/examples/pr-gate-v0/assay-policy.yml \
+  --out .assay/pr-gate/decision.json
+```
+
+Decision output:
+
+```json
+{
+  "overall_decision": "NEEDS_REVIEW",
+  "recommended_action": "require_human_approval",
+  "reasons": [
+    {
+      "rule": "risk_path_touched",
+      "path": "auth/session.py",
+      "matched_pattern": "auth/**"
+    }
+  ],
+  "channels": {
+    "integrity": "PASS",
+    "claim": "PASS",
+    "replay": "NOT_RUN",
+    "trust_policy": "NEEDS_REVIEW"
+  }
+}
+```
+
+Acceptance condition:
+
+> Tests cover risk path, missing check, failed check, untrusted signer, and
+> clean PR.
+
+### Milestone 4: Packet Generator
+
+Planned module:
 
 ```text
-The code may be fine, but policy requires a human because auth/** changed.
+assay/pr_gate/packet.py
 ```
 
-## Tamper Demonstrations
+Planned output:
 
-Keep the existing tamper discipline and apply it to the PR packet:
+```text
+proof-pack/
+  pack_manifest.json
+  pr_gate_evidence.json
+  pr_gate_decision.json
+  changed_files.json
+  observed_checks.json
+  policy.yml
+  verify_transcript.md
 
-| Tamper | Expected result |
-|---|---|
-| Change Verification Report verdict | Signature verification fails. |
-| Change evidence pack file | Pack integrity fails. |
-| Swap evidence pack | Pack root mismatch fails. |
-| Remove risk path evidence | Policy/report consistency fails. |
+signed-report/
+  verify_report.json
+  verify_report.sigstore.json
+```
 
-## Out Of Scope For v0
+Acceptance condition:
 
-- Proving the code is secure.
-- Proving the AI made a good design decision.
-- Replaying the agent run.
-- Full static analysis.
-- Full supply-chain attestation.
+> The Verification Report points to the evidence pack root hash and names all
+> verdict channels.
+
+### Milestone 5: Stable Signing Identity
+
+Graduate from the historical PR sample identity to:
+
+```text
+Haserjian/assay/.github/workflows/assay-pr-gate.yml@refs/heads/main
+```
+
+Acceptance condition:
+
+> Clean report verifies. Report tamper fails. Wrong expected identity fails.
+
+### Milestone 6: Comment Renderer
+
+Planned module:
+
+```text
+assay/pr_gate/render_comment.py
+```
+
+Planned snapshots:
+
+```text
+tests/pr_gate/snapshots/comment_pass.md
+tests/pr_gate/snapshots/comment_needs_review.md
+tests/pr_gate/snapshots/comment_block.md
+```
+
+Acceptance condition:
+
+> The PR comment is stable, readable, and includes the three objects: Evidence
+> Box, Verification Report, Signature Proof.
+
+### Milestone 7: GitHub Workflow
+
+Dogfood workflow:
+
+```text
+.github/workflows/assay-pr-gate.yml
+```
+
+Acceptance condition:
+
+> A real Assay PR gets a comment backed by uploaded evidence pack and signed
+> report artifacts.
+
+### Milestone 8: Verification CLI
+
+Planned CLI:
+
+```bash
+assay pr-gate verify \
+  --pack proof-pack \
+  --report signed-report/verify_report.json \
+  --sigstore signed-report/verify_report.sigstore.json \
+  --expected-identity "Haserjian/assay/.github/workflows/assay-pr-gate.yml@refs/heads/main"
+```
+
+Expected output:
+
+```text
+Result: ASSAY PR GATE VERIFIED
+Decision: NEEDS_REVIEW
+Recommended action: require_human_approval
+Integrity: PASS
+Claim: PASS
+Replay: NOT_RUN
+Trust policy: NEEDS_REVIEW
+```
+
+Acceptance condition:
+
+> Clean packet verifies. Report tamper rejects. Pack tamper rejects. Wrong
+> signer rejects. Policy hash mismatch rejects or downgrades to manual_triage.
+
+### Milestone 9: Demo PR
+
+Create a deliberately obvious dogfood PR:
+
+```text
+touches auth/session.py
+has observed check success
+triggers risk path policy
+receives NEEDS_REVIEW
+packet verifies locally
+tamper demo fails
+```
+
+Acceptance condition:
+
+> A skeptical engineering lead can watch one PR and understand the value in
+> under five minutes.
+
+## Agent Workstreams
+
+Use parallel agents only after the interfaces above are fixed.
+
+| Agent | Ownership | Output |
+|---|---|---|
+| Product/spec | Product docs and non-claims | Updated product contract and examples |
+| Policy engine | `assay/pr_gate/policy.py` | Deterministic `decision.json` and tests |
+| GitHub capture | `assay/pr_gate/github_capture.py` | Stable `evidence.json` and tests |
+| Packet/report | `assay/pr_gate/packet.py` | Evidence pack and Verification Report |
+| Signing/verification | PR Gate verify CLI | clean/tamper/wrong-identity tests |
+| Comment renderer | `assay/pr_gate/render_comment.py` | Markdown snapshots |
+| GitHub workflow | `.github/workflows/assay-pr-gate.yml` | Dogfood PR comments |
+| Demo/docs | `docs/examples/pr-gate-v0/` | Cold-reader walkthrough and tamper demo |
+
+## Out Of Scope For v0.1
+
 - Hosted dashboard.
 - Ledger.
-- Scorecards.
+- Scorecard interpretation.
 - MemoryGraph.
 - Quintet.
+- Full agent replay.
+- Full static analysis.
+- Full vulnerability scanner.
+- Automatic AI-authorship detection.
+- Enterprise compliance mapping.
 - Multi-witness verification.
-- General AI governance platform.
 
-## Open Implementation Questions
+These stay out until a named buyer conversation asks for them.
 
-- Should the first runnable slice live in this repo or in
-  `assay-verify-action`?
-- Should PR comment creation be implemented directly or delegated to an
-  existing comment action?
-- Which CI checks should v0 observe: named checks, local commands, or both?
-- Where should `coding_pr_v0` policy live in a consumer repo?
-- Should hosted verification wait until the PR comment proves useful, or
-  should the first demo use a static verifier page?
+## Buyer Test
 
-## First Build Target
-
-Build the smallest runnable PR Gate slice as a GitHub Action, wherever it can
-be proven fastest.
-
-Minimum successful demo:
+First uncomfortable demo:
 
 ```text
-A GitHub PR receives an Assay comment saying PASS / NEEDS_REVIEW / BLOCK,
-backed by a signed evidence pack and public Verification Report.
+Here is a real PR.
+Here is what changed.
+Here is why Assay marked NEEDS_REVIEW.
+Here is the signed packet.
+Here is what it does not claim.
+Here is what happens if I tamper with it.
+Would this reduce review ambiguity on your team?
+What would make this required in your workflow?
 ```
 
-Do not block this prototype on final package boundaries, hosted dashboards, or
-general trace ingestion. Prove the review loop first.
+The sales question is not:
 
-## Positioning
+```text
+Do you like provenance?
+```
 
-Short:
+The sales question is:
 
-> Signed review packets for AI-assisted pull requests.
+```text
+Would you require this before merging AI-assisted changes to auth, billing,
+infra, or workflows?
+```
 
-Buyer sentence:
+## Real Success Conditions
 
-> Assay PR Gate shows what changed, what checks ran, what passed, what did not
-> run, and what policy says the reviewer should do next.
+1. A real Assay PR receives a signed Assay PR Gate comment saying
+   `NEEDS_REVIEW` for a concrete reason.
+2. The linked evidence pack verifies locally.
+3. Tampering with the report, pack, policy, or signer breaks verification.
+4. A skeptical engineering lead can read the comment and say: "I understand
+   what this is for."
 
-Boundary sentence:
+## Research Anchors
 
-> Assay does not prove AI work is correct. It makes AI-assisted work
-> inspectable, attributable, tamper-evident, and bounded enough to review.
+- GitHub Actions contexts expose run, workflow, ref, actor, SHA, and retention
+  metadata useful for capture:
+  <https://docs.github.com/en/actions/reference/workflows-and-actions/contexts>
+- GitHub Checks API supports listing check runs for a Git reference:
+  <https://docs.github.com/en/rest/reference/checks>
+- GitHub artifact attestations already provide signed build provenance; Assay
+  should add review semantics, not compete on raw signing:
+  <https://docs.github.com/actions/concepts/security/artifact-attestations>
+- GitHub secure-use guidance warns about privileged triggers with untrusted PR
+  checkout:
+  <https://docs.github.com/en/enterprise-server@3.16/actions/reference/security/secure-use>
+- GitHub Security Lab's pwn-request guidance motivates the two-lane model:
+  <https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/>
+- OpenTelemetry GenAI conventions include agent/workflow/tool spans but remain
+  development-stage; PR Gate should be trace-compatible without depending on
+  one final trace schema:
+  <https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/>


### PR DESCRIPTION
## Summary\n- refine Assay PR Gate into a buildable v0.1 product constitution\n- define fixed decision and recommended_action vocabularies\n- add PR comment contract, policy contract, and example coding_pr_v0 policy\n- add ADRs for stable trust root and two-lane GitHub workflow security\n- preserve the boundary that this is planned, not implemented\n\n## Validation\n- git diff --check\n- bash scripts/verify_verification_gate_sample.sh\n- bash scripts/demo_tamper_verification_gate_sample.sh\n- lightweight docs/examples/pr-gate-v0/assay-policy.yml checks; PyYAML unavailable locally\n\n## Research anchors\n- GitHub Actions contexts and Checks API for PR capture\n- GitHub artifact attestations and Sigstore for signing/provenance plumbing\n- GitHub secure-use + Security Lab pwn-request guidance for the two-lane workflow boundary\n- OpenTelemetry GenAI conventions for future trace-compatible ingestion