### PR TITLE
docs: exercise polished PR Gate comment

### DIFF
--- a/docs/product/assay-pr-gate-dogfood-v0.md
+++ b/docs/product/assay-pr-gate-dogfood-v0.md
@@ -9,6 +9,9 @@ signed review packet and posts a single marked PR comment. The comment is the
 review surface. The product object is the signed review decision bound to the
 evidence pack, policy, verdict channels, caveats, and PR commit.
 
+This document is also the stable smoke target for validating PR Gate comment
+changes against a live pull request.
+
 ## Workflow
 
 The workflow is `.github/workflows/assay-pr-gate.yml`.


### PR DESCRIPTION
## Summary
- add a tiny dogfood-doc clarification so the merged PR Gate workflow has a fresh same-repo PR to evaluate
- intentionally touches a dogfood risk path to exercise the new policy/comment surface without introducing code scope

## Validation
- `git diff --check`

## Expected PR Gate behavior
This PR should be evaluated by the post-#137 base workflow. Expected comment shape:
- no required `tests` check warning from dogfood policy
- `NEEDS_REVIEW` because `docs/product/assay-pr-gate-dogfood-v0.md` matches a risk path
- workflow run link and artifact link present
- How to verify / How to challenge sections present