### PR TITLE
fix: polish PR Gate dogfood comments

### DIFF
--- a/.github/workflows/assay-pr-gate.yml
+++ b/.github/workflows/assay-pr-gate.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ASSAY_PR_GATE_DIR: .assay/pr-gate
-      ASSAY_PR_GATE_POLICY: docs/examples/pr-gate-v0/assay-policy.yml
+      ASSAY_PR_GATE_POLICY: docs/examples/pr-gate-v0/assay-dogfood-policy.yml
       ASSAY_PR_GATE_EXPECTED_IDENTITY: https://github.com/Haserjian/assay/.github/workflows/assay-pr-gate.yml@refs/heads/main
       PR_NUMBER: ${{ github.event.pull_request.number }}
       PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -110,18 +110,26 @@ jobs:
             --report "$ASSAY_PR_GATE_DIR/signed-report/verify_report.json" \
             --pack "$ASSAY_PR_GATE_DIR/proof-pack/pack_manifest.json" \
             --out "$ASSAY_PR_GATE_DIR/comment.md"
-          {
-            echo
-            echo "Artifact:"
-            echo "- assay-pr-gate-report"
-          } >> "$ASSAY_PR_GATE_DIR/comment.md"
 
       - name: Upload PR Gate artifacts
+        id: upload-pr-gate-artifacts
         uses: actions/upload-artifact@v4
         with:
           name: assay-pr-gate-report
           path: ${{ env.ASSAY_PR_GATE_DIR }}
           if-no-files-found: error
+
+      - name: Add PR Gate links to comment
+        run: |
+          set -euo pipefail
+          {
+            echo
+            echo "Workflow run:"
+            echo "- https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo
+            echo "Artifact:"
+            echo "- [assay-pr-gate-report](${{ steps.upload-pr-gate-artifacts.outputs.artifact-url }})"
+          } >> "$ASSAY_PR_GATE_DIR/comment.md"
 
       - name: Upsert PR comment
         run: |

--- a/docs/examples/pr-gate-v0/assay-dogfood-policy.yml
+++ b/docs/examples/pr-gate-v0/assay-dogfood-policy.yml
@@ -1,0 +1,34 @@
+profile: coding_pr_v0
+
+risk_paths:
+  - ".github/workflows/**"
+  - "src/assay/pr_gate/**"
+  - "docs/examples/pr-gate-v0/**"
+  - "docs/product/assay-pr-gate-*.md"
+
+required_checks: []
+
+rules:
+  integrity_failed:
+    decision: BLOCK
+    recommended_action: block_integrity_failed
+
+  untrusted_signer:
+    decision: BLOCK
+    recommended_action: block_untrusted_signer
+
+  required_check_failed:
+    decision: BLOCK
+    recommended_action: block_required_check_failed
+
+  required_check_missing:
+    decision: NEEDS_REVIEW
+    recommended_action: rerun_required_check
+
+  risk_path_touched:
+    decision: NEEDS_REVIEW
+    recommended_action: require_human_approval
+
+default:
+  decision: PASS
+  recommended_action: proceed

--- a/docs/product/assay-pr-gate-dogfood-v0.md
+++ b/docs/product/assay-pr-gate-dogfood-v0.md
@@ -28,7 +28,7 @@ The workflow steps are:
 2. Fetch the PR head commit as passive git data.
 3. Install Assay from the trusted checkout.
 4. Capture PR evidence.
-5. Evaluate `coding_pr_v0` policy.
+5. Evaluate the dogfood `coding_pr_v0` policy.
 6. Build `proof-pack/` and `signed-report/`.
 7. Sign `signed-report/verify_report.json` with Cosign/Sigstore.
 8. Verify the signed PR Gate packet locally.
@@ -73,10 +73,22 @@ The comment includes:
 - Evidence Box, Verification Report, and Signature Proof paths
 - do-not-infer caveats
 - expected workflow signer identity
-- artifact name
+- workflow run link
+- artifact link
 
 Existing marked comments are updated in place so the workflow does not spam
 duplicate comments.
+
+## Dogfood Policy
+
+The workflow uses `docs/examples/pr-gate-v0/assay-dogfood-policy.yml`.
+
+That policy intentionally has no required check names. The first live dogfood
+surface should not report a missing `tests` check when this repository's checks
+use different names or report at different times. Required-check semantics are
+kept in `docs/examples/pr-gate-v0/assay-policy.yml` and remain part of PR Gate,
+but dogfood focuses on integrity, signing, artifact publication, comment
+upsert, and risk-path review.
 
 ## Signing Identity
 

--- a/src/assay/pr_gate/packet.py
+++ b/src/assay/pr_gate/packet.py
@@ -252,6 +252,7 @@ def _build_verify_report(
         "overall_decision": decision.get("overall_decision"),
         "recommended_action": decision.get("recommended_action"),
         "reasons": decision.get("reasons", []),
+        "check_observations": decision.get("check_observations", []),
         "channels": {
             "integrity": channels.get("integrity"),
             "claim": channels.get("claim"),

--- a/src/assay/pr_gate/policy.py
+++ b/src/assay/pr_gate/policy.py
@@ -23,6 +23,15 @@ RECOMMENDED_ACTIONS = frozenset(
         "manual_triage",
     }
 )
+CHECK_OBSERVATION_STATUSES = frozenset(
+    {
+        "OBSERVED_PASS",
+        "OBSERVED_FAIL",
+        "OBSERVED_PENDING",
+        "NOT_OBSERVED_YET",
+        "NAME_MISMATCH_POSSIBLE",
+    }
+)
 
 RULE_ORDER = (
     "integrity_failed",
@@ -153,18 +162,27 @@ def evaluate_policy(
         observed_checks=observed_checks,
         head_sha=head_sha,
     )
-    for check_name, outcome, check in check_outcomes:
-        if outcome == "failed":
+    for outcome in check_outcomes:
+        status = str(outcome["status"])
+        if status == "OBSERVED_FAIL":
             reasons_by_rule["required_check_failed"].append(
-                _required_check_failed_reason(check_name, check, head_sha)
+                _required_check_failed_reason(outcome, head_sha)
             )
-        elif outcome == "missing":
+        elif status in {
+            "OBSERVED_PENDING",
+            "NOT_OBSERVED_YET",
+            "NAME_MISMATCH_POSSIBLE",
+        }:
             reason: Dict[str, Any] = {
                 "rule": "required_check_missing",
-                "check": check_name,
+                "check": outcome["name"],
+                "observation_status": status,
             }
             if head_sha:
                 reason["head_sha"] = head_sha
+            observed_names = outcome.get("observed_check_names")
+            if observed_names:
+                reason["observed_check_names"] = observed_names
             reasons_by_rule["required_check_missing"].append(reason)
 
     for path, matched_pattern in _risk_path_matches(changed_files, risk_paths):
@@ -192,6 +210,7 @@ def evaluate_policy(
         "overall_decision": overall_decision,
         "recommended_action": recommended_action,
         "reasons": reasons,
+        "check_observations": check_outcomes,
         "channels": {
             "integrity": "PASS" if integrity == "PASS" else "FAIL",
             "claim": _claim_channel(check_outcomes),
@@ -354,12 +373,23 @@ def _required_check_outcomes(
     required_checks: Iterable[str],
     observed_checks: List[Mapping[str, Any]],
     head_sha: Optional[str],
-) -> List[Tuple[str, str, Optional[Mapping[str, Any]]]]:
-    outcomes: List[Tuple[str, str, Optional[Mapping[str, Any]]]] = []
+) -> List[Dict[str, Any]]:
+    outcomes: List[Dict[str, Any]] = []
+    observed_names = _observed_check_names(observed_checks, head_sha)
     for check_name in sorted(required_checks):
         candidates = _matching_checks(check_name, observed_checks, head_sha)
         if not candidates:
-            outcomes.append((check_name, "missing", None))
+            status = (
+                "NAME_MISMATCH_POSSIBLE"
+                if observed_names
+                else "NOT_OBSERVED_YET"
+            )
+            outcome: Dict[str, Any] = {"name": check_name, "status": status}
+            if head_sha:
+                outcome["head_sha"] = head_sha
+            if observed_names:
+                outcome["observed_check_names"] = observed_names
+            outcomes.append(outcome)
             continue
 
         concluded = [
@@ -368,7 +398,14 @@ def _required_check_outcomes(
             if isinstance(check.get("conclusion"), str) and check.get("conclusion")
         ]
         if not concluded:
-            outcomes.append((check_name, "missing", None))
+            check = _sort_checks(candidates)[0]
+            outcome = {"name": check_name, "status": "OBSERVED_PENDING"}
+            if head_sha:
+                outcome["head_sha"] = head_sha
+            observed_at = check.get("observed_at")
+            if isinstance(observed_at, str) and observed_at:
+                outcome["observed_at"] = observed_at
+            outcomes.append(outcome)
             continue
 
         failed = [
@@ -377,10 +414,59 @@ def _required_check_outcomes(
             if str(check["conclusion"]).lower() not in SUCCESSFUL_CHECK_CONCLUSIONS
         ]
         if failed:
-            outcomes.append((check_name, "failed", _sort_checks(failed)[0]))
+            outcomes.append(
+                _check_observation(
+                    check_name,
+                    "OBSERVED_FAIL",
+                    _sort_checks(failed)[0],
+                    head_sha,
+                )
+            )
         else:
-            outcomes.append((check_name, "passed", _sort_checks(concluded)[0]))
+            outcomes.append(
+                _check_observation(
+                    check_name,
+                    "OBSERVED_PASS",
+                    _sort_checks(concluded)[0],
+                    head_sha,
+                )
+            )
     return outcomes
+
+
+def _observed_check_names(
+    observed_checks: List[Mapping[str, Any]], head_sha: Optional[str]
+) -> List[str]:
+    names = set()
+    for check in observed_checks:
+        check_head = check.get("head_sha")
+        if head_sha and check_head != head_sha:
+            continue
+        name = check.get("name")
+        if isinstance(name, str) and name:
+            names.add(name)
+    return sorted(names)
+
+
+def _check_observation(
+    check_name: str,
+    status: str,
+    check: Mapping[str, Any],
+    head_sha: Optional[str],
+) -> Dict[str, Any]:
+    observation: Dict[str, Any] = {"name": check_name, "status": status}
+    check_head = check.get("head_sha")
+    if isinstance(check_head, str) and check_head:
+        observation["head_sha"] = check_head
+    elif head_sha:
+        observation["head_sha"] = head_sha
+    conclusion = check.get("conclusion")
+    if isinstance(conclusion, str) and conclusion:
+        observation["conclusion"] = conclusion
+    observed_at = check.get("observed_at")
+    if isinstance(observed_at, str) and observed_at:
+        observation["observed_at"] = observed_at
+    return observation
 
 
 def _matching_checks(
@@ -412,16 +498,16 @@ def _sort_checks(checks: List[Mapping[str, Any]]) -> List[Mapping[str, Any]]:
 
 
 def _required_check_failed_reason(
-    check_name: str,
-    check: Optional[Mapping[str, Any]],
+    outcome: Mapping[str, Any],
     head_sha: Optional[str],
 ) -> Dict[str, Any]:
     reason: Dict[str, Any] = {
         "rule": "required_check_failed",
-        "check": check_name,
-        "conclusion": str((check or {}).get("conclusion") or "unknown"),
+        "check": outcome["name"],
+        "conclusion": str(outcome.get("conclusion") or "unknown"),
+        "observation_status": str(outcome.get("status") or "OBSERVED_FAIL"),
     }
-    check_head = (check or {}).get("head_sha")
+    check_head = outcome.get("head_sha")
     if isinstance(check_head, str) and check_head:
         reason["head_sha"] = check_head
     elif head_sha:
@@ -460,14 +546,14 @@ def _selected_rule(
 
 
 def _claim_channel(
-    check_outcomes: List[Tuple[str, str, Optional[Mapping[str, Any]]]]
+    check_outcomes: List[Mapping[str, Any]]
 ) -> str:
-    outcomes = {outcome for _, outcome, _ in check_outcomes}
-    if "failed" in outcomes:
+    statuses = {outcome.get("status") for outcome in check_outcomes}
+    if "OBSERVED_FAIL" in statuses:
         return "FAIL"
-    if "missing" in outcomes:
+    if statuses - {"OBSERVED_PASS"}:
         return "NOT_EVALUATED"
-    if "passed" in outcomes:
+    if "OBSERVED_PASS" in statuses:
         return "PASS"
     return "NOT_EVALUATED"
 
@@ -488,6 +574,7 @@ def _trust_policy_channel(
 
 __all__ = [
     "DECISIONS",
+    "CHECK_OBSERVATION_STATUSES",
     "RECOMMENDED_ACTIONS",
     "RULE_ORDER",
     "PolicyEvaluationError",

--- a/src/assay/pr_gate/render_comment.py
+++ b/src/assay/pr_gate/render_comment.py
@@ -62,6 +62,12 @@ def render_pr_gate_comment(
             "",
             "Signed by expected workflow:",
             _expected_identity(report),
+            "",
+            "How to verify:",
+            "- Download `assay-pr-gate-report`, then run `assay pr-gate verify` against `proof-pack/` and `signed-report/`.",
+            "",
+            "How to challenge:",
+            "- Comment with missing evidence, stale policy, signer trust, replay divergence, overbroad claim, or contradictory evidence.",
         ]
     )
     return "\n".join(lines) + "\n"
@@ -143,7 +149,7 @@ def _reason_summary(reasons: List[Mapping[str, Any]]) -> str:
         pattern = reason.get("matched_pattern")
         return f"touched risk path {pattern}" if pattern else "touched risk path"
     if rule == "required_check_missing":
-        return f"required check \"{reason.get('check')}\" was not observed"
+        return _missing_check_summary(reason)
     if rule == "required_check_failed":
         return f"required check \"{reason.get('check')}\" failed"
     if rule == "integrity_failed":
@@ -180,7 +186,7 @@ def _non_pass_claim_line(*, report: Mapping[str, Any], claim: str) -> str:
     for reason in _reasons(report):
         rule = reason.get("rule")
         if rule == "required_check_missing":
-            return f"{claim} - required check \"{reason.get('check')}\" was not observed"
+            return f"{claim} - {_missing_check_summary(reason)}"
         if rule == "required_check_failed":
             return f"{claim} - required check \"{reason.get('check')}\" failed"
     return claim
@@ -198,10 +204,31 @@ def _trust_policy_line(*, report: Mapping[str, Any]) -> str:
         if rule == "required_check_failed":
             return f"{trust_policy} - required check \"{reason.get('check')}\" failed"
         if rule == "required_check_missing":
-            return f"{trust_policy} - required check \"{reason.get('check')}\" missing"
+            return f"{trust_policy} - {_missing_check_summary(reason)}"
         if rule == "integrity_failed":
             return f"{trust_policy} - integrity failed"
     return str(trust_policy)
+
+
+def _missing_check_summary(reason: Mapping[str, Any]) -> str:
+    check = reason.get("check")
+    status = reason.get("observation_status")
+    if status == "OBSERVED_PENDING":
+        return f"required check \"{check}\" is still pending"
+    if status == "NAME_MISMATCH_POSSIBLE":
+        observed = reason.get("observed_check_names")
+        if isinstance(observed, list) and observed:
+            names = ", ".join(f'"{name}"' for name in observed if isinstance(name, str))
+            if names:
+                return (
+                    f"required check \"{check}\" was not observed; "
+                    f"observed checks used other names: {names}"
+                )
+        return (
+            f"required check \"{check}\" was not observed; "
+            "observed checks used other names"
+        )
+    return f"required check \"{check}\" was not observed yet"
 
 
 def _evidence_ref(report: Mapping[str, Any], kind: str, default: str) -> str:

--- a/src/assay/pr_gate/verify.py
+++ b/src/assay/pr_gate/verify.py
@@ -217,7 +217,13 @@ def _verify_recomputed_decision(
     if decision_ref.get("channels") != decision.get("channels"):
         raise PRGateVerificationError("manifest decision_ref does not match decision")
 
-    for field in ("overall_decision", "recommended_action", "reasons", "channels"):
+    for field in (
+        "overall_decision",
+        "recommended_action",
+        "reasons",
+        "check_observations",
+        "channels",
+    ):
         if report.get(field) != decision.get(field):
             raise PRGateVerificationError(f"report {field} does not match decision")
 

--- a/tests/assay/snapshots/comment_block.md
+++ b/tests/assay/snapshots/comment_block.md
@@ -29,3 +29,9 @@ Do not infer:
 
 Signed by expected workflow:
 https://github.com/Haserjian/assay/.github/workflows/assay-pr-gate.yml@refs/heads/main
+
+How to verify:
+- Download `assay-pr-gate-report`, then run `assay pr-gate verify` against `proof-pack/` and `signed-report/`.
+
+How to challenge:
+- Comment with missing evidence, stale policy, signer trust, replay divergence, overbroad claim, or contradictory evidence.

--- a/tests/assay/snapshots/comment_needs_review.md
+++ b/tests/assay/snapshots/comment_needs_review.md
@@ -29,3 +29,9 @@ Do not infer:
 
 Signed by expected workflow:
 https://github.com/Haserjian/assay/.github/workflows/assay-pr-gate.yml@refs/heads/main
+
+How to verify:
+- Download `assay-pr-gate-report`, then run `assay pr-gate verify` against `proof-pack/` and `signed-report/`.
+
+How to challenge:
+- Comment with missing evidence, stale policy, signer trust, replay divergence, overbroad claim, or contradictory evidence.

--- a/tests/assay/snapshots/comment_pass.md
+++ b/tests/assay/snapshots/comment_pass.md
@@ -29,3 +29,9 @@ Do not infer:
 
 Signed by expected workflow:
 https://github.com/Haserjian/assay/.github/workflows/assay-pr-gate.yml@refs/heads/main
+
+How to verify:
+- Download `assay-pr-gate-report`, then run `assay pr-gate verify` against `proof-pack/` and `signed-report/`.
+
+How to challenge:
+- Comment with missing evidence, stale policy, signer trust, replay divergence, overbroad claim, or contradictory evidence.

--- a/tests/assay/test_pr_gate_dogfood_workflow.py
+++ b/tests/assay/test_pr_gate_dogfood_workflow.py
@@ -7,6 +7,7 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = ROOT / ".github" / "workflows" / "assay-pr-gate.yml"
+DOGFOOD_POLICY = ROOT / "docs" / "examples" / "pr-gate-v0" / "assay-dogfood-policy.yml"
 
 
 def _workflow_text() -> str:
@@ -49,6 +50,29 @@ def test_pr_gate_dogfood_workflow_runs_full_command_sequence() -> None:
         "actions/upload-artifact@v4",
     ):
         assert command in text
+
+
+def test_pr_gate_dogfood_workflow_uses_dogfood_policy() -> None:
+    text = _workflow_text()
+
+    assert "ASSAY_PR_GATE_POLICY: docs/examples/pr-gate-v0/assay-dogfood-policy.yml" in text
+    assert "docs/examples/pr-gate-v0/assay-policy.yml" not in text
+
+
+def test_pr_gate_dogfood_policy_does_not_require_named_checks() -> None:
+    payload = yaml.safe_load(DOGFOOD_POLICY.read_text(encoding="utf-8"))
+
+    assert payload["profile"] == "coding_pr_v0"
+    assert payload["required_checks"] == []
+    assert "src/assay/pr_gate/**" in payload["risk_paths"]
+
+
+def test_pr_gate_dogfood_workflow_adds_run_and_artifact_links() -> None:
+    text = _workflow_text()
+
+    assert "id: upload-pr-gate-artifacts" in text
+    assert "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" in text
+    assert "${{ steps.upload-pr-gate-artifacts.outputs.artifact-url }}" in text
 
 
 def test_pr_gate_dogfood_workflow_uses_stable_expected_identity() -> None:

--- a/tests/assay/test_pr_gate_packet.py
+++ b/tests/assay/test_pr_gate_packet.py
@@ -15,7 +15,7 @@ from assay.pr_gate.packet import (
     PacketError,
     build_pr_gate_packet,
 )
-from assay.pr_gate.policy import compute_policy_sha256, load_policy
+from assay.pr_gate.policy import compute_policy_sha256, evaluate_policy, load_policy
 
 runner = CliRunner()
 
@@ -70,23 +70,7 @@ def _evidence() -> Dict[str, Any]:
 
 
 def _decision() -> Dict[str, Any]:
-    return {
-        "overall_decision": "NEEDS_REVIEW",
-        "recommended_action": "require_human_approval",
-        "reasons": [
-            {
-                "rule": "risk_path_touched",
-                "path": "auth/session.py",
-                "matched_pattern": "auth/**",
-            }
-        ],
-        "channels": {
-            "integrity": "PASS",
-            "claim": "PASS",
-            "replay": "NOT_RUN",
-            "trust_policy": "NEEDS_REVIEW",
-        },
-    }
+    return evaluate_policy(_evidence(), load_policy(POLICY_PATH))
 
 
 def test_build_pr_gate_packet_writes_expected_tree(tmp_path: Path) -> None:
@@ -125,6 +109,7 @@ def test_build_pr_gate_packet_writes_expected_tree(tmp_path: Path) -> None:
     assert report["pack_manifest_sha256"].startswith("sha256:")
     assert report["policy"] == manifest["policy"]
     assert report["channels"] == _decision()["channels"]
+    assert report["check_observations"] == _decision()["check_observations"]
     assert report["overall_decision"] == "NEEDS_REVIEW"
     assert report["recommended_action"] == "require_human_approval"
     assert report["signature_policy"] == {

--- a/tests/assay/test_pr_gate_policy.py
+++ b/tests/assay/test_pr_gate_policy.py
@@ -76,6 +76,15 @@ class TestPrGatePolicyEvaluator:
             "overall_decision": "PASS",
             "recommended_action": "proceed",
             "reasons": [],
+            "check_observations": [
+                {
+                    "name": "tests",
+                    "status": "OBSERVED_PASS",
+                    "head_sha": "head",
+                    "conclusion": "success",
+                    "observed_at": "2026-05-08T12:00:00Z",
+                }
+            ],
             "channels": {
                 "integrity": "PASS",
                 "claim": "PASS",
@@ -94,6 +103,15 @@ class TestPrGatePolicyEvaluator:
         assert decision["recommended_action"] == "require_human_approval"
         assert decision["channels"]["claim"] == "PASS"
         assert decision["channels"]["trust_policy"] == "NEEDS_REVIEW"
+        assert decision["check_observations"] == [
+            {
+                "name": "tests",
+                "status": "OBSERVED_PASS",
+                "head_sha": "head",
+                "conclusion": "success",
+                "observed_at": "2026-05-08T12:00:00Z",
+            }
+        ]
         assert decision["reasons"] == [
             {
                 "rule": "risk_path_touched",
@@ -116,6 +134,14 @@ class TestPrGatePolicyEvaluator:
             {
                 "rule": "required_check_missing",
                 "check": "tests",
+                "observation_status": "NOT_OBSERVED_YET",
+                "head_sha": "head",
+            }
+        ]
+        assert decision["check_observations"] == [
+            {
+                "name": "tests",
+                "status": "NOT_OBSERVED_YET",
                 "head_sha": "head",
             }
         ]
@@ -145,7 +171,17 @@ class TestPrGatePolicyEvaluator:
                 "rule": "required_check_failed",
                 "check": "tests",
                 "conclusion": "failure",
+                "observation_status": "OBSERVED_FAIL",
                 "head_sha": "head",
+            }
+        ]
+        assert decision["check_observations"] == [
+            {
+                "name": "tests",
+                "status": "OBSERVED_FAIL",
+                "head_sha": "head",
+                "conclusion": "failure",
+                "observed_at": "2026-05-08T12:00:00Z",
             }
         ]
 
@@ -207,6 +243,14 @@ class TestPrGatePolicyEvaluator:
             {
                 "rule": "required_check_missing",
                 "check": "tests",
+                "observation_status": "NOT_OBSERVED_YET",
+                "head_sha": "head",
+            }
+        ]
+        assert decision["check_observations"] == [
+            {
+                "name": "tests",
+                "status": "NOT_OBSERVED_YET",
                 "head_sha": "head",
             }
         ]
@@ -233,7 +277,52 @@ class TestPrGatePolicyEvaluator:
             {
                 "rule": "required_check_missing",
                 "check": "tests",
+                "observation_status": "OBSERVED_PENDING",
                 "head_sha": "head",
+            }
+        ]
+        assert decision["check_observations"] == [
+            {
+                "name": "tests",
+                "status": "OBSERVED_PENDING",
+                "head_sha": "head",
+                "observed_at": "2026-05-08T12:00:00Z",
+            }
+        ]
+
+    def test_mismatched_check_name_is_reported_without_overclaiming(self) -> None:
+        decision = evaluate_policy(
+            _evidence(
+                observed_checks=[
+                    {
+                        "name": "Prepare",
+                        "provider": "github_checks",
+                        "head_sha": "head",
+                        "conclusion": "success",
+                        "observed_at": "2026-05-08T12:00:00Z",
+                    }
+                ]
+            ),
+            _policy(),
+        )
+
+        assert decision["overall_decision"] == "NEEDS_REVIEW"
+        assert decision["channels"]["claim"] == "NOT_EVALUATED"
+        assert decision["reasons"] == [
+            {
+                "rule": "required_check_missing",
+                "check": "tests",
+                "observation_status": "NAME_MISMATCH_POSSIBLE",
+                "head_sha": "head",
+                "observed_check_names": ["Prepare"],
+            }
+        ]
+        assert decision["check_observations"] == [
+            {
+                "name": "tests",
+                "status": "NAME_MISMATCH_POSSIBLE",
+                "head_sha": "head",
+                "observed_check_names": ["Prepare"],
             }
         ]
 

--- a/tests/assay/test_pr_gate_render_comment.py
+++ b/tests/assay/test_pr_gate_render_comment.py
@@ -173,7 +173,10 @@ def test_render_comment_missing_required_check_does_not_quote_unrelated_check(
 
     comment = _render_case(tmp_path, evidence)
 
-    assert 'Claim: NOT_EVALUATED - required check "tests" was not observed' in comment
+    assert (
+        'Claim: NOT_EVALUATED - required check "tests" was not observed; '
+        'observed checks used other names: "Prepare"'
+    ) in comment
     assert 'observed check "Prepare"' not in comment
 
 

--- a/tests/assay/test_pr_gate_verify.py
+++ b/tests/assay/test_pr_gate_verify.py
@@ -12,7 +12,7 @@ from typer.testing import CliRunner
 
 from assay.commands import assay_app
 from assay.pr_gate.packet import build_pr_gate_packet
-from assay.pr_gate.policy import compute_policy_sha256, load_policy
+from assay.pr_gate.policy import compute_policy_sha256, evaluate_policy, load_policy
 from assay.pr_gate.verify import (
     DEFAULT_CERTIFICATE_OIDC_ISSUER,
     DEFAULT_EXPECTED_SIGNER_IDENTITY,
@@ -74,23 +74,7 @@ def _evidence() -> Dict[str, Any]:
 
 
 def _decision() -> Dict[str, Any]:
-    return {
-        "overall_decision": "NEEDS_REVIEW",
-        "recommended_action": "require_human_approval",
-        "reasons": [
-            {
-                "rule": "risk_path_touched",
-                "path": "auth/session.py",
-                "matched_pattern": "auth/**",
-            }
-        ],
-        "channels": {
-            "integrity": "PASS",
-            "claim": "PASS",
-            "replay": "NOT_RUN",
-            "trust_policy": "NEEDS_REVIEW",
-        },
-    }
+    return evaluate_policy(_evidence(), load_policy(POLICY_PATH))
 
 
 def _build_signed_packet(tmp_path: Path) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- add explicit PR Gate check-observation states: OBSERVED_PASS, OBSERVED_FAIL, OBSERVED_PENDING, NOT_OBSERVED_YET, and NAME_MISMATCH_POSSIBLE
- carry check observations into the signed report and verifier comparison, and render clearer missing/name-mismatch language in PR comments
- add a dogfood policy with no required check names, then link the workflow run and uploaded artifact from the PR comment
- update dogfood docs, snapshots, and workflow contract tests

## Validation
- `/Users/timmybhaserjian/assay/.venv/bin/python -m pytest tests/assay/test_pr_gate_policy.py tests/assay/test_pr_gate_github_capture.py tests/assay/test_pr_gate_packet.py tests/assay/test_pr_gate_verify.py tests/assay/test_pr_gate_render_comment.py tests/assay/test_pr_gate_comment_upsert.py tests/assay/test_pr_gate_dogfood_workflow.py -q` -> 54 passed
- `/Users/timmybhaserjian/assay/.venv/bin/python -m ruff check src/assay/pr_gate/policy.py src/assay/pr_gate/packet.py src/assay/pr_gate/verify.py src/assay/pr_gate/render_comment.py tests/assay/test_pr_gate_policy.py tests/assay/test_pr_gate_packet.py tests/assay/test_pr_gate_verify.py tests/assay/test_pr_gate_render_comment.py tests/assay/test_pr_gate_dogfood_workflow.py`
- `/Users/timmybhaserjian/assay/.venv/bin/python -m py_compile ...` on changed PR Gate modules/tests
- `git diff --check`
- PR Gate CLI help checks for capture/evaluate/pack/verify/render-comment
- `bash scripts/verify_verification_gate_sample.sh`
- `bash scripts/demo_tamper_verification_gate_sample.sh`
- `HOME=$(mktemp -d) /Users/timmybhaserjian/assay/.venv/bin/python -m pytest tests/assay -q` -> 3384 passed, 62 skipped, 1 xfailed

## Note
Because the dogfood workflow runs from the trusted base branch under `pull_request_target`, this PR itself may still be commented by the previous workflow version. The new dogfood policy and artifact links are exercised by subsequent PRs after merge.