### PR TITLE
feat: verify PR Gate signatures

### DIFF
--- a/docs/adr/ADR-pr-gate-trust-root.md
+++ b/docs/adr/ADR-pr-gate-trust-root.md
@@ -22,7 +22,7 @@ recommended action.
 The intended dogfood signer identity is:
 
 ```text
-Haserjian/assay/.github/workflows/assay-pr-gate.yml@refs/heads/main
+https://github.com/Haserjian/assay/.github/workflows/assay-pr-gate.yml@refs/heads/main
 ```
 
 The public Verification Report must be signed by the expected workflow

--- a/docs/product/assay-pr-gate-comment-v0.md
+++ b/docs/product/assay-pr-gate-comment-v0.md
@@ -62,7 +62,7 @@ Do not infer:
 - production approval was granted
 
 Signed by expected workflow:
-Haserjian/assay/.github/workflows/assay-pr-gate.yml@refs/heads/main
+https://github.com/Haserjian/assay/.github/workflows/assay-pr-gate.yml@refs/heads/main
 ```
 
 ## Decision Rendering

--- a/docs/product/assay-pr-gate-v0.md
+++ b/docs/product/assay-pr-gate-v0.md
@@ -176,7 +176,7 @@ Do not infer:
 - production approval was granted
 
 Signed by expected workflow:
-Haserjian/assay/.github/workflows/assay-pr-gate.yml@refs/heads/main
+https://github.com/Haserjian/assay/.github/workflows/assay-pr-gate.yml@refs/heads/main
 ```
 
 Detailed rendering rules live in:
@@ -462,7 +462,7 @@ Acceptance condition:
 Graduate from the historical PR sample identity to:
 
 ```text
-Haserjian/assay/.github/workflows/assay-pr-gate.yml@refs/heads/main
+https://github.com/Haserjian/assay/.github/workflows/assay-pr-gate.yml@refs/heads/main
 ```
 
 Acceptance condition:
@@ -513,7 +513,7 @@ assay pr-gate verify \
   --pack proof-pack \
   --report signed-report/verify_report.json \
   --sigstore signed-report/verify_report.sigstore.json \
-  --expected-identity "Haserjian/assay/.github/workflows/assay-pr-gate.yml@refs/heads/main"
+  --expected-identity "https://github.com/Haserjian/assay/.github/workflows/assay-pr-gate.yml@refs/heads/main"
 ```
 
 Expected output:

--- a/src/assay/commands.py
+++ b/src/assay/commands.py
@@ -8333,6 +8333,17 @@ def pr_gate_pack_cmd(
     out: str = typer.Option(
         ..., "--out", help="Artifact root; creates proof-pack/ and signed-report/"
     ),
+    expected_identity: str = typer.Option(
+        "https://github.com/Haserjian/assay/.github/workflows/"
+        "assay-pr-gate.yml@refs/heads/main",
+        "--expected-identity",
+        help="Expected GitHub Actions workflow identity for PR Gate signing",
+    ),
+    certificate_oidc_issuer: str = typer.Option(
+        "https://token.actions.githubusercontent.com",
+        "--certificate-oidc-issuer",
+        help="Expected OIDC issuer for Sigstore verification",
+    ),
 ) -> None:
     """Build a PR Gate proof-pack and Verification Report."""
     from pathlib import Path as P
@@ -8346,6 +8357,8 @@ def pr_gate_pack_cmd(
             decision_path=P(decision),
             policy_path=P(policy),
             out_dir=P(out),
+            expected_identity=expected_identity,
+            certificate_oidc_issuer=certificate_oidc_issuer,
         )
     except (OSError, PacketError, PolicyEvaluationError) as exc:
         _output_json(
@@ -8366,9 +8379,87 @@ def pr_gate_pack_cmd(
             "pack_root_sha256": result["pack_manifest"]["pack_root_sha256"],
             "report_id": result["verify_report"]["report_id"],
             "signature_status": result["signature_proof"]["signature_status"],
+            "expected_identity": expected_identity,
         },
         exit_code=0,
     )
+
+
+@pr_gate_app.command("verify")
+def pr_gate_verify_cmd(
+    pack: str = typer.Option(
+        ..., "--pack", help="Path to PR Gate proof-pack directory"
+    ),
+    report: str = typer.Option(
+        ..., "--report", help="Path to signed-report/verify_report.json"
+    ),
+    sigstore: str = typer.Option(
+        ..., "--sigstore", help="Path to signed-report/verify_report.sigstore.json"
+    ),
+    expected_identity: str = typer.Option(
+        "https://github.com/Haserjian/assay/.github/workflows/"
+        "assay-pr-gate.yml@refs/heads/main",
+        "--expected-identity",
+        help="Expected GitHub Actions workflow identity for PR Gate signing",
+    ),
+    certificate_oidc_issuer: str = typer.Option(
+        "https://token.actions.githubusercontent.com",
+        "--certificate-oidc-issuer",
+        help="Expected OIDC issuer for Sigstore verification",
+    ),
+    cosign_bin: str = typer.Option(
+        "cosign", "--cosign-bin", help="cosign executable to use"
+    ),
+    output_json: bool = typer.Option(False, "--json", help="Output as JSON"),
+) -> None:
+    """Verify a PR Gate packet, Verification Report, and Signature Proof."""
+    from pathlib import Path as P
+
+    from assay.pr_gate.verify import (
+        PRGateInputError,
+        PRGateVerificationError,
+        render_verification_text,
+        verify_pr_gate_packet,
+    )
+
+    try:
+        result = verify_pr_gate_packet(
+            pack_dir=P(pack),
+            report_path=P(report),
+            sigstore_path=P(sigstore),
+            expected_identity=expected_identity,
+            certificate_oidc_issuer=certificate_oidc_issuer,
+            cosign_bin=cosign_bin,
+        )
+    except PRGateInputError as exc:
+        if output_json:
+            _output_json(
+                {
+                    "command": "assay pr-gate verify",
+                    "status": "error",
+                    "error": str(exc),
+                },
+                exit_code=3,
+            )
+        console.print(f"[red]Error:[/] {exc}")
+        raise typer.Exit(3)
+    except PRGateVerificationError as exc:
+        if output_json:
+            _output_json(
+                {
+                    "command": "assay pr-gate verify",
+                    "status": "failed",
+                    "error": str(exc),
+                },
+                exit_code=2,
+            )
+        console.print(f"[red]PR Gate verification failed:[/] {exc}")
+        raise typer.Exit(2)
+
+    if output_json:
+        _output_json(result, exit_code=0)
+    console.print(render_verification_text(result))
+    raise typer.Exit(0)
 
 
 # ---------------------------------------------------------------------------

--- a/src/assay/pr_gate/packet.py
+++ b/src/assay/pr_gate/packet.py
@@ -18,6 +18,11 @@ from assay.pr_gate.policy import (
 PACK_SCHEMA_VERSION = "assay.pr_gate.pack_manifest.v0.1"
 VERIFY_REPORT_SCHEMA_VERSION = "assay.pr_gate.verify_report.v0.1"
 SIGNATURE_PROOF_SCHEMA_VERSION = "assay.pr_gate.signature_proof.v0.1"
+DEFAULT_EXPECTED_SIGNER_IDENTITY = (
+    "https://github.com/Haserjian/assay/.github/workflows/"
+    "assay-pr-gate.yml@refs/heads/main"
+)
+DEFAULT_CERTIFICATE_OIDC_ISSUER = "https://token.actions.githubusercontent.com"
 
 PACK_FILES = (
     "pr_gate_evidence.json",
@@ -47,6 +52,8 @@ def build_pr_gate_packet(
     decision: Mapping[str, Any],
     policy_path: Path,
     out_dir: Path,
+    expected_identity: str = DEFAULT_EXPECTED_SIGNER_IDENTITY,
+    certificate_oidc_issuer: str = DEFAULT_CERTIFICATE_OIDC_ISSUER,
 ) -> Dict[str, Any]:
     """Write a PR Gate proof-pack plus Verification Report.
 
@@ -55,6 +62,10 @@ def build_pr_gate_packet(
     """
     _validate_evidence(evidence)
     _validate_decision(decision)
+    expected_identity = _string(expected_identity, "expected_identity")
+    certificate_oidc_issuer = _string(
+        certificate_oidc_issuer, "certificate_oidc_issuer"
+    )
     policy = load_policy(policy_path)
     policy_ref = _policy_ref(policy)
     _validate_policy_binding(evidence, policy)
@@ -96,6 +107,8 @@ def build_pr_gate_packet(
         manifest=manifest,
         pack_manifest_sha256=pack_manifest_sha256,
         policy_ref=policy_ref,
+        expected_identity=expected_identity,
+        certificate_oidc_issuer=certificate_oidc_issuer,
     )
     _write_json(signed_report_dir / "verify_report.json", verify_report)
 
@@ -107,6 +120,8 @@ def build_pr_gate_packet(
         "signature_status": "NOT_SIGNED",
         "reason": "PR Gate signing is deferred to the stable signer milestone.",
         "signed_artifact": "verify_report.json",
+        "expected_certificate_identity": expected_identity,
+        "certificate_oidc_issuer": certificate_oidc_issuer,
         "verify_report_sha256": verify_report_sha256,
     }
     _write_json(signed_report_dir / "verify_report.sigstore.json", signature_proof)
@@ -126,6 +141,8 @@ def build_pr_gate_packet_files(
     decision_path: Path,
     policy_path: Path,
     out_dir: Path,
+    expected_identity: str = DEFAULT_EXPECTED_SIGNER_IDENTITY,
+    certificate_oidc_issuer: str = DEFAULT_CERTIFICATE_OIDC_ISSUER,
 ) -> Dict[str, Any]:
     """Load files and write a PR Gate packet/report artifact tree."""
     return build_pr_gate_packet(
@@ -133,6 +150,8 @@ def build_pr_gate_packet_files(
         decision=_load_decision(decision_path),
         policy_path=policy_path,
         out_dir=out_dir,
+        expected_identity=expected_identity,
+        certificate_oidc_issuer=certificate_oidc_issuer,
     )
 
 
@@ -210,6 +229,8 @@ def _build_verify_report(
     manifest: Mapping[str, Any],
     pack_manifest_sha256: str,
     policy_ref: Mapping[str, str],
+    expected_identity: str,
+    certificate_oidc_issuer: str,
 ) -> Dict[str, Any]:
     channels = _mapping(decision.get("channels"), "decision.channels")
     pack_root_sha256 = _string(manifest.get("pack_root_sha256"), "pack_root_sha256")
@@ -255,7 +276,12 @@ def _build_verify_report(
             },
         ],
         "do_not_infer": list(DO_NOT_INFER),
-        "signature_status": "NOT_SIGNED",
+        "signature_policy": {
+            "scheme": "sigstore_keyless",
+            "required": True,
+            "expected_certificate_identity": expected_identity,
+            "certificate_oidc_issuer": certificate_oidc_issuer,
+        },
         "generator": {
             "name": "assay pr-gate pack",
             "version": "v0.1",
@@ -382,6 +408,8 @@ def _sha256_hex(data: bytes) -> str:
 
 __all__ = [
     "DO_NOT_INFER",
+    "DEFAULT_CERTIFICATE_OIDC_ISSUER",
+    "DEFAULT_EXPECTED_SIGNER_IDENTITY",
     "PACK_FILES",
     "PACK_SCHEMA_VERSION",
     "PacketError",

--- a/src/assay/pr_gate/verify.py
+++ b/src/assay/pr_gate/verify.py
@@ -1,0 +1,372 @@
+"""PR Gate packet, report, and signature verifier."""
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
+
+from assay._receipts.jcs import canonicalize as jcs_canonicalize
+from assay.pr_gate.packet import (
+    DEFAULT_CERTIFICATE_OIDC_ISSUER,
+    DEFAULT_EXPECTED_SIGNER_IDENTITY,
+    PACK_SCHEMA_VERSION,
+    VERIFY_REPORT_SCHEMA_VERSION,
+)
+from assay.pr_gate.policy import (
+    PolicyEvaluationError,
+    compute_policy_sha256,
+    evaluate_policy,
+    load_policy,
+)
+
+VERIFY_RESULT = "ASSAY PR GATE VERIFIED"
+CosignRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+
+
+class PRGateInputError(ValueError):
+    """Raised when verifier inputs cannot be read or parsed."""
+
+
+class PRGateVerificationError(ValueError):
+    """Raised when a PR Gate packet fails verification."""
+
+
+def verify_pr_gate_packet(
+    *,
+    pack_dir: Path,
+    report_path: Path,
+    sigstore_path: Path,
+    expected_identity: str = DEFAULT_EXPECTED_SIGNER_IDENTITY,
+    certificate_oidc_issuer: str = DEFAULT_CERTIFICATE_OIDC_ISSUER,
+    cosign_bin: str = "cosign",
+    cosign_runner: Optional[CosignRunner] = None,
+) -> Dict[str, Any]:
+    """Verify a PR Gate proof-pack, report binding, and Sigstore signature."""
+    expected_identity = _non_empty_string(expected_identity, "expected_identity")
+    certificate_oidc_issuer = _non_empty_string(
+        certificate_oidc_issuer, "certificate_oidc_issuer"
+    )
+    if cosign_runner is None:
+        cosign_runner = _run_cosign
+
+    pack_dir = pack_dir.resolve()
+    manifest_path = pack_dir / "pack_manifest.json"
+    manifest = _load_json_object(manifest_path, "pack manifest")
+    report = _load_json_object(report_path, "verification report")
+    signature_proof = _load_json_object(sigstore_path, "signature proof")
+
+    _verify_signature_proof_metadata(
+        report_path=report_path,
+        signature_proof=signature_proof,
+        expected_identity=expected_identity,
+        certificate_oidc_issuer=certificate_oidc_issuer,
+    )
+    _verify_manifest(pack_dir=pack_dir, manifest=manifest)
+    _verify_report_binding(
+        pack_dir=pack_dir,
+        manifest_path=manifest_path,
+        manifest=manifest,
+        report=report,
+        expected_identity=expected_identity,
+        certificate_oidc_issuer=certificate_oidc_issuer,
+    )
+    _verify_recomputed_decision(pack_dir=pack_dir, manifest=manifest, report=report)
+    _verify_sigstore_bundle(
+        report_path=report_path,
+        sigstore_path=sigstore_path,
+        expected_identity=expected_identity,
+        certificate_oidc_issuer=certificate_oidc_issuer,
+        cosign_bin=cosign_bin,
+        cosign_runner=cosign_runner,
+    )
+
+    channels = _mapping(report.get("channels"), "report.channels")
+    return {
+        "command": "assay pr-gate verify",
+        "status": "ok",
+        "result": VERIFY_RESULT,
+        "pack_root_sha256": report["pack_root_sha256"],
+        "report_id": report.get("report_id"),
+        "decision": report.get("overall_decision"),
+        "recommended_action": report.get("recommended_action"),
+        "channels": {
+            "integrity": channels.get("integrity"),
+            "claim": channels.get("claim"),
+            "replay": channels.get("replay"),
+            "trust_policy": channels.get("trust_policy"),
+        },
+        "expected_identity": expected_identity,
+        "certificate_oidc_issuer": certificate_oidc_issuer,
+    }
+
+
+def render_verification_text(result: Mapping[str, Any]) -> str:
+    """Render the reviewer-facing PR Gate verification summary."""
+    channels = _mapping(result.get("channels"), "result.channels")
+    return (
+        f"Result: {result.get('result')}\n"
+        f"Decision: {result.get('decision')}\n"
+        f"Recommended action: {result.get('recommended_action')}\n"
+        f"Integrity: {channels.get('integrity')}\n"
+        f"Claim: {channels.get('claim')}\n"
+        f"Replay: {channels.get('replay')}\n"
+        f"Trust policy: {channels.get('trust_policy')}\n"
+        "Signed by expected workflow:\n"
+        f"{result.get('expected_identity')}"
+    )
+
+
+def _verify_manifest(*, pack_dir: Path, manifest: Mapping[str, Any]) -> None:
+    if manifest.get("schema_version") != PACK_SCHEMA_VERSION:
+        raise PRGateVerificationError("pack manifest schema_version is not PR Gate v0.1")
+    expected_files = _string_list(manifest.get("expected_files"), "manifest.expected_files")
+    file_entries = _file_entries(manifest.get("files"))
+    entry_paths = [entry["path"] for entry in file_entries]
+    if sorted(expected_files) != sorted([*entry_paths, "pack_manifest.json"]):
+        raise PRGateVerificationError("pack manifest expected_files does not match files")
+
+    for relative_path in expected_files:
+        _safe_pack_path(pack_dir, relative_path)
+
+    for entry in file_entries:
+        path = _safe_pack_path(pack_dir, entry["path"])
+        actual_bytes = path.read_bytes()
+        actual_sha256 = _sha256_prefixed(actual_bytes)
+        if entry["sha256"] != actual_sha256:
+            raise PRGateVerificationError(f"proof-pack file hash mismatch: {entry['path']}")
+        if "bytes" in entry and entry["bytes"] != len(actual_bytes):
+            raise PRGateVerificationError(f"proof-pack file byte count mismatch: {entry['path']}")
+
+    expected_root = _non_empty_string(
+        manifest.get("pack_root_sha256"), "manifest.pack_root_sha256"
+    )
+    manifest_without_root = dict(manifest)
+    manifest_without_root.pop("pack_root_sha256", None)
+    actual_root = _sha256_prefixed(jcs_canonicalize(manifest_without_root))
+    if actual_root != expected_root:
+        raise PRGateVerificationError("pack manifest root hash mismatch")
+
+
+def _verify_report_binding(
+    *,
+    pack_dir: Path,
+    manifest_path: Path,
+    manifest: Mapping[str, Any],
+    report: Mapping[str, Any],
+    expected_identity: str,
+    certificate_oidc_issuer: str,
+) -> None:
+    if report.get("schema_version") != VERIFY_REPORT_SCHEMA_VERSION:
+        raise PRGateVerificationError("verify report schema_version is not PR Gate v0.1")
+    if report.get("pack_root_sha256") != manifest.get("pack_root_sha256"):
+        raise PRGateVerificationError("report pack_root_sha256 does not match manifest")
+    actual_manifest_sha256 = _sha256_prefixed(manifest_path.read_bytes())
+    if report.get("pack_manifest_sha256") != actual_manifest_sha256:
+        raise PRGateVerificationError("report pack_manifest_sha256 does not match manifest")
+    if report.get("subject") != manifest.get("subject"):
+        raise PRGateVerificationError("report subject does not match manifest")
+    if report.get("policy") != manifest.get("policy"):
+        raise PRGateVerificationError("report policy does not match manifest")
+
+    try:
+        policy = load_policy(pack_dir / "policy.yml")
+    except PolicyEvaluationError as exc:
+        raise PRGateVerificationError(f"policy.yml cannot be evaluated: {exc}") from exc
+    policy_ref = {
+        "profile": policy.get("profile"),
+        "policy_sha256": compute_policy_sha256(policy),
+    }
+    if report.get("policy") != policy_ref:
+        raise PRGateVerificationError("report policy hash does not match policy.yml")
+
+    signature_policy = _mapping(
+        report.get("signature_policy"), "report.signature_policy"
+    )
+    if signature_policy.get("scheme") != "sigstore_keyless":
+        raise PRGateVerificationError("unsupported report signature policy scheme")
+    if signature_policy.get("required") is not True:
+        raise PRGateVerificationError("report signature policy must be required")
+    if signature_policy.get("expected_certificate_identity") != expected_identity:
+        raise PRGateVerificationError("expected signer identity does not match report")
+    if signature_policy.get("certificate_oidc_issuer") != certificate_oidc_issuer:
+        raise PRGateVerificationError("certificate OIDC issuer does not match report")
+
+
+def _verify_recomputed_decision(
+    *, pack_dir: Path, manifest: Mapping[str, Any], report: Mapping[str, Any]
+) -> None:
+    evidence = _load_json_object(pack_dir / "pr_gate_evidence.json", "PR Gate evidence")
+    decision = _load_json_object(pack_dir / "pr_gate_decision.json", "PR Gate decision")
+    try:
+        policy = load_policy(pack_dir / "policy.yml")
+        expected_decision = evaluate_policy(evidence, policy)
+    except PolicyEvaluationError as exc:
+        raise PRGateVerificationError(
+            f"decision cannot be recomputed from evidence and policy.yml: {exc}"
+        ) from exc
+    if jcs_canonicalize(decision) != jcs_canonicalize(expected_decision):
+        raise PRGateVerificationError("decision does not match evidence and policy.yml")
+
+    decision_ref = _mapping(manifest.get("decision_ref"), "manifest.decision_ref")
+    if decision_ref.get("overall_decision") != decision.get("overall_decision"):
+        raise PRGateVerificationError("manifest decision_ref does not match decision")
+    if decision_ref.get("recommended_action") != decision.get("recommended_action"):
+        raise PRGateVerificationError("manifest decision_ref does not match decision")
+    if decision_ref.get("channels") != decision.get("channels"):
+        raise PRGateVerificationError("manifest decision_ref does not match decision")
+
+    for field in ("overall_decision", "recommended_action", "reasons", "channels"):
+        if report.get(field) != decision.get(field):
+            raise PRGateVerificationError(f"report {field} does not match decision")
+
+
+def _verify_signature_proof_metadata(
+    *,
+    report_path: Path,
+    signature_proof: Mapping[str, Any],
+    expected_identity: str,
+    certificate_oidc_issuer: str,
+) -> None:
+    status = signature_proof.get("signature_status")
+    if status == "NOT_SIGNED":
+        raise PRGateVerificationError("signature proof is not signed")
+    if status is not None and status != "SIGNED":
+        raise PRGateVerificationError(f"unsupported signature_status: {status!r}")
+
+    report_hash = signature_proof.get("verify_report_sha256")
+    if report_hash is not None and report_hash != _sha256_prefixed(report_path.read_bytes()):
+        raise PRGateVerificationError("signature proof does not match verify_report.json")
+
+    for key in ("certificate_identity", "expected_certificate_identity"):
+        identity = signature_proof.get(key)
+        if identity is not None and identity != expected_identity:
+            raise PRGateVerificationError(
+                "signature identity does not match expected signer identity"
+            )
+    issuer = signature_proof.get("certificate_oidc_issuer")
+    if issuer is not None and issuer != certificate_oidc_issuer:
+        raise PRGateVerificationError("signature OIDC issuer does not match expected issuer")
+
+
+def _verify_sigstore_bundle(
+    *,
+    report_path: Path,
+    sigstore_path: Path,
+    expected_identity: str,
+    certificate_oidc_issuer: str,
+    cosign_bin: str,
+    cosign_runner: CosignRunner,
+) -> None:
+    args = [
+        cosign_bin,
+        "verify-blob",
+        str(report_path),
+        "--bundle",
+        str(sigstore_path),
+        "--certificate-identity",
+        expected_identity,
+        "--certificate-oidc-issuer",
+        certificate_oidc_issuer,
+    ]
+    try:
+        result = cosign_runner(args)
+    except FileNotFoundError as exc:
+        raise PRGateInputError(f"cosign not found: {cosign_bin}") from exc
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "cosign verify-blob failed").strip()
+        raise PRGateVerificationError(f"sigstore verification failed: {detail}")
+
+
+def _run_cosign(args: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(args),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+
+
+def _load_json_object(path: Path, label: str) -> Dict[str, Any]:
+    if not path.exists():
+        raise PRGateInputError(f"{label} not found: {path}")
+    if not path.is_file():
+        raise PRGateInputError(f"{label} path is not a file: {path}")
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise PRGateInputError(f"failed to parse {label} JSON: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise PRGateInputError(f"{label} must be a JSON object")
+    return raw
+
+
+def _safe_pack_path(pack_dir: Path, relative_path: str) -> Path:
+    if not isinstance(relative_path, str) or not relative_path:
+        raise PRGateVerificationError("proof-pack file path must be a non-empty string")
+    candidate = Path(relative_path)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        raise PRGateVerificationError(f"unsafe proof-pack path: {relative_path}")
+    resolved = (pack_dir / candidate).resolve()
+    try:
+        resolved.relative_to(pack_dir)
+    except ValueError as exc:
+        raise PRGateVerificationError(f"unsafe proof-pack path: {relative_path}") from exc
+    if not resolved.exists():
+        raise PRGateVerificationError(f"missing proof-pack file: {relative_path}")
+    if not resolved.is_file():
+        raise PRGateVerificationError(f"proof-pack path is not a file: {relative_path}")
+    return resolved
+
+
+def _file_entries(raw: Any) -> List[Dict[str, Any]]:
+    if not isinstance(raw, list):
+        raise PRGateVerificationError("manifest.files must be a list")
+    entries: List[Dict[str, Any]] = []
+    for index, entry in enumerate(raw):
+        if not isinstance(entry, Mapping):
+            raise PRGateVerificationError(f"manifest.files[{index}] must be a mapping")
+        path = _non_empty_string(entry.get("path"), f"manifest.files[{index}].path")
+        sha256 = _non_empty_string(entry.get("sha256"), f"manifest.files[{index}].sha256")
+        if not sha256.startswith("sha256:"):
+            raise PRGateVerificationError(f"manifest.files[{index}].sha256 must be prefixed")
+        normalized = dict(entry)
+        normalized["path"] = path
+        normalized["sha256"] = sha256
+        entries.append(normalized)
+    return entries
+
+
+def _string_list(raw: Any, label: str) -> List[str]:
+    if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
+        raise PRGateVerificationError(f"{label} must be a list of strings")
+    return list(raw)
+
+
+def _mapping(raw: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise PRGateVerificationError(f"{label} must be a mapping")
+    return raw
+
+
+def _non_empty_string(raw: Any, label: str) -> str:
+    if not isinstance(raw, str) or not raw:
+        raise PRGateVerificationError(f"{label} must be a non-empty string")
+    return raw
+
+
+def _sha256_prefixed(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+__all__ = [
+    "DEFAULT_CERTIFICATE_OIDC_ISSUER",
+    "DEFAULT_EXPECTED_SIGNER_IDENTITY",
+    "PRGateInputError",
+    "PRGateVerificationError",
+    "VERIFY_RESULT",
+    "render_verification_text",
+    "verify_pr_gate_packet",
+]

--- a/tests/assay/test_pr_gate_packet.py
+++ b/tests/assay/test_pr_gate_packet.py
@@ -127,8 +127,20 @@ def test_build_pr_gate_packet_writes_expected_tree(tmp_path: Path) -> None:
     assert report["channels"] == _decision()["channels"]
     assert report["overall_decision"] == "NEEDS_REVIEW"
     assert report["recommended_action"] == "require_human_approval"
-    assert report["signature_status"] == "NOT_SIGNED"
+    assert report["signature_policy"] == {
+        "scheme": "sigstore_keyless",
+        "required": True,
+        "expected_certificate_identity": (
+            "https://github.com/Haserjian/assay/.github/workflows/"
+            "assay-pr-gate.yml@refs/heads/main"
+        ),
+        "certificate_oidc_issuer": "https://token.actions.githubusercontent.com",
+    }
     assert signature_proof["signature_status"] == "NOT_SIGNED"
+    assert signature_proof["expected_certificate_identity"] == (
+        "https://github.com/Haserjian/assay/.github/workflows/"
+        "assay-pr-gate.yml@refs/heads/main"
+    )
     assert signature_proof["verify_report_sha256"].startswith("sha256:")
 
 

--- a/tests/assay/test_pr_gate_verify.py
+++ b/tests/assay/test_pr_gate_verify.py
@@ -1,0 +1,263 @@
+"""Tests for PR Gate packet/report/signature verification."""
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, Sequence
+
+import pytest
+from typer.testing import CliRunner
+
+from assay.commands import assay_app
+from assay.pr_gate.packet import build_pr_gate_packet
+from assay.pr_gate.policy import compute_policy_sha256, load_policy
+from assay.pr_gate.verify import (
+    DEFAULT_CERTIFICATE_OIDC_ISSUER,
+    DEFAULT_EXPECTED_SIGNER_IDENTITY,
+    PRGateVerificationError,
+    VERIFY_RESULT,
+    verify_pr_gate_packet,
+)
+
+runner = CliRunner()
+
+ROOT = Path(__file__).resolve().parents[2]
+POLICY_PATH = ROOT / "docs" / "examples" / "pr-gate-v0" / "assay-policy.yml"
+
+
+def _evidence() -> Dict[str, Any]:
+    policy = load_policy(POLICY_PATH)
+    return {
+        "schema_version": "assay.pr_gate.evidence.v0.1",
+        "subject": {
+            "repo": "Haserjian/assay",
+            "pr_number": 123,
+            "base_sha": "base",
+            "head_sha": "head",
+            "diff_sha256": "sha256:" + "a" * 64,
+            "diff_source": "git diff --binary --full-index <base_sha> <head_sha>",
+        },
+        "capture": {
+            "provider": "github_actions",
+            "workflow_ref": DEFAULT_EXPECTED_SIGNER_IDENTITY,
+            "workflow_sha": "workflow-sha",
+            "run_id": "1001",
+            "run_attempt": "1",
+            "actor": "tim",
+            "event_name": "pull_request",
+            "github_sha": "merge-sha",
+        },
+        "changed_files": [
+            {
+                "path": "auth/session.py",
+                "status": "modified",
+                "sha256_after": "sha256:" + "b" * 64,
+            }
+        ],
+        "observed_checks": [
+            {
+                "name": "tests",
+                "provider": "github_checks",
+                "head_sha": "head",
+                "status": "completed",
+                "conclusion": "success",
+                "observed_at": "2026-05-08T12:00:00Z",
+            }
+        ],
+        "policy": {
+            "profile": "coding_pr_v0",
+            "policy_sha256": compute_policy_sha256(policy),
+        },
+    }
+
+
+def _decision() -> Dict[str, Any]:
+    return {
+        "overall_decision": "NEEDS_REVIEW",
+        "recommended_action": "require_human_approval",
+        "reasons": [
+            {
+                "rule": "risk_path_touched",
+                "path": "auth/session.py",
+                "matched_pattern": "auth/**",
+            }
+        ],
+        "channels": {
+            "integrity": "PASS",
+            "claim": "PASS",
+            "replay": "NOT_RUN",
+            "trust_policy": "NEEDS_REVIEW",
+        },
+    }
+
+
+def _build_signed_packet(tmp_path: Path) -> Dict[str, Any]:
+    result = build_pr_gate_packet(
+        evidence=_evidence(),
+        decision=_decision(),
+        policy_path=POLICY_PATH,
+        out_dir=tmp_path,
+    )
+    report_path = tmp_path / "signed-report" / "verify_report.json"
+    signature_proof = {
+        "schema_version": "assay.pr_gate.signature_proof.v0.1",
+        "signature_status": "SIGNED",
+        "signed_artifact": "verify_report.json",
+        "certificate_identity": DEFAULT_EXPECTED_SIGNER_IDENTITY,
+        "certificate_oidc_issuer": DEFAULT_CERTIFICATE_OIDC_ISSUER,
+        "verify_report_sha256": "sha256:" + hashlib.sha256(
+            report_path.read_bytes()
+        ).hexdigest(),
+    }
+    (tmp_path / "signed-report" / "verify_report.sigstore.json").write_text(
+        json.dumps(signature_proof, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return result
+
+
+def _passing_cosign(
+    args: Sequence[str],
+) -> subprocess.CompletedProcess[str]:
+    assert DEFAULT_EXPECTED_SIGNER_IDENTITY.startswith("https://github.com/")
+    assert "verify-blob" in args
+    assert "--certificate-identity" in args
+    assert DEFAULT_EXPECTED_SIGNER_IDENTITY in args
+    return subprocess.CompletedProcess(args, 0, "Verified OK", "")
+
+
+def test_verify_pr_gate_packet_accepts_signed_clean_packet(tmp_path: Path) -> None:
+    _build_signed_packet(tmp_path)
+
+    result = verify_pr_gate_packet(
+        pack_dir=tmp_path / "proof-pack",
+        report_path=tmp_path / "signed-report" / "verify_report.json",
+        sigstore_path=tmp_path / "signed-report" / "verify_report.sigstore.json",
+        cosign_runner=_passing_cosign,
+    )
+
+    assert result["status"] == "ok"
+    assert result["result"] == VERIFY_RESULT
+    assert result["decision"] == "NEEDS_REVIEW"
+    assert result["recommended_action"] == "require_human_approval"
+    assert result["channels"]["trust_policy"] == "NEEDS_REVIEW"
+
+
+def test_verify_pr_gate_packet_rejects_unsigned_placeholder(tmp_path: Path) -> None:
+    build_pr_gate_packet(
+        evidence=_evidence(),
+        decision=_decision(),
+        policy_path=POLICY_PATH,
+        out_dir=tmp_path,
+    )
+
+    with pytest.raises(PRGateVerificationError, match="not signed"):
+        verify_pr_gate_packet(
+            pack_dir=tmp_path / "proof-pack",
+            report_path=tmp_path / "signed-report" / "verify_report.json",
+            sigstore_path=tmp_path / "signed-report" / "verify_report.sigstore.json",
+            cosign_runner=_passing_cosign,
+        )
+
+
+def test_verify_pr_gate_packet_rejects_report_tamper(tmp_path: Path) -> None:
+    _build_signed_packet(tmp_path)
+    report_path = tmp_path / "signed-report" / "verify_report.json"
+    report = json.loads(report_path.read_text())
+    report["recommended_action"] = "proceed"
+    report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+
+    with pytest.raises(PRGateVerificationError, match="signature proof"):
+        verify_pr_gate_packet(
+            pack_dir=tmp_path / "proof-pack",
+            report_path=report_path,
+            sigstore_path=tmp_path / "signed-report" / "verify_report.sigstore.json",
+            cosign_runner=_passing_cosign,
+        )
+
+
+def test_verify_pr_gate_packet_rejects_pack_tamper(tmp_path: Path) -> None:
+    _build_signed_packet(tmp_path)
+    (tmp_path / "proof-pack" / "changed_files.json").write_text("[]\n")
+
+    with pytest.raises(PRGateVerificationError, match="file hash mismatch"):
+        verify_pr_gate_packet(
+            pack_dir=tmp_path / "proof-pack",
+            report_path=tmp_path / "signed-report" / "verify_report.json",
+            sigstore_path=tmp_path / "signed-report" / "verify_report.sigstore.json",
+            cosign_runner=_passing_cosign,
+        )
+
+
+def test_verify_pr_gate_packet_rejects_wrong_identity(tmp_path: Path) -> None:
+    _build_signed_packet(tmp_path)
+
+    with pytest.raises(PRGateVerificationError, match="expected signer identity"):
+        verify_pr_gate_packet(
+            pack_dir=tmp_path / "proof-pack",
+            report_path=tmp_path / "signed-report" / "verify_report.json",
+            sigstore_path=tmp_path / "signed-report" / "verify_report.sigstore.json",
+            expected_identity=(
+                "https://github.com/Haserjian/assay/.github/workflows/"
+                "other.yml@refs/heads/main"
+            ),
+            cosign_runner=_passing_cosign,
+        )
+
+
+def test_verify_pr_gate_packet_rejects_non_required_signature_policy(
+    tmp_path: Path,
+) -> None:
+    _build_signed_packet(tmp_path)
+    report_path = tmp_path / "signed-report" / "verify_report.json"
+    report = json.loads(report_path.read_text())
+    report["signature_policy"]["required"] = False
+    report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+
+    signature_path = tmp_path / "signed-report" / "verify_report.sigstore.json"
+    signature_proof = json.loads(signature_path.read_text())
+    signature_proof["verify_report_sha256"] = (
+        "sha256:" + hashlib.sha256(report_path.read_bytes()).hexdigest()
+    )
+    signature_path.write_text(
+        json.dumps(signature_proof, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(PRGateVerificationError, match="signature policy"):
+        verify_pr_gate_packet(
+            pack_dir=tmp_path / "proof-pack",
+            report_path=report_path,
+            sigstore_path=signature_path,
+            cosign_runner=_passing_cosign,
+        )
+
+
+def test_pr_gate_verify_cli_json_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import assay.pr_gate.verify as verify_mod
+
+    _build_signed_packet(tmp_path)
+    monkeypatch.setattr(verify_mod, "_run_cosign", _passing_cosign)
+
+    result = runner.invoke(
+        assay_app,
+        [
+            "pr-gate",
+            "verify",
+            "--pack",
+            str(tmp_path / "proof-pack"),
+            "--report",
+            str(tmp_path / "signed-report" / "verify_report.json"),
+            "--sigstore",
+            str(tmp_path / "signed-report" / "verify_report.sigstore.json"),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["status"] == "ok"
+    assert payload["result"] == VERIFY_RESULT
+    assert payload["expected_identity"] == DEFAULT_EXPECTED_SIGNER_IDENTITY


### PR DESCRIPTION
## Summary
- add PR Gate signature verification CLI for proof-pack/report/Sigstore bundle validation
- pin the default expected signer to the full GitHub Actions certificate identity URI
- carry Sigstore signature policy in verify_report.json while keeping generated bundles honestly NOT_SIGNED until workflow signing lands
- harden verification for pack hashes, pack root, report binding, policy hash, recomputed decision, signer identity, OIDC issuer, and required Sigstore-keyless policy
- update PR Gate product/trust-root docs to use the certificate URI form

## Validation
- .venv/bin/python -m pytest tests/assay/test_pr_gate_policy.py tests/assay/test_pr_gate_github_capture.py tests/assay/test_pr_gate_packet.py tests/assay/test_pr_gate_verify.py -q
- .venv/bin/python -m ruff check src/assay/pr_gate/github_capture.py src/assay/pr_gate/policy.py src/assay/pr_gate/packet.py src/assay/pr_gate/verify.py tests/assay/test_pr_gate_github_capture.py tests/assay/test_pr_gate_policy.py tests/assay/test_pr_gate_packet.py tests/assay/test_pr_gate_verify.py
- .venv/bin/python -m py_compile src/assay/commands.py src/assay/pr_gate/github_capture.py src/assay/pr_gate/policy.py src/assay/pr_gate/packet.py src/assay/pr_gate/verify.py tests/assay/test_pr_gate_github_capture.py tests/assay/test_pr_gate_policy.py tests/assay/test_pr_gate_packet.py tests/assay/test_pr_gate_verify.py
- git diff --check
- .venv/bin/assay pr-gate pack --help
- .venv/bin/assay pr-gate verify --help
- bash scripts/verify_verification_gate_sample.sh
- bash scripts/demo_tamper_verification_gate_sample.sh

Note: pre-existing untracked docs/strategy/ was left untouched.