### PR TITLE
feat: add PR Gate packet generator

### DIFF
--- a/src/assay/commands.py
+++ b/src/assay/commands.py
@@ -8319,6 +8319,58 @@ def pr_gate_capture_cmd(
         )
 
 
+@pr_gate_app.command("pack")
+def pr_gate_pack_cmd(
+    evidence: str = typer.Option(
+        ..., "--evidence", help="Path to PR Gate evidence JSON"
+    ),
+    decision: str = typer.Option(
+        ..., "--decision", help="Path to PR Gate decision JSON"
+    ),
+    policy: str = typer.Option(
+        ..., "--policy", help="Path to PR Gate policy YAML"
+    ),
+    out: str = typer.Option(
+        ..., "--out", help="Artifact root; creates proof-pack/ and signed-report/"
+    ),
+) -> None:
+    """Build a PR Gate proof-pack and Verification Report."""
+    from pathlib import Path as P
+
+    from assay.pr_gate.packet import PacketError, build_pr_gate_packet_files
+    from assay.pr_gate.policy import PolicyEvaluationError
+
+    try:
+        result = build_pr_gate_packet_files(
+            evidence_path=P(evidence),
+            decision_path=P(decision),
+            policy_path=P(policy),
+            out_dir=P(out),
+        )
+    except (OSError, PacketError, PolicyEvaluationError) as exc:
+        _output_json(
+            {
+                "command": "assay pr-gate pack",
+                "status": "error",
+                "error": str(exc),
+            },
+            exit_code=3,
+        )
+
+    _output_json(
+        {
+            "command": "assay pr-gate pack",
+            "status": "ok",
+            "proof_pack_dir": result["proof_pack_dir"],
+            "signed_report_dir": result["signed_report_dir"],
+            "pack_root_sha256": result["pack_manifest"]["pack_root_sha256"],
+            "report_id": result["verify_report"]["report_id"],
+            "signature_status": result["signature_proof"]["signature_status"],
+        },
+        exit_code=0,
+    )
+
+
 # ---------------------------------------------------------------------------
 # gate subcommands
 # ---------------------------------------------------------------------------

--- a/src/assay/pr_gate/packet.py
+++ b/src/assay/pr_gate/packet.py
@@ -1,0 +1,393 @@
+"""PR Gate proof-pack and Verification Report generator."""
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from pathlib import Path
+from typing import Any, Dict, List, Mapping
+
+from assay._receipts.jcs import canonicalize as jcs_canonicalize
+from assay.pr_gate.policy import (
+    compute_policy_sha256,
+    evaluate_policy,
+    load_evidence,
+    load_policy,
+)
+
+PACK_SCHEMA_VERSION = "assay.pr_gate.pack_manifest.v0.1"
+VERIFY_REPORT_SCHEMA_VERSION = "assay.pr_gate.verify_report.v0.1"
+SIGNATURE_PROOF_SCHEMA_VERSION = "assay.pr_gate.signature_proof.v0.1"
+
+PACK_FILES = (
+    "pr_gate_evidence.json",
+    "pr_gate_decision.json",
+    "changed_files.json",
+    "observed_checks.json",
+    "policy.yml",
+    "verify_transcript.md",
+)
+
+DO_NOT_INFER = (
+    "code is secure",
+    "all possible tests passed",
+    "AI made a good design decision",
+    "replay was performed",
+    "production approval was granted",
+)
+
+
+class PacketError(ValueError):
+    """Raised when PR Gate packet generation cannot bind inputs safely."""
+
+
+def build_pr_gate_packet(
+    *,
+    evidence: Mapping[str, Any],
+    decision: Mapping[str, Any],
+    policy_path: Path,
+    out_dir: Path,
+) -> Dict[str, Any]:
+    """Write a PR Gate proof-pack plus Verification Report.
+
+    ``out_dir`` is the PR Gate artifact root. The function creates
+    ``proof-pack/`` and ``signed-report/`` below it.
+    """
+    _validate_evidence(evidence)
+    _validate_decision(decision)
+    policy = load_policy(policy_path)
+    policy_ref = _policy_ref(policy)
+    _validate_policy_binding(evidence, policy)
+    _validate_decision_binding(evidence=evidence, decision=decision, policy=policy)
+
+    proof_pack_dir = out_dir / "proof-pack"
+    signed_report_dir = out_dir / "signed-report"
+    _prepare_output_dir(proof_pack_dir)
+    _prepare_output_dir(signed_report_dir)
+
+    _write_json(proof_pack_dir / "pr_gate_evidence.json", evidence)
+    _write_json(proof_pack_dir / "pr_gate_decision.json", decision)
+    _write_json(proof_pack_dir / "changed_files.json", evidence.get("changed_files", []))
+    _write_json(
+        proof_pack_dir / "observed_checks.json",
+        evidence.get("observed_checks", []),
+    )
+    shutil.copyfile(policy_path, proof_pack_dir / "policy.yml")
+    (proof_pack_dir / "verify_transcript.md").write_text(
+        render_verify_transcript(evidence=evidence, decision=decision),
+        encoding="utf-8",
+    )
+
+    files = [_file_entry(proof_pack_dir / path, path) for path in PACK_FILES]
+    manifest_without_root = _build_manifest_without_root(
+        evidence=evidence,
+        decision=decision,
+        files=files,
+        policy_ref=policy_ref,
+    )
+    pack_root_sha256 = _sha256_prefixed(jcs_canonicalize(manifest_without_root))
+    manifest = {**manifest_without_root, "pack_root_sha256": pack_root_sha256}
+    _write_json(proof_pack_dir / "pack_manifest.json", manifest)
+
+    pack_manifest_sha256 = _sha256_prefixed((proof_pack_dir / "pack_manifest.json").read_bytes())
+    verify_report = _build_verify_report(
+        evidence=evidence,
+        decision=decision,
+        manifest=manifest,
+        pack_manifest_sha256=pack_manifest_sha256,
+        policy_ref=policy_ref,
+    )
+    _write_json(signed_report_dir / "verify_report.json", verify_report)
+
+    verify_report_sha256 = _sha256_prefixed(
+        (signed_report_dir / "verify_report.json").read_bytes()
+    )
+    signature_proof = {
+        "schema_version": SIGNATURE_PROOF_SCHEMA_VERSION,
+        "signature_status": "NOT_SIGNED",
+        "reason": "PR Gate signing is deferred to the stable signer milestone.",
+        "signed_artifact": "verify_report.json",
+        "verify_report_sha256": verify_report_sha256,
+    }
+    _write_json(signed_report_dir / "verify_report.sigstore.json", signature_proof)
+
+    return {
+        "proof_pack_dir": str(proof_pack_dir),
+        "signed_report_dir": str(signed_report_dir),
+        "pack_manifest": manifest,
+        "verify_report": verify_report,
+        "signature_proof": signature_proof,
+    }
+
+
+def build_pr_gate_packet_files(
+    *,
+    evidence_path: Path,
+    decision_path: Path,
+    policy_path: Path,
+    out_dir: Path,
+) -> Dict[str, Any]:
+    """Load files and write a PR Gate packet/report artifact tree."""
+    return build_pr_gate_packet(
+        evidence=load_evidence(evidence_path),
+        decision=_load_decision(decision_path),
+        policy_path=policy_path,
+        out_dir=out_dir,
+    )
+
+
+def render_verify_transcript(
+    *, evidence: Mapping[str, Any], decision: Mapping[str, Any]
+) -> str:
+    """Render a compact human transcript for the PR Gate proof-pack."""
+    subject = _mapping(evidence.get("subject"), "evidence.subject")
+    channels = _mapping(decision.get("channels"), "decision.channels")
+    reasons = decision.get("reasons") or []
+    reason_lines = "\n".join(
+        f"- {json.dumps(reason, sort_keys=True)}" for reason in reasons
+    ) or "- none"
+    return (
+        "# Assay PR Gate Verification Transcript\n\n"
+        f"Repository: {subject.get('repo')}\n"
+        f"PR: #{subject.get('pr_number')}\n"
+        f"Head commit: {subject.get('head_sha')}\n"
+        f"Diff hash: {subject.get('diff_sha256')}\n\n"
+        f"Decision: {decision.get('overall_decision')}\n"
+        f"Recommended action: {decision.get('recommended_action')}\n\n"
+        "Verdict channels:\n"
+        f"- Integrity: {channels.get('integrity')}\n"
+        f"- Claim: {channels.get('claim')}\n"
+        f"- Replay: {channels.get('replay')}\n"
+        f"- Trust policy: {channels.get('trust_policy')}\n\n"
+        "Reasons:\n"
+        f"{reason_lines}\n\n"
+        "Do not infer:\n"
+        + "".join(f"- {item}\n" for item in DO_NOT_INFER)
+    )
+
+
+def _build_manifest_without_root(
+    *,
+    evidence: Mapping[str, Any],
+    decision: Mapping[str, Any],
+    files: List[Dict[str, Any]],
+    policy_ref: Mapping[str, str],
+) -> Dict[str, Any]:
+    subject = _mapping(evidence.get("subject"), "evidence.subject")
+    pack_seed = {
+        "schema_version": PACK_SCHEMA_VERSION,
+        "subject": subject,
+        "policy": policy_ref,
+        "decision": {
+            "overall_decision": decision.get("overall_decision"),
+            "recommended_action": decision.get("recommended_action"),
+            "channels": decision.get("channels"),
+        },
+        "files": files,
+    }
+    pack_id = "prgate_pack_" + _sha256_hex(jcs_canonicalize(pack_seed))[:16]
+    return {
+        "schema_version": PACK_SCHEMA_VERSION,
+        "pack_id": pack_id,
+        "subject": subject,
+        "policy": dict(policy_ref),
+        "decision_ref": {
+            "overall_decision": decision.get("overall_decision"),
+            "recommended_action": decision.get("recommended_action"),
+            "channels": decision.get("channels"),
+        },
+        "files": files,
+        "expected_files": [*PACK_FILES, "pack_manifest.json"],
+        "hash_alg": "sha256",
+        "canonicalization": "jcs-rfc8785",
+    }
+
+
+def _build_verify_report(
+    *,
+    evidence: Mapping[str, Any],
+    decision: Mapping[str, Any],
+    manifest: Mapping[str, Any],
+    pack_manifest_sha256: str,
+    policy_ref: Mapping[str, str],
+) -> Dict[str, Any]:
+    channels = _mapping(decision.get("channels"), "decision.channels")
+    pack_root_sha256 = _string(manifest.get("pack_root_sha256"), "pack_root_sha256")
+    report_seed = {
+        "schema_version": VERIFY_REPORT_SCHEMA_VERSION,
+        "pack_root_sha256": pack_root_sha256,
+        "decision": decision,
+    }
+    report_id = "vr_" + _sha256_hex(jcs_canonicalize(report_seed))[:20]
+    return {
+        "schema_version": VERIFY_REPORT_SCHEMA_VERSION,
+        "report_id": report_id,
+        "pack_id": manifest.get("pack_id"),
+        "pack_root_sha256": pack_root_sha256,
+        "pack_manifest_sha256": pack_manifest_sha256,
+        "subject": evidence.get("subject"),
+        "capture": evidence.get("capture"),
+        "policy": dict(policy_ref),
+        "overall_decision": decision.get("overall_decision"),
+        "recommended_action": decision.get("recommended_action"),
+        "reasons": decision.get("reasons", []),
+        "channels": {
+            "integrity": channels.get("integrity"),
+            "claim": channels.get("claim"),
+            "replay": channels.get("replay"),
+            "trust_policy": channels.get("trust_policy"),
+        },
+        "evidence_refs": [
+            {
+                "kind": "Evidence Box",
+                "path": "proof-pack/pack_manifest.json",
+                "sha256": pack_manifest_sha256,
+            },
+            {
+                "kind": "Verification Report",
+                "path": "signed-report/verify_report.json",
+                "sha256": None,
+            },
+            {
+                "kind": "Signature Proof",
+                "path": "signed-report/verify_report.sigstore.json",
+                "sha256": None,
+            },
+        ],
+        "do_not_infer": list(DO_NOT_INFER),
+        "signature_status": "NOT_SIGNED",
+        "generator": {
+            "name": "assay pr-gate pack",
+            "version": "v0.1",
+        },
+    }
+
+
+def _load_decision(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        raise PacketError(f"Decision file not found: {path}")
+    if not path.is_file():
+        raise PacketError(f"Decision path is not a file: {path}")
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise PacketError(f"Failed to parse decision JSON: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise PacketError(f"Decision file must be a JSON object, got {type(raw).__name__}")
+    _validate_decision(raw)
+    return raw
+
+
+def _validate_evidence(evidence: Mapping[str, Any]) -> None:
+    subject = _mapping(evidence.get("subject"), "evidence.subject")
+    for key in ("repo", "pr_number", "base_sha", "head_sha", "diff_sha256"):
+        if key not in subject:
+            raise PacketError(f"evidence.subject missing {key}")
+    if not isinstance(evidence.get("changed_files", []), list):
+        raise PacketError("evidence.changed_files must be a list")
+    if not isinstance(evidence.get("observed_checks", []), list):
+        raise PacketError("evidence.observed_checks must be a list")
+
+
+def _validate_decision(decision: Mapping[str, Any]) -> None:
+    for key in ("overall_decision", "recommended_action", "channels"):
+        if key not in decision:
+            raise PacketError(f"decision missing {key}")
+    channels = _mapping(decision.get("channels"), "decision.channels")
+    for key in ("integrity", "claim", "replay", "trust_policy"):
+        if key not in channels:
+            raise PacketError(f"decision.channels missing {key}")
+    if not isinstance(decision.get("reasons", []), list):
+        raise PacketError("decision.reasons must be a list")
+
+
+def _validate_policy_binding(
+    evidence: Mapping[str, Any], policy: Mapping[str, Any]
+) -> None:
+    evidence_policy = evidence.get("policy")
+    if not isinstance(evidence_policy, Mapping):
+        return
+    profile = evidence_policy.get("profile")
+    if profile is not None and profile != policy.get("profile"):
+        raise PacketError("evidence policy profile does not match policy.yml")
+    expected_hash = evidence_policy.get("policy_sha256")
+    actual_hash = compute_policy_sha256(policy)
+    if expected_hash is not None and expected_hash != actual_hash:
+        raise PacketError("evidence policy_sha256 does not match policy.yml")
+
+
+def _validate_decision_binding(
+    *,
+    evidence: Mapping[str, Any],
+    decision: Mapping[str, Any],
+    policy: Mapping[str, Any],
+) -> None:
+    expected_decision = evaluate_policy(evidence, policy)
+    if jcs_canonicalize(decision) != jcs_canonicalize(expected_decision):
+        raise PacketError("decision does not match evidence and policy.yml")
+
+
+def _policy_ref(policy: Mapping[str, Any]) -> Dict[str, str]:
+    profile = policy.get("profile")
+    if not isinstance(profile, str) or not profile:
+        raise PacketError("policy.yml missing profile")
+    return {
+        "profile": profile,
+        "policy_sha256": compute_policy_sha256(policy),
+    }
+
+
+def _prepare_output_dir(path: Path) -> None:
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+    elif path.exists():
+        if not path.is_dir():
+            raise PacketError(f"Output path is not a directory: {path}")
+        shutil.rmtree(path)
+    path.mkdir(parents=True, exist_ok=False)
+
+
+def _file_entry(path: Path, relative_path: str) -> Dict[str, Any]:
+    data = path.read_bytes()
+    return {
+        "path": relative_path,
+        "sha256": _sha256_prefixed(data),
+        "bytes": len(data),
+    }
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _mapping(raw: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise PacketError(f"{label} must be a mapping")
+    return raw
+
+
+def _string(raw: Any, label: str) -> str:
+    if not isinstance(raw, str) or not raw:
+        raise PacketError(f"{label} must be a non-empty string")
+    return raw
+
+
+def _sha256_prefixed(data: bytes) -> str:
+    return "sha256:" + _sha256_hex(data)
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+__all__ = [
+    "DO_NOT_INFER",
+    "PACK_FILES",
+    "PACK_SCHEMA_VERSION",
+    "PacketError",
+    "SIGNATURE_PROOF_SCHEMA_VERSION",
+    "VERIFY_REPORT_SCHEMA_VERSION",
+    "build_pr_gate_packet",
+    "build_pr_gate_packet_files",
+    "render_verify_transcript",
+]

--- a/tests/assay/test_pr_gate_packet.py
+++ b/tests/assay/test_pr_gate_packet.py
@@ -1,0 +1,255 @@
+"""Tests for PR Gate packet/report generation."""
+from __future__ import annotations
+
+import json
+import hashlib
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+from typer.testing import CliRunner
+
+from assay.commands import assay_app
+from assay.pr_gate.packet import (
+    PACK_FILES,
+    PacketError,
+    build_pr_gate_packet,
+)
+from assay.pr_gate.policy import compute_policy_sha256, load_policy
+
+runner = CliRunner()
+
+ROOT = Path(__file__).resolve().parents[2]
+POLICY_PATH = ROOT / "docs" / "examples" / "pr-gate-v0" / "assay-policy.yml"
+
+
+def _evidence() -> Dict[str, Any]:
+    policy = load_policy(POLICY_PATH)
+    return {
+        "schema_version": "assay.pr_gate.evidence.v0.1",
+        "subject": {
+            "repo": "Haserjian/assay",
+            "pr_number": 123,
+            "base_sha": "base",
+            "head_sha": "head",
+            "diff_sha256": "sha256:" + "a" * 64,
+            "diff_source": "git diff --binary --full-index <base_sha> <head_sha>",
+        },
+        "capture": {
+            "provider": "github_actions",
+            "workflow_ref": "Haserjian/assay/.github/workflows/assay.yml@refs/heads/main",
+            "workflow_sha": "workflow-sha",
+            "run_id": "1001",
+            "run_attempt": "1",
+            "actor": "tim",
+            "event_name": "pull_request",
+            "github_sha": "merge-sha",
+        },
+        "changed_files": [
+            {
+                "path": "auth/session.py",
+                "status": "modified",
+                "sha256_after": "sha256:" + "b" * 64,
+            }
+        ],
+        "observed_checks": [
+            {
+                "name": "tests",
+                "provider": "github_checks",
+                "head_sha": "head",
+                "status": "completed",
+                "conclusion": "success",
+                "observed_at": "2026-05-08T12:00:00Z",
+            }
+        ],
+        "policy": {
+            "profile": "coding_pr_v0",
+            "policy_sha256": compute_policy_sha256(policy),
+        },
+    }
+
+
+def _decision() -> Dict[str, Any]:
+    return {
+        "overall_decision": "NEEDS_REVIEW",
+        "recommended_action": "require_human_approval",
+        "reasons": [
+            {
+                "rule": "risk_path_touched",
+                "path": "auth/session.py",
+                "matched_pattern": "auth/**",
+            }
+        ],
+        "channels": {
+            "integrity": "PASS",
+            "claim": "PASS",
+            "replay": "NOT_RUN",
+            "trust_policy": "NEEDS_REVIEW",
+        },
+    }
+
+
+def test_build_pr_gate_packet_writes_expected_tree(tmp_path: Path) -> None:
+    result = build_pr_gate_packet(
+        evidence=_evidence(),
+        decision=_decision(),
+        policy_path=POLICY_PATH,
+        out_dir=tmp_path,
+    )
+
+    proof_pack = tmp_path / "proof-pack"
+    signed_report = tmp_path / "signed-report"
+    for name in (*PACK_FILES, "pack_manifest.json"):
+        assert (proof_pack / name).exists(), name
+    assert (signed_report / "verify_report.json").exists()
+    assert (signed_report / "verify_report.sigstore.json").exists()
+
+    manifest = json.loads((proof_pack / "pack_manifest.json").read_text())
+    report = json.loads((signed_report / "verify_report.json").read_text())
+    signature_proof = json.loads(
+        (signed_report / "verify_report.sigstore.json").read_text()
+    )
+
+    assert manifest == result["pack_manifest"]
+    assert manifest["schema_version"] == "assay.pr_gate.pack_manifest.v0.1"
+    assert manifest["pack_root_sha256"].startswith("sha256:")
+    assert manifest["policy"]["profile"] == "coding_pr_v0"
+    assert manifest["policy"]["policy_sha256"] == _evidence()["policy"]["policy_sha256"]
+    assert manifest["expected_files"] == [*PACK_FILES, "pack_manifest.json"]
+    assert {entry["path"] for entry in manifest["files"]} == set(PACK_FILES)
+    for entry in manifest["files"]:
+        file_bytes = (proof_pack / entry["path"]).read_bytes()
+        assert entry["sha256"] == "sha256:" + hashlib.sha256(file_bytes).hexdigest()
+    assert report["schema_version"] == "assay.pr_gate.verify_report.v0.1"
+    assert report["pack_root_sha256"] == manifest["pack_root_sha256"]
+    assert report["pack_manifest_sha256"].startswith("sha256:")
+    assert report["policy"] == manifest["policy"]
+    assert report["channels"] == _decision()["channels"]
+    assert report["overall_decision"] == "NEEDS_REVIEW"
+    assert report["recommended_action"] == "require_human_approval"
+    assert report["signature_status"] == "NOT_SIGNED"
+    assert signature_proof["signature_status"] == "NOT_SIGNED"
+    assert signature_proof["verify_report_sha256"].startswith("sha256:")
+
+
+def test_build_pr_gate_packet_is_deterministic(tmp_path: Path) -> None:
+    first = build_pr_gate_packet(
+        evidence=_evidence(),
+        decision=_decision(),
+        policy_path=POLICY_PATH,
+        out_dir=tmp_path / "first",
+    )
+    second = build_pr_gate_packet(
+        evidence=_evidence(),
+        decision=_decision(),
+        policy_path=POLICY_PATH,
+        out_dir=tmp_path / "second",
+    )
+
+    assert (
+        first["pack_manifest"]["pack_root_sha256"]
+        == second["pack_manifest"]["pack_root_sha256"]
+    )
+    assert first["verify_report"]["report_id"] == second["verify_report"]["report_id"]
+
+
+def test_build_pr_gate_packet_removes_stale_generated_files(tmp_path: Path) -> None:
+    stale_pack = tmp_path / "proof-pack" / "stale.json"
+    stale_report = tmp_path / "signed-report" / "stale.json"
+    stale_pack.parent.mkdir(parents=True)
+    stale_report.parent.mkdir(parents=True)
+    stale_pack.write_text("stale", encoding="utf-8")
+    stale_report.write_text("stale", encoding="utf-8")
+
+    build_pr_gate_packet(
+        evidence=_evidence(),
+        decision=_decision(),
+        policy_path=POLICY_PATH,
+        out_dir=tmp_path,
+    )
+
+    assert not stale_pack.exists()
+    assert not stale_report.exists()
+
+
+def test_build_pr_gate_packet_rejects_policy_hash_mismatch(tmp_path: Path) -> None:
+    evidence = _evidence()
+    evidence["policy"]["policy_sha256"] = "sha256:" + "0" * 64
+
+    with pytest.raises(PacketError, match="policy_sha256"):
+        build_pr_gate_packet(
+            evidence=evidence,
+            decision=_decision(),
+            policy_path=POLICY_PATH,
+            out_dir=tmp_path,
+        )
+
+
+def test_build_pr_gate_packet_rejects_decision_mismatch(tmp_path: Path) -> None:
+    decision = _decision()
+    decision["overall_decision"] = "PASS"
+    decision["recommended_action"] = "proceed"
+    decision["reasons"] = []
+    decision["channels"]["trust_policy"] = "PASS"
+
+    with pytest.raises(PacketError, match="decision does not match"):
+        build_pr_gate_packet(
+            evidence=_evidence(),
+            decision=decision,
+            policy_path=POLICY_PATH,
+            out_dir=tmp_path,
+        )
+
+
+def test_pr_gate_pack_cli_writes_artifacts(tmp_path: Path) -> None:
+    evidence_path = tmp_path / "evidence.json"
+    decision_path = tmp_path / "decision.json"
+    out_dir = tmp_path / "artifacts"
+    evidence_path.write_text(json.dumps(_evidence()), encoding="utf-8")
+    decision_path.write_text(json.dumps(_decision()), encoding="utf-8")
+
+    result = runner.invoke(
+        assay_app,
+        [
+            "pr-gate",
+            "pack",
+            "--evidence",
+            str(evidence_path),
+            "--decision",
+            str(decision_path),
+            "--policy",
+            str(POLICY_PATH),
+            "--out",
+            str(out_dir),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["status"] == "ok"
+    assert payload["pack_root_sha256"].startswith("sha256:")
+    assert (out_dir / "proof-pack" / "pack_manifest.json").exists()
+    assert (out_dir / "signed-report" / "verify_report.json").exists()
+
+
+def test_pr_gate_pack_cli_bad_input_exits_3(tmp_path: Path) -> None:
+    result = runner.invoke(
+        assay_app,
+        [
+            "pr-gate",
+            "pack",
+            "--evidence",
+            str(tmp_path / "missing-evidence.json"),
+            "--decision",
+            str(tmp_path / "missing-decision.json"),
+            "--policy",
+            str(POLICY_PATH),
+            "--out",
+            str(tmp_path / "artifacts"),
+        ],
+    )
+
+    assert result.exit_code == 3
+    payload = json.loads(result.output)
+    assert payload["status"] == "error"
+    assert "Evidence file not found" in payload["error"]


### PR DESCRIPTION
## Summary
- add `assay.pr_gate.packet` to write PR Gate proof-pack and signed-report artifact trees
- add hidden `assay pr-gate pack --evidence ... --decision ... --policy ... --out ...` CLI
- preserve subject binding, policy hash, verdict channels, caveats, pack root, and an honest `NOT_SIGNED` signature placeholder
- reject policy hash mismatch and re-evaluate evidence+policy to reject stale or edited `decision.json`
- clean generated output dirs before writing so stale artifacts do not persist

## Validation
- `.venv/bin/python -m pytest tests/assay/test_pr_gate_policy.py tests/assay/test_pr_gate_github_capture.py tests/assay/test_pr_gate_packet.py -q`
- `.venv/bin/python -m ruff check src/assay/pr_gate/github_capture.py src/assay/pr_gate/policy.py src/assay/pr_gate/packet.py tests/assay/test_pr_gate_github_capture.py tests/assay/test_pr_gate_policy.py tests/assay/test_pr_gate_packet.py`
- `.venv/bin/python -m py_compile src/assay/commands.py src/assay/pr_gate/github_capture.py src/assay/pr_gate/policy.py src/assay/pr_gate/packet.py tests/assay/test_pr_gate_github_capture.py tests/assay/test_pr_gate_policy.py tests/assay/test_pr_gate_packet.py`
- `git diff --check`
- `.venv/bin/assay pr-gate pack --help`
- `bash scripts/verify_verification_gate_sample.sh`
- `bash scripts/demo_tamper_verification_gate_sample.sh`

## Notes
- stable Sigstore signing remains the next milestone
- leaves pre-existing untracked `docs/strategy/` untouched