### PR TITLE
feat: render PR Gate comments

### DIFF
--- a/src/assay/commands.py
+++ b/src/assay/commands.py
@@ -8462,6 +8462,53 @@ def pr_gate_verify_cmd(
     raise typer.Exit(0)
 
 
+@pr_gate_app.command("render-comment")
+def pr_gate_render_comment_cmd(
+    report: str = typer.Option(
+        ..., "--report", help="Path to signed-report/verify_report.json"
+    ),
+    pack: str = typer.Option(
+        ..., "--pack", help="Path to proof-pack/pack_manifest.json"
+    ),
+    out: str = typer.Option(
+        ..., "--out", help="Write rendered PR comment Markdown to this path"
+    ),
+) -> None:
+    """Render a PR Gate pull request comment."""
+    from pathlib import Path as P
+
+    from assay.pr_gate.render_comment import (
+        CommentRenderError,
+        render_pr_gate_comment_files,
+    )
+
+    try:
+        comment = render_pr_gate_comment_files(
+            report_path=P(report),
+            pack_manifest_path=P(pack),
+            out_path=P(out),
+        )
+    except (OSError, CommentRenderError) as exc:
+        _output_json(
+            {
+                "command": "assay pr-gate render-comment",
+                "status": "error",
+                "error": str(exc),
+            },
+            exit_code=3,
+        )
+
+    _output_json(
+        {
+            "command": "assay pr-gate render-comment",
+            "status": "ok",
+            "out": out,
+            "bytes": len(comment.encode("utf-8")),
+        },
+        exit_code=0,
+    )
+
+
 # ---------------------------------------------------------------------------
 # gate subcommands
 # ---------------------------------------------------------------------------

--- a/src/assay/pr_gate/render_comment.py
+++ b/src/assay/pr_gate/render_comment.py
@@ -1,0 +1,272 @@
+"""Render PR Gate Verification Reports as pull request comments."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional
+
+from assay.pr_gate.packet import DO_NOT_INFER, VERIFY_REPORT_SCHEMA_VERSION
+
+
+class CommentRenderError(ValueError):
+    """Raised when a PR Gate comment cannot be rendered safely."""
+
+
+def render_pr_gate_comment(
+    *,
+    report: Mapping[str, Any],
+    pack_manifest: Mapping[str, Any],
+    evidence: Optional[Mapping[str, Any]] = None,
+) -> str:
+    """Render a stable Markdown PR Gate comment."""
+    _validate_report(report)
+    _validate_manifest(pack_manifest)
+    _validate_report_manifest_binding(report=report, pack_manifest=pack_manifest)
+    subject = _mapping(report.get("subject"), "report.subject")
+    channels = _mapping(report.get("channels"), "report.channels")
+    decision = _string(report.get("overall_decision"), "report.overall_decision")
+    recommended_action = _string(
+        report.get("recommended_action"), "report.recommended_action"
+    )
+    reasons = _reasons(report)
+    evidence = evidence or {}
+
+    lines = [
+        f"Assay PR Gate: {_decision_label(decision)}",
+        "",
+        f"Recommended action: {recommended_action}",
+        f"Reason: {_reason_summary(reasons)}",
+        "",
+        "Subject:",
+        f"- repo: {subject.get('repo')}",
+        f"- PR: #{subject.get('pr_number')}",
+        f"- head commit: {subject.get('head_sha')}",
+        f"- diff hash: {subject.get('diff_sha256')}",
+        "",
+        "Verdict channels:",
+        f"- Integrity: {channels.get('integrity')}",
+        f"- Claim: {_claim_line(report=report, evidence=evidence)}",
+        f"- Replay: {channels.get('replay')}",
+        f"- Trust policy: {_trust_policy_line(report=report)}",
+        "",
+        "Evidence:",
+        f"- Evidence Box: {_evidence_ref(report, 'Evidence Box', 'proof-pack/pack_manifest.json')}",
+        f"- Verification Report: {_evidence_ref(report, 'Verification Report', 'signed-report/verify_report.json')}",
+        f"- Signature Proof: {_evidence_ref(report, 'Signature Proof', 'signed-report/verify_report.sigstore.json')}",
+        "",
+        "Do not infer:",
+    ]
+    lines.extend(f"- {item}" for item in _do_not_infer(report))
+    lines.extend(
+        [
+            "",
+            "Signed by expected workflow:",
+            _expected_identity(report),
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def render_pr_gate_comment_files(
+    *,
+    report_path: Path,
+    pack_manifest_path: Path,
+    out_path: Optional[Path] = None,
+) -> str:
+    """Load a PR Gate report and manifest, render a comment, and optionally write it."""
+    report = _load_json_object(report_path, "Verification Report")
+    pack_manifest = _load_json_object(pack_manifest_path, "pack manifest")
+    evidence = _load_optional_evidence(pack_manifest_path)
+    comment = render_pr_gate_comment(
+        report=report,
+        pack_manifest=pack_manifest,
+        evidence=evidence,
+    )
+    if out_path is not None:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(comment, encoding="utf-8")
+    return comment
+
+
+def _validate_report(report: Mapping[str, Any]) -> None:
+    if report.get("schema_version") != VERIFY_REPORT_SCHEMA_VERSION:
+        raise CommentRenderError("report schema_version is not PR Gate v0.1")
+    for key in (
+        "subject",
+        "overall_decision",
+        "recommended_action",
+        "channels",
+        "signature_policy",
+    ):
+        if key not in report:
+            raise CommentRenderError(f"report missing {key}")
+
+
+def _validate_manifest(pack_manifest: Mapping[str, Any]) -> None:
+    for key in ("pack_root_sha256", "subject", "decision_ref"):
+        if key not in pack_manifest:
+            raise CommentRenderError(f"pack manifest missing {key}")
+
+
+def _validate_report_manifest_binding(
+    *, report: Mapping[str, Any], pack_manifest: Mapping[str, Any]
+) -> None:
+    if report.get("pack_root_sha256") != pack_manifest.get("pack_root_sha256"):
+        raise CommentRenderError("report pack_root_sha256 does not match pack manifest")
+    if report.get("subject") != pack_manifest.get("subject"):
+        raise CommentRenderError("report subject does not match pack manifest")
+    if report.get("policy") != pack_manifest.get("policy"):
+        raise CommentRenderError("report policy does not match pack manifest")
+
+    decision_ref = _mapping(
+        pack_manifest.get("decision_ref"), "pack_manifest.decision_ref"
+    )
+    for field in ("overall_decision", "recommended_action", "channels"):
+        if report.get(field) != decision_ref.get(field):
+            raise CommentRenderError(
+                f"report {field} does not match pack manifest decision_ref"
+            )
+
+
+def _decision_label(decision: str) -> str:
+    if decision == "PASS":
+        return "PASS - proceed to normal review"
+    return decision
+
+
+def _reason_summary(reasons: List[Mapping[str, Any]]) -> str:
+    if not reasons:
+        return "none"
+    reason = reasons[0]
+    rule = reason.get("rule")
+    if rule == "risk_path_touched":
+        pattern = reason.get("matched_pattern")
+        return f"touched risk path {pattern}" if pattern else "touched risk path"
+    if rule == "required_check_missing":
+        return f"required check \"{reason.get('check')}\" was not observed"
+    if rule == "required_check_failed":
+        return f"required check \"{reason.get('check')}\" failed"
+    if rule == "integrity_failed":
+        return "integrity failed"
+    if rule == "untrusted_signer":
+        return "untrusted signer"
+    return json.dumps(reason, sort_keys=True)
+
+
+def _claim_line(*, report: Mapping[str, Any], evidence: Mapping[str, Any]) -> str:
+    channels = _mapping(report.get("channels"), "report.channels")
+    claim = channels.get("claim")
+    subject = _mapping(report.get("subject"), "report.subject")
+    head_sha = subject.get("head_sha")
+    checks = evidence.get("observed_checks") or []
+    if isinstance(checks, list):
+        for check in checks:
+            if not isinstance(check, Mapping):
+                continue
+            name = check.get("name")
+            conclusion = check.get("conclusion")
+            check_sha = check.get("head_sha")
+            if name and conclusion and check_sha == head_sha:
+                return (
+                    f"{claim} - observed check \"{name}\" concluded "
+                    f"{conclusion} for commit {head_sha}"
+                )
+    return str(claim)
+
+
+def _trust_policy_line(*, report: Mapping[str, Any]) -> str:
+    channels = _mapping(report.get("channels"), "report.channels")
+    trust_policy = channels.get("trust_policy")
+    for reason in _reasons(report):
+        rule = reason.get("rule")
+        if rule == "risk_path_touched" and reason.get("path"):
+            return f"{trust_policy} - touched {reason.get('path')}"
+        if rule == "untrusted_signer":
+            return f"{trust_policy} - untrusted signer"
+        if rule == "required_check_failed":
+            return f"{trust_policy} - required check \"{reason.get('check')}\" failed"
+        if rule == "required_check_missing":
+            return f"{trust_policy} - required check \"{reason.get('check')}\" missing"
+        if rule == "integrity_failed":
+            return f"{trust_policy} - integrity failed"
+    return str(trust_policy)
+
+
+def _evidence_ref(report: Mapping[str, Any], kind: str, default: str) -> str:
+    refs = report.get("evidence_refs") or []
+    if isinstance(refs, list):
+        for ref in refs:
+            if isinstance(ref, Mapping) and ref.get("kind") == kind:
+                path = ref.get("path")
+                if isinstance(path, str) and path:
+                    return path
+    return default
+
+
+def _do_not_infer(report: Mapping[str, Any]) -> List[str]:
+    raw = report.get("do_not_infer")
+    if isinstance(raw, list) and all(isinstance(item, str) for item in raw):
+        return list(raw)
+    return list(DO_NOT_INFER)
+
+
+def _expected_identity(report: Mapping[str, Any]) -> str:
+    signature_policy = _mapping(
+        report.get("signature_policy"), "report.signature_policy"
+    )
+    return _string(
+        signature_policy.get("expected_certificate_identity"),
+        "report.signature_policy.expected_certificate_identity",
+    )
+
+
+def _reasons(report: Mapping[str, Any]) -> List[Mapping[str, Any]]:
+    raw = report.get("reasons") or []
+    if not isinstance(raw, list):
+        raise CommentRenderError("report.reasons must be a list")
+    reasons: List[Mapping[str, Any]] = []
+    for index, reason in enumerate(raw):
+        if not isinstance(reason, Mapping):
+            raise CommentRenderError(f"report.reasons[{index}] must be a mapping")
+        reasons.append(reason)
+    return reasons
+
+
+def _load_optional_evidence(pack_manifest_path: Path) -> Dict[str, Any]:
+    evidence_path = pack_manifest_path.parent / "pr_gate_evidence.json"
+    if not evidence_path.exists():
+        return {}
+    return _load_json_object(evidence_path, "PR Gate evidence")
+
+
+def _load_json_object(path: Path, label: str) -> Dict[str, Any]:
+    if not path.exists():
+        raise CommentRenderError(f"{label} not found: {path}")
+    if not path.is_file():
+        raise CommentRenderError(f"{label} path is not a file: {path}")
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise CommentRenderError(f"failed to parse {label} JSON: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise CommentRenderError(f"{label} must be a JSON object")
+    return raw
+
+
+def _mapping(raw: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise CommentRenderError(f"{label} must be a mapping")
+    return raw
+
+
+def _string(raw: Any, label: str) -> str:
+    if not isinstance(raw, str) or not raw:
+        raise CommentRenderError(f"{label} must be a non-empty string")
+    return raw
+
+
+__all__ = [
+    "CommentRenderError",
+    "render_pr_gate_comment",
+    "render_pr_gate_comment_files",
+]

--- a/tests/assay/snapshots/comment_block.md
+++ b/tests/assay/snapshots/comment_block.md
@@ -1,0 +1,31 @@
+Assay PR Gate: BLOCK
+
+Recommended action: block_required_check_failed
+Reason: required check "tests" failed
+
+Subject:
+- repo: Haserjian/assay
+- PR: #123
+- head commit: head-block
+- diff hash: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+Verdict channels:
+- Integrity: PASS
+- Claim: FAIL - observed check "tests" concluded failure for commit head-block
+- Replay: NOT_RUN
+- Trust policy: BLOCK - required check "tests" failed
+
+Evidence:
+- Evidence Box: proof-pack/pack_manifest.json
+- Verification Report: signed-report/verify_report.json
+- Signature Proof: signed-report/verify_report.sigstore.json
+
+Do not infer:
+- code is secure
+- all possible tests passed
+- AI made a good design decision
+- replay was performed
+- production approval was granted
+
+Signed by expected workflow:
+https://github.com/Haserjian/assay/.github/workflows/assay-pr-gate.yml@refs/heads/main

--- a/tests/assay/snapshots/comment_needs_review.md
+++ b/tests/assay/snapshots/comment_needs_review.md
@@ -1,0 +1,31 @@
+Assay PR Gate: NEEDS_REVIEW
+
+Recommended action: require_human_approval
+Reason: touched risk path auth/**
+
+Subject:
+- repo: Haserjian/assay
+- PR: #123
+- head commit: head-needs-review
+- diff hash: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+Verdict channels:
+- Integrity: PASS
+- Claim: PASS - observed check "tests" concluded success for commit head-needs-review
+- Replay: NOT_RUN
+- Trust policy: NEEDS_REVIEW - touched auth/session.py
+
+Evidence:
+- Evidence Box: proof-pack/pack_manifest.json
+- Verification Report: signed-report/verify_report.json
+- Signature Proof: signed-report/verify_report.sigstore.json
+
+Do not infer:
+- code is secure
+- all possible tests passed
+- AI made a good design decision
+- replay was performed
+- production approval was granted
+
+Signed by expected workflow:
+https://github.com/Haserjian/assay/.github/workflows/assay-pr-gate.yml@refs/heads/main

--- a/tests/assay/snapshots/comment_pass.md
+++ b/tests/assay/snapshots/comment_pass.md
@@ -1,0 +1,31 @@
+Assay PR Gate: PASS - proceed to normal review
+
+Recommended action: proceed
+Reason: none
+
+Subject:
+- repo: Haserjian/assay
+- PR: #123
+- head commit: head-pass
+- diff hash: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+Verdict channels:
+- Integrity: PASS
+- Claim: PASS - observed check "tests" concluded success for commit head-pass
+- Replay: NOT_RUN
+- Trust policy: PASS
+
+Evidence:
+- Evidence Box: proof-pack/pack_manifest.json
+- Verification Report: signed-report/verify_report.json
+- Signature Proof: signed-report/verify_report.sigstore.json
+
+Do not infer:
+- code is secure
+- all possible tests passed
+- AI made a good design decision
+- replay was performed
+- production approval was granted
+
+Signed by expected workflow:
+https://github.com/Haserjian/assay/.github/workflows/assay-pr-gate.yml@refs/heads/main

--- a/tests/assay/test_pr_gate_render_comment.py
+++ b/tests/assay/test_pr_gate_render_comment.py
@@ -1,0 +1,235 @@
+"""Tests for PR Gate comment rendering."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+from typer.testing import CliRunner
+
+from assay.commands import assay_app
+from assay.pr_gate.packet import build_pr_gate_packet
+from assay.pr_gate.policy import compute_policy_sha256, evaluate_policy, load_policy
+from assay.pr_gate.render_comment import (
+    CommentRenderError,
+    render_pr_gate_comment_files,
+)
+
+runner = CliRunner()
+
+ROOT = Path(__file__).resolve().parents[2]
+POLICY_PATH = ROOT / "docs" / "examples" / "pr-gate-v0" / "assay-policy.yml"
+SNAPSHOT_DIR = Path(__file__).resolve().parent / "snapshots"
+
+
+def _evidence(
+    *,
+    head_sha: str,
+    changed_files: List[Dict[str, Any]],
+    conclusion: str,
+) -> Dict[str, Any]:
+    policy = load_policy(POLICY_PATH)
+    return {
+        "schema_version": "assay.pr_gate.evidence.v0.1",
+        "subject": {
+            "repo": "Haserjian/assay",
+            "pr_number": 123,
+            "base_sha": "base",
+            "head_sha": head_sha,
+            "diff_sha256": "sha256:" + "a" * 64,
+            "diff_source": "git diff --binary --full-index <base_sha> <head_sha>",
+        },
+        "capture": {
+            "provider": "github_actions",
+            "workflow_ref": (
+                "Haserjian/assay/.github/workflows/"
+                "assay-pr-gate.yml@refs/heads/main"
+            ),
+            "workflow_sha": "workflow-sha",
+            "run_id": "1001",
+            "run_attempt": "1",
+            "actor": "tim",
+            "event_name": "pull_request",
+            "github_sha": "merge-sha",
+        },
+        "changed_files": changed_files,
+        "observed_checks": [
+            {
+                "name": "tests",
+                "provider": "github_checks",
+                "head_sha": head_sha,
+                "status": "completed",
+                "conclusion": conclusion,
+                "observed_at": "2026-05-08T12:00:00Z",
+            }
+        ],
+        "policy": {
+            "profile": "coding_pr_v0",
+            "policy_sha256": compute_policy_sha256(policy),
+        },
+    }
+
+
+def _render_case(tmp_path: Path, evidence: Dict[str, Any]) -> str:
+    decision = evaluate_policy(evidence, load_policy(POLICY_PATH))
+    build_pr_gate_packet(
+        evidence=evidence,
+        decision=decision,
+        policy_path=POLICY_PATH,
+        out_dir=tmp_path,
+    )
+    return render_pr_gate_comment_files(
+        report_path=tmp_path / "signed-report" / "verify_report.json",
+        pack_manifest_path=tmp_path / "proof-pack" / "pack_manifest.json",
+    )
+
+
+def _snapshot(name: str) -> str:
+    return (SNAPSHOT_DIR / name).read_text(encoding="utf-8")
+
+
+def test_render_comment_pass_snapshot(tmp_path: Path) -> None:
+    comment = _render_case(
+        tmp_path,
+        _evidence(
+            head_sha="head-pass",
+            changed_files=[
+                {
+                    "path": "README.md",
+                    "status": "modified",
+                    "sha256_after": "sha256:" + "b" * 64,
+                }
+            ],
+            conclusion="success",
+        ),
+    )
+
+    assert comment == _snapshot("comment_pass.md")
+
+
+def test_render_comment_needs_review_snapshot(tmp_path: Path) -> None:
+    comment = _render_case(
+        tmp_path,
+        _evidence(
+            head_sha="head-needs-review",
+            changed_files=[
+                {
+                    "path": "auth/session.py",
+                    "status": "modified",
+                    "sha256_after": "sha256:" + "b" * 64,
+                }
+            ],
+            conclusion="success",
+        ),
+    )
+
+    assert comment == _snapshot("comment_needs_review.md")
+
+
+def test_render_comment_block_snapshot(tmp_path: Path) -> None:
+    comment = _render_case(
+        tmp_path,
+        _evidence(
+            head_sha="head-block",
+            changed_files=[
+                {
+                    "path": "README.md",
+                    "status": "modified",
+                    "sha256_after": "sha256:" + "b" * 64,
+                }
+            ],
+            conclusion="failure",
+        ),
+    )
+
+    assert comment == _snapshot("comment_block.md")
+
+
+def test_pr_gate_render_comment_cli_writes_comment(tmp_path: Path) -> None:
+    _render_case(
+        tmp_path,
+        _evidence(
+            head_sha="head-pass",
+            changed_files=[
+                {
+                    "path": "README.md",
+                    "status": "modified",
+                    "sha256_after": "sha256:" + "b" * 64,
+                }
+            ],
+            conclusion="success",
+        ),
+    )
+    out_path = tmp_path / "comment.md"
+
+    result = runner.invoke(
+        assay_app,
+        [
+            "pr-gate",
+            "render-comment",
+            "--report",
+            str(tmp_path / "signed-report" / "verify_report.json"),
+            "--pack",
+            str(tmp_path / "proof-pack" / "pack_manifest.json"),
+            "--out",
+            str(out_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["status"] == "ok"
+    assert payload["bytes"] == len(out_path.read_bytes())
+    assert out_path.read_text(encoding="utf-8") == _snapshot("comment_pass.md")
+
+
+def test_render_comment_rejects_mismatched_report_and_pack(tmp_path: Path) -> None:
+    _render_case(
+        tmp_path,
+        _evidence(
+            head_sha="head-pass",
+            changed_files=[
+                {
+                    "path": "README.md",
+                    "status": "modified",
+                    "sha256_after": "sha256:" + "b" * 64,
+                }
+            ],
+            conclusion="success",
+        ),
+    )
+    report_path = tmp_path / "signed-report" / "verify_report.json"
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    report["pack_root_sha256"] = "sha256:" + "c" * 64
+    report_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CommentRenderError, match="pack_root_sha256"):
+        render_pr_gate_comment_files(
+            report_path=report_path,
+            pack_manifest_path=tmp_path / "proof-pack" / "pack_manifest.json",
+        )
+
+
+def test_pr_gate_render_comment_cli_bad_input_exits_3(tmp_path: Path) -> None:
+    result = runner.invoke(
+        assay_app,
+        [
+            "pr-gate",
+            "render-comment",
+            "--report",
+            str(tmp_path / "missing-report.json"),
+            "--pack",
+            str(tmp_path / "missing-pack.json"),
+            "--out",
+            str(tmp_path / "comment.md"),
+        ],
+    )
+
+    assert result.exit_code == 3
+    payload = json.loads(result.output)
+    assert payload["status"] == "error"
+    assert "Verification Report not found" in payload["error"]


### PR DESCRIPTION
## Summary
- add deterministic PR Gate Markdown comment renderer
- add hidden `assay pr-gate render-comment` CLI that writes the comment and returns JSON status
- add snapshots for PASS, NEEDS_REVIEW, and BLOCK comment outputs
- include overall decision, recommended action, reason, subject, verdict channels, three evidence objects, do-not-infer footer, and expected signer identity
- harden renderer so it rejects report/pack-manifest binding mismatches before rendering

## Validation
- `.venv/bin/python -m pytest tests/assay/test_pr_gate_render_comment.py -q`
- `.venv/bin/python -m pytest tests/assay/test_pr_gate_policy.py tests/assay/test_pr_gate_github_capture.py tests/assay/test_pr_gate_packet.py tests/assay/test_pr_gate_verify.py tests/assay/test_pr_gate_render_comment.py -q`
- `.venv/bin/python -m ruff check src/assay/pr_gate/github_capture.py src/assay/pr_gate/policy.py src/assay/pr_gate/packet.py src/assay/pr_gate/verify.py src/assay/pr_gate/render_comment.py tests/assay/test_pr_gate_github_capture.py tests/assay/test_pr_gate_policy.py tests/assay/test_pr_gate_packet.py tests/assay/test_pr_gate_verify.py tests/assay/test_pr_gate_render_comment.py`
- `.venv/bin/python -m py_compile src/assay/commands.py src/assay/pr_gate/github_capture.py src/assay/pr_gate/policy.py src/assay/pr_gate/packet.py src/assay/pr_gate/verify.py src/assay/pr_gate/render_comment.py tests/assay/test_pr_gate_github_capture.py tests/assay/test_pr_gate_policy.py tests/assay/test_pr_gate_packet.py tests/assay/test_pr_gate_verify.py tests/assay/test_pr_gate_render_comment.py`
- `git diff --check`
- `.venv/bin/assay pr-gate render-comment --help`
- `bash scripts/verify_verification_gate_sample.sh`
- `bash scripts/demo_tamper_verification_gate_sample.sh`

Note: unrelated local `docs/examples/verification-gate-v0/START-HERE.md` title edit and pre-existing `docs/strategy/` were left unstaged.