### PR TITLE
feat: dogfood PR Gate workflow

### DIFF
--- a/.github/workflows/assay-pr-gate.yml
+++ b/.github/workflows/assay-pr-gate.yml
@@ -1,0 +1,132 @@
+name: Assay PR Gate
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  actions: read
+  checks: read
+  issues: write
+  pull-requests: read
+  id-token: write
+
+jobs:
+  assay-pr-gate:
+    name: signed review packet
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    env:
+      ASSAY_PR_GATE_DIR: .assay/pr-gate
+      ASSAY_PR_GATE_POLICY: docs/examples/pr-gate-v0/assay-policy.yml
+      ASSAY_PR_GATE_EXPECTED_IDENTITY: https://github.com/Haserjian/assay/.github/workflows/assay-pr-gate.yml@refs/heads/main
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Check out trusted base workflow code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 0
+
+      - name: Fetch pull request head as passive git data
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "+refs/pull/${PR_NUMBER}/head:refs/remotes/assay-pr-gate/head"
+          test "$(git rev-parse refs/remotes/assay-pr-gate/head)" = "$PR_HEAD_SHA"
+          git cat-file -e "${PR_BASE_SHA}^{commit}"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install trusted Assay checkout
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.0.0
+
+      - name: Capture PR evidence
+        run: |
+          set -euo pipefail
+          mkdir -p "$ASSAY_PR_GATE_DIR"
+          assay pr-gate capture \
+            --repo "$GITHUB_REPOSITORY" \
+            --pr "$PR_NUMBER" \
+            --head-sha "$PR_HEAD_SHA" \
+            --policy "$ASSAY_PR_GATE_POLICY" \
+            --out "$ASSAY_PR_GATE_DIR/evidence.json" \
+            --git-cwd .
+
+      - name: Evaluate PR Gate policy
+        run: |
+          set -euo pipefail
+          assay pr-gate evaluate \
+            --evidence "$ASSAY_PR_GATE_DIR/evidence.json" \
+            --policy "$ASSAY_PR_GATE_POLICY" \
+            --out "$ASSAY_PR_GATE_DIR/decision.json"
+
+      - name: Build PR Gate packet
+        run: |
+          set -euo pipefail
+          assay pr-gate pack \
+            --evidence "$ASSAY_PR_GATE_DIR/evidence.json" \
+            --decision "$ASSAY_PR_GATE_DIR/decision.json" \
+            --policy "$ASSAY_PR_GATE_POLICY" \
+            --out "$ASSAY_PR_GATE_DIR" \
+            --expected-identity "$ASSAY_PR_GATE_EXPECTED_IDENTITY"
+
+      - name: Sign Verification Report
+        run: |
+          set -euo pipefail
+          rm -f "$ASSAY_PR_GATE_DIR/signed-report/verify_report.sigstore.json"
+          cosign sign-blob \
+            --yes \
+            --bundle "$ASSAY_PR_GATE_DIR/signed-report/verify_report.sigstore.json" \
+            "$ASSAY_PR_GATE_DIR/signed-report/verify_report.json"
+
+      - name: Verify signed PR Gate packet
+        run: |
+          set -euo pipefail
+          assay pr-gate verify \
+            --pack "$ASSAY_PR_GATE_DIR/proof-pack" \
+            --report "$ASSAY_PR_GATE_DIR/signed-report/verify_report.json" \
+            --sigstore "$ASSAY_PR_GATE_DIR/signed-report/verify_report.sigstore.json" \
+            --expected-identity "$ASSAY_PR_GATE_EXPECTED_IDENTITY"
+
+      - name: Render PR comment
+        run: |
+          set -euo pipefail
+          assay pr-gate render-comment \
+            --report "$ASSAY_PR_GATE_DIR/signed-report/verify_report.json" \
+            --pack "$ASSAY_PR_GATE_DIR/proof-pack/pack_manifest.json" \
+            --out "$ASSAY_PR_GATE_DIR/comment.md"
+          {
+            echo
+            echo "Artifact:"
+            echo "- assay-pr-gate-report"
+          } >> "$ASSAY_PR_GATE_DIR/comment.md"
+
+      - name: Upload PR Gate artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: assay-pr-gate-report
+          path: ${{ env.ASSAY_PR_GATE_DIR }}
+          if-no-files-found: error
+
+      - name: Upsert PR comment
+        run: |
+          set -euo pipefail
+          assay pr-gate upsert-comment \
+            --repo "$GITHUB_REPOSITORY" \
+            --pr "$PR_NUMBER" \
+            --body "$ASSAY_PR_GATE_DIR/comment.md"

--- a/docs/product/assay-pr-gate-dogfood-v0.md
+++ b/docs/product/assay-pr-gate-dogfood-v0.md
@@ -1,0 +1,137 @@
+# Assay PR Gate Dogfood v0
+
+## Purpose
+
+This dogfood workflow makes PR Gate visible on real Assay pull requests.
+
+For same-repository pull requests targeting `main`, Assay PR Gate produces a
+signed review packet and posts a single marked PR comment. The comment is the
+review surface. The product object is the signed review decision bound to the
+evidence pack, policy, verdict channels, caveats, and PR commit.
+
+## Workflow
+
+The workflow is `.github/workflows/assay-pr-gate.yml`.
+
+It runs on `pull_request_target` for same-repo PRs only:
+
+```text
+github.event.pull_request.head.repo.full_name == github.repository
+```
+
+The workflow checks out trusted base-branch code, fetches the PR head as passive
+git data, and does not execute scripts from the PR head.
+
+The workflow steps are:
+
+1. Check out trusted base workflow code.
+2. Fetch the PR head commit as passive git data.
+3. Install Assay from the trusted checkout.
+4. Capture PR evidence.
+5. Evaluate `coding_pr_v0` policy.
+6. Build `proof-pack/` and `signed-report/`.
+7. Sign `signed-report/verify_report.json` with Cosign/Sigstore.
+8. Verify the signed PR Gate packet locally.
+9. Render the PR comment.
+10. Upload the `assay-pr-gate-report` artifact.
+11. Create or update the marked PR comment.
+
+## Uploaded Artifact
+
+The artifact is named:
+
+```text
+assay-pr-gate-report
+```
+
+It contains:
+
+```text
+.assay/pr-gate/
+  evidence.json
+  decision.json
+  proof-pack/
+  signed-report/
+  comment.md
+```
+
+## PR Comment
+
+The workflow posts or updates one PR timeline comment with this marker:
+
+```text
+<!-- assay-pr-gate:v0 -->
+```
+
+The comment includes:
+
+- overall decision
+- recommended action
+- primary reason
+- PR subject
+- verdict channels
+- Evidence Box, Verification Report, and Signature Proof paths
+- do-not-infer caveats
+- expected workflow signer identity
+- artifact name
+
+Existing marked comments are updated in place so the workflow does not spam
+duplicate comments.
+
+## Signing Identity
+
+The expected signer identity is:
+
+```text
+https://github.com/Haserjian/assay/.github/workflows/assay-pr-gate.yml@refs/heads/main
+```
+
+The workflow uses GitHub Actions OIDC and Sigstore/Cosign signing. Verification
+requires the expected certificate identity and issuer:
+
+```text
+https://token.actions.githubusercontent.com
+```
+
+## What This Proves
+
+The dogfood workflow proves that the PR Gate loop can produce a signed,
+portable review decision for a real PR:
+
+- the evidence pack hashes match
+- the Verification Report binds to the evidence pack root
+- the policy hash matches the policy file
+- the decision recomputes from evidence and policy
+- the signed report verifies against the expected workflow identity
+
+## What This Does Not Prove
+
+This workflow does not prove:
+
+- the code is secure
+- all possible tests passed
+- AI made a good design decision
+- replay was performed
+- production approval was granted
+- fork-safe production publishing is complete
+
+## Security Boundary
+
+This is a same-repo dogfood workflow, not the full fork-safe production design.
+
+The workflow uses `pull_request_target` so the signing identity can be the stable
+base workflow identity. That is dangerous if combined with checkout or execution
+of untrusted PR code.
+
+The rule for this workflow is:
+
+```text
+PR contents are passive evidence, not executable code.
+```
+
+The workflow may inspect diffs, object hashes, paths, check-run metadata, and
+GitHub API facts. It must not run build scripts, tests, package scripts, or other
+code from the PR head in the privileged signing/comment lane.
+
+Fork-safe production mode remains a separate two-lane implementation described
+in `docs/adr/ADR-pr-gate-two-lane-github-security.md`.

--- a/src/assay/commands.py
+++ b/src/assay/commands.py
@@ -8509,6 +8509,67 @@ def pr_gate_render_comment_cmd(
     )
 
 
+@pr_gate_app.command("upsert-comment")
+def pr_gate_upsert_comment_cmd(
+    body: str = typer.Option(
+        ..., "--body", help="Path to rendered PR Gate comment Markdown"
+    ),
+    repo: Optional[str] = typer.Option(
+        None, "--repo", help="GitHub repository in owner/name form"
+    ),
+    pr: Optional[int] = typer.Option(
+        None, "--pr", help="Pull request number"
+    ),
+    github_api_url: Optional[str] = typer.Option(
+        None, "--github-api-url", help="GitHub API base URL"
+    ),
+) -> None:
+    """Create or update the marked PR Gate pull request comment."""
+    from pathlib import Path as P
+
+    from assay.pr_gate.comment_upsert import (
+        CommentUpsertError,
+        upsert_pr_gate_comment_file,
+    )
+    from assay.pr_gate.github_capture import CaptureError, resolve_pr_number
+
+    try:
+        repo_value = repo or os.environ.get("GITHUB_REPOSITORY")
+        if not repo_value:
+            raise CommentUpsertError("--repo is required outside GitHub Actions")
+        pr_value = pr if pr is not None else resolve_pr_number(os.environ)
+        if pr_value is None:
+            raise CommentUpsertError("--pr is required outside a pull_request event")
+        token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+        if not token:
+            raise CommentUpsertError("GITHUB_TOKEN or GH_TOKEN is required")
+        result = upsert_pr_gate_comment_file(
+            repo=repo_value,
+            pr_number=pr_value,
+            body_path=P(body),
+            token=token,
+            api_url=github_api_url or os.environ.get("GITHUB_API_URL") or None,
+        )
+    except (OSError, CaptureError, CommentUpsertError) as exc:
+        _output_json(
+            {
+                "command": "assay pr-gate upsert-comment",
+                "status": "error",
+                "error": str(exc),
+            },
+            exit_code=3,
+        )
+
+    _output_json(
+        {
+            "command": "assay pr-gate upsert-comment",
+            "status": "ok",
+            **result,
+        },
+        exit_code=0,
+    )
+
+
 # ---------------------------------------------------------------------------
 # gate subcommands
 # ---------------------------------------------------------------------------

--- a/src/assay/pr_gate/comment_upsert.py
+++ b/src/assay/pr_gate/comment_upsert.py
@@ -1,0 +1,258 @@
+"""Create or update the Assay PR Gate pull request comment."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlencode
+from urllib.request import Request, urlopen
+
+from assay.pr_gate.github_capture import DEFAULT_GITHUB_API_URL
+
+COMMENT_MARKER = "<!-- assay-pr-gate:v0 -->"
+
+
+class CommentUpsertError(ValueError):
+    """Raised when the PR Gate comment cannot be published safely."""
+
+
+class IssueCommentClient(Protocol):
+    """Minimal client contract for PR timeline comments."""
+
+    def list_issue_comments(self, *, repo: str, issue_number: int) -> List[Dict[str, Any]]:
+        """Return issue comments for a PR/issue timeline."""
+
+    def create_issue_comment(
+        self, *, repo: str, issue_number: int, body: str
+    ) -> Dict[str, Any]:
+        """Create a PR/issue timeline comment."""
+
+    def update_issue_comment(
+        self, *, repo: str, comment_id: int, body: str
+    ) -> Dict[str, Any]:
+        """Update a PR/issue timeline comment."""
+
+
+class GitHubIssueCommentClient:
+    """Small GitHub REST client for PR Gate issue comments."""
+
+    def __init__(
+        self,
+        *,
+        token: str,
+        api_url: str = DEFAULT_GITHUB_API_URL,
+        timeout_sec: int = 30,
+    ) -> None:
+        if not token:
+            raise CommentUpsertError("GitHub token is required to upsert PR comments")
+        self.token = token
+        self.api_url = api_url.rstrip("/")
+        self.timeout_sec = timeout_sec
+
+    def list_issue_comments(self, *, repo: str, issue_number: int) -> List[Dict[str, Any]]:
+        all_items: List[Dict[str, Any]] = []
+        page = 1
+        while True:
+            payload = self._request_json(
+                "GET",
+                _repo_path(repo, f"issues/{issue_number}/comments"),
+                params={"per_page": 100, "page": page},
+            )
+            if not isinstance(payload, list):
+                raise CommentUpsertError("GitHub comments response was not a list")
+            items: List[Dict[str, Any]] = []
+            for index, item in enumerate(payload):
+                if not isinstance(item, dict):
+                    raise CommentUpsertError(
+                        f"GitHub comments[{index}] response was not an object"
+                    )
+                items.append(item)
+            all_items.extend(items)
+            if len(items) < 100:
+                return all_items
+            page += 1
+
+    def create_issue_comment(
+        self, *, repo: str, issue_number: int, body: str
+    ) -> Dict[str, Any]:
+        payload = self._request_json(
+            "POST",
+            _repo_path(repo, f"issues/{issue_number}/comments"),
+            body={"body": body},
+        )
+        return _json_object(payload, "create comment response")
+
+    def update_issue_comment(
+        self, *, repo: str, comment_id: int, body: str
+    ) -> Dict[str, Any]:
+        payload = self._request_json(
+            "PATCH",
+            _repo_path(repo, f"issues/comments/{comment_id}"),
+            body={"body": body},
+        )
+        return _json_object(payload, "update comment response")
+
+    def _request_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Mapping[str, Any]] = None,
+        body: Optional[Mapping[str, Any]] = None,
+    ) -> Any:
+        url = f"{self.api_url}/{path.lstrip('/')}"
+        if params:
+            url = f"{url}?{urlencode(params)}"
+        data = None
+        if body is not None:
+            data = json.dumps(body).encode("utf-8")
+        request = Request(
+            url,
+            data=data,
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": "application/json",
+                "User-Agent": "assay-pr-gate-comment",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with urlopen(request, timeout=self.timeout_sec) as response:
+                raw = response.read().decode("utf-8")
+        except HTTPError as exc:
+            raise CommentUpsertError(
+                f"GitHub comment request failed: HTTP {exc.code} {exc.reason}"
+            ) from exc
+        except URLError as exc:
+            raise CommentUpsertError(
+                f"GitHub comment request failed: {exc.reason}"
+            ) from exc
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise CommentUpsertError("GitHub comment response was malformed JSON") from exc
+
+
+def upsert_pr_gate_comment(
+    *,
+    repo: str,
+    pr_number: int,
+    body: str,
+    client: IssueCommentClient,
+) -> Dict[str, Any]:
+    """Create or update the marked PR Gate PR comment."""
+    _validate_repo(repo)
+    if pr_number <= 0:
+        raise CommentUpsertError("pr_number must be positive")
+    marked_body = ensure_comment_marker(body)
+    comments = client.list_issue_comments(repo=repo, issue_number=pr_number)
+    existing = find_marked_comment(comments)
+    if existing is None:
+        created = client.create_issue_comment(
+            repo=repo,
+            issue_number=pr_number,
+            body=marked_body,
+        )
+        return {
+            "action": "created",
+            "comment_id": created.get("id"),
+            "marker": COMMENT_MARKER,
+            "bytes": len(marked_body.encode("utf-8")),
+        }
+
+    comment_id = _comment_id(existing)
+    updated = client.update_issue_comment(
+        repo=repo,
+        comment_id=comment_id,
+        body=marked_body,
+    )
+    return {
+        "action": "updated",
+        "comment_id": updated.get("id", comment_id),
+        "marker": COMMENT_MARKER,
+        "bytes": len(marked_body.encode("utf-8")),
+    }
+
+
+def upsert_pr_gate_comment_file(
+    *,
+    repo: str,
+    pr_number: int,
+    body_path: Path,
+    token: str,
+    api_url: Optional[str] = None,
+    client: Optional[IssueCommentClient] = None,
+) -> Dict[str, Any]:
+    """Load a rendered comment file and upsert it on the PR timeline."""
+    if not body_path.exists():
+        raise CommentUpsertError(f"comment body file not found: {body_path}")
+    if not body_path.is_file():
+        raise CommentUpsertError(f"comment body path is not a file: {body_path}")
+    body = body_path.read_text(encoding="utf-8")
+    actual_client = client or GitHubIssueCommentClient(
+        token=token,
+        api_url=api_url or DEFAULT_GITHUB_API_URL,
+    )
+    return upsert_pr_gate_comment(
+        repo=repo,
+        pr_number=pr_number,
+        body=body,
+        client=actual_client,
+    )
+
+
+def ensure_comment_marker(body: str) -> str:
+    """Return the comment body with a stable PR Gate marker."""
+    if COMMENT_MARKER in body:
+        return body if body.endswith("\n") else f"{body}\n"
+    suffix = body if body.endswith("\n") else f"{body}\n"
+    return f"{COMMENT_MARKER}\n{suffix}"
+
+
+def find_marked_comment(comments: List[Mapping[str, Any]]) -> Optional[Mapping[str, Any]]:
+    """Return the first existing PR Gate comment, if present."""
+    for comment in comments:
+        body = comment.get("body")
+        if isinstance(body, str) and COMMENT_MARKER in body:
+            return comment
+    return None
+
+
+def _comment_id(comment: Mapping[str, Any]) -> int:
+    raw = comment.get("id")
+    if isinstance(raw, bool) or not isinstance(raw, int) or raw <= 0:
+        raise CommentUpsertError("marked comment has invalid id")
+    return raw
+
+
+def _repo_path(repo: str, suffix: str) -> str:
+    owner, name = repo.split("/", 1)
+    return f"/repos/{quote(owner)}/{quote(name)}/{suffix.lstrip('/')}"
+
+
+def _validate_repo(repo: str) -> None:
+    if "/" not in repo:
+        raise CommentUpsertError("repo must be in owner/name form")
+    owner, name = repo.split("/", 1)
+    if not owner or not name:
+        raise CommentUpsertError("repo must be in owner/name form")
+
+
+def _json_object(raw: Any, label: str) -> Dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise CommentUpsertError(f"{label} was not a JSON object")
+    return raw
+
+
+__all__ = [
+    "COMMENT_MARKER",
+    "CommentUpsertError",
+    "GitHubIssueCommentClient",
+    "ensure_comment_marker",
+    "find_marked_comment",
+    "upsert_pr_gate_comment",
+    "upsert_pr_gate_comment_file",
+]

--- a/tests/assay/test_pr_gate_comment_upsert.py
+++ b/tests/assay/test_pr_gate_comment_upsert.py
@@ -1,0 +1,113 @@
+"""Tests for PR Gate comment upsert behavior."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+from assay.pr_gate.comment_upsert import (
+    COMMENT_MARKER,
+    ensure_comment_marker,
+    find_marked_comment,
+    upsert_pr_gate_comment,
+    upsert_pr_gate_comment_file,
+)
+
+
+class FakeCommentClient:
+    def __init__(self, comments: List[Dict[str, Any]]) -> None:
+        self.comments = list(comments)
+        self.created: List[Dict[str, Any]] = []
+        self.updated: List[Dict[str, Any]] = []
+
+    def list_issue_comments(self, *, repo: str, issue_number: int) -> List[Dict[str, Any]]:
+        self.repo = repo
+        self.issue_number = issue_number
+        return list(self.comments)
+
+    def create_issue_comment(
+        self, *, repo: str, issue_number: int, body: str
+    ) -> Dict[str, Any]:
+        comment = {"id": 9001, "body": body}
+        self.created.append(
+            {"repo": repo, "issue_number": issue_number, "body": body}
+        )
+        self.comments.append(comment)
+        return comment
+
+    def update_issue_comment(
+        self, *, repo: str, comment_id: int, body: str
+    ) -> Dict[str, Any]:
+        self.updated.append({"repo": repo, "comment_id": comment_id, "body": body})
+        return {"id": comment_id, "body": body}
+
+
+def test_ensure_comment_marker_adds_stable_marker() -> None:
+    body = ensure_comment_marker("Assay PR Gate: PASS\n")
+
+    assert body.startswith(f"{COMMENT_MARKER}\n")
+    assert body.count(COMMENT_MARKER) == 1
+
+
+def test_ensure_comment_marker_does_not_duplicate_marker() -> None:
+    body = ensure_comment_marker(f"{COMMENT_MARKER}\nAssay PR Gate: PASS\n")
+
+    assert body.count(COMMENT_MARKER) == 1
+
+
+def test_find_marked_comment_returns_existing_pr_gate_comment() -> None:
+    marked = {"id": 2, "body": f"{COMMENT_MARKER}\nold"}
+
+    assert find_marked_comment([{"id": 1, "body": "other"}, marked]) == marked
+
+
+def test_upsert_pr_gate_comment_creates_when_marker_missing() -> None:
+    client = FakeCommentClient([{"id": 1, "body": "other"}])
+
+    result = upsert_pr_gate_comment(
+        repo="Haserjian/assay",
+        pr_number=123,
+        body="Assay PR Gate: PASS\n",
+        client=client,
+    )
+
+    assert result["action"] == "created"
+    assert len(client.created) == 1
+    assert len(client.updated) == 0
+    assert client.created[0]["body"].startswith(f"{COMMENT_MARKER}\n")
+
+
+def test_upsert_pr_gate_comment_updates_existing_marker_without_duplicate() -> None:
+    client = FakeCommentClient(
+        [{"id": 44, "body": f"{COMMENT_MARKER}\nAssay PR Gate: OLD\n"}]
+    )
+
+    result = upsert_pr_gate_comment(
+        repo="Haserjian/assay",
+        pr_number=123,
+        body="Assay PR Gate: NEEDS_REVIEW\n",
+        client=client,
+    )
+
+    assert result["action"] == "updated"
+    assert result["comment_id"] == 44
+    assert len(client.created) == 0
+    assert len(client.updated) == 1
+    assert client.updated[0]["body"].count(COMMENT_MARKER) == 1
+    assert "NEEDS_REVIEW" in client.updated[0]["body"]
+
+
+def test_upsert_pr_gate_comment_file_reads_body_and_inserts_marker(tmp_path: Path) -> None:
+    body_path = tmp_path / "comment.md"
+    body_path.write_text("Assay PR Gate: BLOCK\n", encoding="utf-8")
+    client = FakeCommentClient([])
+
+    result = upsert_pr_gate_comment_file(
+        repo="Haserjian/assay",
+        pr_number=123,
+        body_path=body_path,
+        token="token",
+        client=client,
+    )
+
+    assert result["action"] == "created"
+    assert client.created[0]["body"].startswith(f"{COMMENT_MARKER}\n")

--- a/tests/assay/test_pr_gate_dogfood_workflow.py
+++ b/tests/assay/test_pr_gate_dogfood_workflow.py
@@ -1,0 +1,60 @@
+"""Tests for the PR Gate dogfood workflow contract."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "assay-pr-gate.yml"
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_pr_gate_dogfood_workflow_yaml_parses() -> None:
+    payload = yaml.safe_load(_workflow_text())
+
+    assert payload["name"] == "Assay PR Gate"
+    assert "assay-pr-gate" in payload["jobs"]
+
+
+def test_pr_gate_dogfood_workflow_uses_same_repo_guard() -> None:
+    text = _workflow_text()
+
+    assert "pull_request_target:" in text
+    assert "github.event.pull_request.head.repo.full_name == github.repository" in text
+
+
+def test_pr_gate_dogfood_workflow_does_not_checkout_pr_head() -> None:
+    text = _workflow_text()
+
+    assert "ref: ${{ github.event.pull_request.base.ref }}" in text
+    assert "github.event.pull_request.head.ref" not in text
+    assert "refs/pull/${PR_NUMBER}/head" in text
+
+
+def test_pr_gate_dogfood_workflow_runs_full_command_sequence() -> None:
+    text = _workflow_text()
+
+    for command in (
+        "assay pr-gate capture",
+        "assay pr-gate evaluate",
+        "assay pr-gate pack",
+        "cosign sign-blob",
+        "assay pr-gate verify",
+        "assay pr-gate render-comment",
+        "assay pr-gate upsert-comment",
+        "actions/upload-artifact@v4",
+    ):
+        assert command in text
+
+
+def test_pr_gate_dogfood_workflow_uses_stable_expected_identity() -> None:
+    text = _workflow_text()
+
+    assert (
+        "https://github.com/Haserjian/assay/.github/workflows/"
+        "assay-pr-gate.yml@refs/heads/main"
+    ) in text


### PR DESCRIPTION
## Summary
- add same-repo PR Gate dogfood workflow at `.github/workflows/assay-pr-gate.yml`
- add marker-based PR comment upsert helper and hidden `assay pr-gate upsert-comment` CLI
- sign `signed-report/verify_report.json` with Cosign/Sigstore, verify locally, render the PR comment, upload `assay-pr-gate-report`, and create/update one marked PR comment
- document the dogfood workflow, artifact shape, signer identity, and security boundary
- add focused tests for comment marker behavior, update-vs-create behavior, no duplicate comments, workflow YAML, same-repo guard, passive PR-head fetch, and command sequence

## Security shape
- Uses `pull_request_target` only with a same-repo guard: `github.event.pull_request.head.repo.full_name == github.repository`
- Checks out trusted base-branch code, not PR head code
- Fetches PR head only as passive git object data through `refs/pull/${PR_NUMBER}/head`
- Does not run scripts, tests, or package code from the PR head in the privileged signing/comment lane
- Fork-safe two-lane production mode remains out of scope for this slice

## Validation
- `.venv/bin/python -m pytest tests/assay/test_pr_gate_comment_upsert.py tests/assay/test_pr_gate_dogfood_workflow.py -q`
- `.venv/bin/python -m pytest tests/assay/test_pr_gate_policy.py tests/assay/test_pr_gate_github_capture.py tests/assay/test_pr_gate_packet.py tests/assay/test_pr_gate_verify.py tests/assay/test_pr_gate_render_comment.py tests/assay/test_pr_gate_comment_upsert.py tests/assay/test_pr_gate_dogfood_workflow.py -q`
- `.venv/bin/python -m ruff check src/assay/pr_gate/github_capture.py src/assay/pr_gate/policy.py src/assay/pr_gate/packet.py src/assay/pr_gate/verify.py src/assay/pr_gate/render_comment.py src/assay/pr_gate/comment_upsert.py tests/assay/test_pr_gate_github_capture.py tests/assay/test_pr_gate_policy.py tests/assay/test_pr_gate_packet.py tests/assay/test_pr_gate_verify.py tests/assay/test_pr_gate_render_comment.py tests/assay/test_pr_gate_comment_upsert.py tests/assay/test_pr_gate_dogfood_workflow.py`
- `.venv/bin/python -m py_compile src/assay/commands.py src/assay/pr_gate/github_capture.py src/assay/pr_gate/policy.py src/assay/pr_gate/packet.py src/assay/pr_gate/verify.py src/assay/pr_gate/render_comment.py src/assay/pr_gate/comment_upsert.py tests/assay/test_pr_gate_github_capture.py tests/assay/test_pr_gate_policy.py tests/assay/test_pr_gate_packet.py tests/assay/test_pr_gate_verify.py tests/assay/test_pr_gate_render_comment.py tests/assay/test_pr_gate_comment_upsert.py tests/assay/test_pr_gate_dogfood_workflow.py`
- `git diff --check`
- `assay pr-gate capture/evaluate/pack/verify/render-comment/upsert-comment --help`
- `bash scripts/verify_verification_gate_sample.sh`
- `bash scripts/demo_tamper_verification_gate_sample.sh`

## Notes
- The first real dogfood comment should appear on the next same-repo PR after this workflow lands on `main`.
- Unrelated local `docs/examples/verification-gate-v0/START-HERE.md` title edit and pre-existing `docs/strategy/` remain unstaged and untouched.