### PR TITLE
docs: add uvx demo challenge path

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ non-claims instead of turning every packet into a vague green badge.
 Best first run:
 
 ```bash
+uvx --from assay-ai assay demo-challenge
+```
+
+If Assay is already installed:
+
+```bash
 assay demo-challenge
 ```
 
@@ -151,7 +157,9 @@ pipx install assay-ai
 
 To update later: `pipx upgrade assay-ai`
 
-_(No pipx? `python3 -m pip install assay-ai` also works, or `brew install pipx && pipx install assay-ai`)_
+_(No pipx? `uvx --from assay-ai assay demo-challenge` runs the first demo
+without a persistent install. `python3 -m pip install assay-ai` also works, or
+`brew install pipx && pipx install assay-ai`.)_
 
 ## Exit Codes
 


### PR DESCRIPTION
## Summary
- add `uvx --from assay-ai assay demo-challenge` as the README best first run
- keep `assay demo-challenge` for already-installed environments
- clarify the no-pipx path in the install section

## Validation
- `git diff --check`
- `UV_CACHE_DIR=$(mktemp -d) uvx --from assay-ai assay demo-challenge`

## PR Gate expectation
This should be the complementary clean-path dogfood signal: README is not in the dogfood risk paths, so PR Gate should produce `PASS` / `proceed` unless another policy fact intervenes.