### PR TITLE
fix: unblock PR Gate dogfood comments

### DIFF
--- a/.github/workflows/assay-pr-gate.yml
+++ b/.github/workflows/assay-pr-gate.yml
@@ -10,7 +10,7 @@ permissions:
   actions: read
   checks: read
   issues: write
-  pull-requests: read
+  pull-requests: write
   id-token: write
 
 jobs:

--- a/src/assay/pr_gate/comment_upsert.py
+++ b/src/assay/pr_gate/comment_upsert.py
@@ -123,8 +123,11 @@ class GitHubIssueCommentClient:
             with urlopen(request, timeout=self.timeout_sec) as response:
                 raw = response.read().decode("utf-8")
         except HTTPError as exc:
+            detail = _http_error_detail(exc.read().decode("utf-8", errors="replace"))
+            suffix = f": {detail}" if detail else ""
             raise CommentUpsertError(
-                f"GitHub comment request failed: HTTP {exc.code} {exc.reason}"
+                "GitHub comment request failed: "
+                f"{method} {path} -> HTTP {exc.code} {exc.reason}{suffix}"
             ) from exc
         except URLError as exc:
             raise CommentUpsertError(
@@ -245,6 +248,26 @@ def _json_object(raw: Any, label: str) -> Dict[str, Any]:
     if not isinstance(raw, dict):
         raise CommentUpsertError(f"{label} was not a JSON object")
     return raw
+
+
+def _http_error_detail(raw: str) -> str:
+    text = raw.strip()
+    if not text:
+        return ""
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return text[:500]
+    if not isinstance(parsed, Mapping):
+        return text[:500]
+    fields: List[str] = []
+    message = parsed.get("message")
+    if isinstance(message, str) and message:
+        fields.append(message)
+    documentation_url = parsed.get("documentation_url")
+    if isinstance(documentation_url, str) and documentation_url:
+        fields.append(f"docs: {documentation_url}")
+    return "; ".join(fields)[:500]
 
 
 __all__ = [

--- a/src/assay/pr_gate/render_comment.py
+++ b/src/assay/pr_gate/render_comment.py
@@ -156,6 +156,8 @@ def _reason_summary(reasons: List[Mapping[str, Any]]) -> str:
 def _claim_line(*, report: Mapping[str, Any], evidence: Mapping[str, Any]) -> str:
     channels = _mapping(report.get("channels"), "report.channels")
     claim = channels.get("claim")
+    if claim != "PASS":
+        return _non_pass_claim_line(report=report, claim=str(claim))
     subject = _mapping(report.get("subject"), "report.subject")
     head_sha = subject.get("head_sha")
     checks = evidence.get("observed_checks") or []
@@ -172,6 +174,16 @@ def _claim_line(*, report: Mapping[str, Any], evidence: Mapping[str, Any]) -> st
                     f"{conclusion} for commit {head_sha}"
                 )
     return str(claim)
+
+
+def _non_pass_claim_line(*, report: Mapping[str, Any], claim: str) -> str:
+    for reason in _reasons(report):
+        rule = reason.get("rule")
+        if rule == "required_check_missing":
+            return f"{claim} - required check \"{reason.get('check')}\" was not observed"
+        if rule == "required_check_failed":
+            return f"{claim} - required check \"{reason.get('check')}\" failed"
+    return claim
 
 
 def _trust_policy_line(*, report: Mapping[str, Any]) -> str:

--- a/tests/assay/snapshots/comment_block.md
+++ b/tests/assay/snapshots/comment_block.md
@@ -11,7 +11,7 @@ Subject:
 
 Verdict channels:
 - Integrity: PASS
-- Claim: FAIL - observed check "tests" concluded failure for commit head-block
+- Claim: FAIL - required check "tests" failed
 - Replay: NOT_RUN
 - Trust policy: BLOCK - required check "tests" failed
 

--- a/tests/assay/test_pr_gate_comment_upsert.py
+++ b/tests/assay/test_pr_gate_comment_upsert.py
@@ -1,11 +1,18 @@
 """Tests for PR Gate comment upsert behavior."""
 from __future__ import annotations
 
+from io import BytesIO
 from pathlib import Path
 from typing import Any, Dict, List
+from urllib.error import HTTPError
 
+import pytest
+
+from assay.pr_gate import comment_upsert
 from assay.pr_gate.comment_upsert import (
     COMMENT_MARKER,
+    CommentUpsertError,
+    GitHubIssueCommentClient,
     ensure_comment_marker,
     find_marked_comment,
     upsert_pr_gate_comment,
@@ -111,3 +118,30 @@ def test_upsert_pr_gate_comment_file_reads_body_and_inserts_marker(tmp_path: Pat
 
     assert result["action"] == "created"
     assert client.created[0]["body"].startswith(f"{COMMENT_MARKER}\n")
+
+
+def test_github_client_http_errors_include_response_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_urlopen(request: Any, timeout: int) -> None:
+        raise HTTPError(
+            request.full_url,
+            403,
+            "Forbidden",
+            {},
+            BytesIO(
+                b'{"message":"Resource not accessible by integration",'
+                b'"documentation_url":"https://docs.github.com/rest"}'
+            ),
+        )
+
+    monkeypatch.setattr(comment_upsert, "urlopen", fake_urlopen)
+    client = GitHubIssueCommentClient(token="token")
+
+    with pytest.raises(CommentUpsertError) as exc_info:
+        client.list_issue_comments(repo="Haserjian/assay", issue_number=134)
+
+    message = str(exc_info.value)
+    assert "GET /repos/Haserjian/assay/issues/134/comments" in message
+    assert "HTTP 403 Forbidden" in message
+    assert "Resource not accessible by integration" in message

--- a/tests/assay/test_pr_gate_render_comment.py
+++ b/tests/assay/test_pr_gate_render_comment.py
@@ -146,6 +146,37 @@ def test_render_comment_block_snapshot(tmp_path: Path) -> None:
     assert comment == _snapshot("comment_block.md")
 
 
+def test_render_comment_missing_required_check_does_not_quote_unrelated_check(
+    tmp_path: Path,
+) -> None:
+    evidence = _evidence(
+        head_sha="head-missing-check",
+        changed_files=[
+            {
+                "path": "README.md",
+                "status": "modified",
+                "sha256_after": "sha256:" + "b" * 64,
+            }
+        ],
+        conclusion="success",
+    )
+    evidence["observed_checks"] = [
+        {
+            "name": "Prepare",
+            "provider": "github_checks",
+            "head_sha": "head-missing-check",
+            "status": "completed",
+            "conclusion": "success",
+            "observed_at": "2026-05-08T12:00:00Z",
+        }
+    ]
+
+    comment = _render_case(tmp_path, evidence)
+
+    assert 'Claim: NOT_EVALUATED - required check "tests" was not observed' in comment
+    assert 'observed check "Prepare"' not in comment
+
+
 def test_pr_gate_render_comment_cli_writes_comment(tmp_path: Path) -> None:
     _render_case(
         tmp_path,


### PR DESCRIPTION
This fixes the first live PR Gate dogfood edge exposed by PR #134.\n\nChanges:\n- grant PR Gate workflow pull-request write permission for PR timeline comment upsert\n- include GitHub HTTP response details in comment-upsert failures\n- keep comment claim wording bounded when the required check is missing or failed\n\nValidation run locally:\n- .venv/bin/python -m pytest tests/assay/test_pr_gate_policy.py tests/assay/test_pr_gate_github_capture.py tests/assay/test_pr_gate_packet.py tests/assay/test_pr_gate_verify.py tests/assay/test_pr_gate_render_comment.py tests/assay/test_pr_gate_comment_upsert.py tests/assay/test_pr_gate_dogfood_workflow.py -q\n- .venv/bin/python -m ruff check src/assay/pr_gate/comment_upsert.py src/assay/pr_gate/render_comment.py tests/assay/test_pr_gate_comment_upsert.py tests/assay/test_pr_gate_render_comment.py\n- .venv/bin/python -m py_compile src/assay/pr_gate/comment_upsert.py src/assay/pr_gate/render_comment.py tests/assay/test_pr_gate_comment_upsert.py tests/assay/test_pr_gate_render_comment.py\n- git diff --check\n- bash scripts/verify_verification_gate_sample.sh\n- bash scripts/demo_tamper_verification_gate_sample.sh