### PR TITLE
Add green check trust decision post

### DIFF
--- a/docs/a-green-check-is-not-a-trust-decision/index.html
+++ b/docs/a-green-check-is-not-a-trust-decision/index.html
@@ -1,0 +1,347 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>A Green Check Is Not a Trust Decision | Assay</title>
+<meta name="description" content="A short Assay thesis post: verification status is not the same thing as trust, reliance, or claim scope.">
+<style>
+  :root {
+    --bg: #0d1117;
+    --bg2: #161b22;
+    --bg3: #1c2128;
+    --border: #30363d;
+    --text: #e6edf3;
+    --text2: #9aa7b4;
+    --muted: #6e7681;
+    --accent: #58a6ff;
+    --green: #3fb950;
+    --yellow: #d29922;
+    --red: #f85149;
+    --mono: "SF Mono", "Cascadia Code", "Fira Code", Consolas, monospace;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--sans);
+    line-height: 1.65;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code { font-family: var(--mono); }
+
+  .wrap {
+    width: min(920px, calc(100vw - 40px));
+    margin: 0 auto;
+  }
+
+  nav {
+    border-bottom: 1px solid var(--border);
+    background: rgba(13, 17, 23, 0.96);
+  }
+
+  .nav-inner {
+    min-height: 64px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 18px;
+  }
+
+  .brand {
+    color: var(--text);
+    font-family: var(--mono);
+    font-size: 18px;
+    font-weight: 700;
+  }
+
+  .nav-links {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 16px;
+    font-size: 14px;
+  }
+
+  .nav-links a { color: var(--text2); }
+  .nav-links a:hover { color: var(--text); text-decoration: none; }
+
+  header {
+    padding: 72px 0 32px;
+  }
+
+  .eyebrow {
+    margin: 0 0 14px;
+    color: var(--text2);
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  h1 {
+    max-width: 820px;
+    margin: 0;
+    font-size: clamp(42px, 7vw, 72px);
+    line-height: 0.98;
+    letter-spacing: -0.035em;
+  }
+
+  .lede {
+    max-width: 760px;
+    margin: 24px 0 0;
+    color: var(--text2);
+    font-size: clamp(18px, 2vw, 22px);
+  }
+
+  article {
+    border-top: 1px solid var(--border);
+    padding: 38px 0 78px;
+  }
+
+  .post {
+    max-width: 760px;
+  }
+
+  .post p {
+    margin: 0 0 22px;
+    color: var(--text2);
+    font-size: 18px;
+  }
+
+  .post p strong { color: var(--text); }
+
+  .post h2 {
+    margin: 42px 0 14px;
+    color: var(--text);
+    font-size: 24px;
+    line-height: 1.2;
+    letter-spacing: -0.015em;
+  }
+
+  .rule-list {
+    margin: 22px 0 28px;
+    padding: 0;
+    list-style: none;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    overflow: hidden;
+    background: var(--bg2);
+  }
+
+  .rule-list li {
+    display: grid;
+    grid-template-columns: 36px minmax(0, 1fr);
+    gap: 12px;
+    border-bottom: 1px solid var(--border);
+    padding: 14px 16px;
+    color: var(--text2);
+    font-size: 16px;
+  }
+
+  .rule-list li:last-child { border-bottom: 0; }
+
+  .rule-list span {
+    color: var(--red);
+    font-family: var(--mono);
+    font-weight: 700;
+  }
+
+  .spine {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1px;
+    margin: 30px 0;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    overflow: hidden;
+    background: var(--border);
+  }
+
+  .spine div {
+    background: var(--bg2);
+    padding: 18px;
+  }
+
+  .spine b {
+    display: block;
+    margin-bottom: 5px;
+    color: var(--text);
+    font-size: 15px;
+  }
+
+  .spine span {
+    color: var(--text2);
+    font-size: 14px;
+  }
+
+  .callout {
+    margin: 34px 0 0;
+    border: 1px solid rgba(88, 166, 255, 0.38);
+    border-radius: 10px;
+    background: rgba(88, 166, 255, 0.07);
+    padding: 18px;
+  }
+
+  .callout p {
+    margin: 0 0 14px;
+    color: var(--text);
+    font-size: 17px;
+  }
+
+  .button {
+    display: inline-block;
+    border: 1px solid var(--accent);
+    border-radius: 7px;
+    padding: 9px 16px;
+    color: var(--accent);
+    font-weight: 700;
+    font-size: 14px;
+  }
+
+  .button:hover {
+    background: rgba(88, 166, 255, 0.12);
+    text-decoration: none;
+  }
+
+  .final-line {
+    margin-top: 38px;
+    color: var(--text);
+    font-size: 24px;
+    line-height: 1.25;
+    letter-spacing: -0.015em;
+  }
+
+  footer {
+    border-top: 1px solid var(--border);
+    padding: 28px 0;
+    color: var(--text2);
+    font-size: 13px;
+  }
+
+  @media (max-width: 760px) {
+    header { padding-top: 52px; }
+    .spine { grid-template-columns: 1fr; }
+    .rule-list li { grid-template-columns: 28px minmax(0, 1fr); }
+  }
+</style>
+</head>
+<body>
+<nav>
+  <div class="wrap nav-inner">
+    <a class="brand" href="../">assay</a>
+    <div class="nav-links">
+      <a href="../claim-gap-report/">Claim Gap Report</a>
+      <a href="../packet-viewer/">Packet Viewer</a>
+      <a href="https://github.com/Haserjian/assay" target="_blank" rel="noreferrer">GitHub</a>
+    </div>
+  </div>
+</nav>
+
+<header>
+  <div class="wrap">
+    <p class="eyebrow">Assay thesis</p>
+    <h1>A green check is not a trust decision.</h1>
+    <p class="lede">
+      A green check means something narrow passed. It does not tell you how far
+      the claim is allowed to travel.
+    </p>
+  </div>
+</header>
+
+<article>
+  <div class="wrap post">
+    <p>
+      A signature can prove bytes were not changed. A test can prove one check
+      passed. A log can prove one event happened.
+    </p>
+
+    <p>
+      Those are useful facts. They are not the same thing as trust.
+    </p>
+
+    <p>
+      The failure mode in AI and software evidence is rarely just that evidence is
+      absent. The more common failure is that evidence gets stretched. A narrow
+      fact becomes a broad promise. A passing check becomes approval. A signed
+      packet becomes assurance. A demo becomes production safety.
+    </p>
+
+    <p>
+      That is the gap Assay is built to expose.
+    </p>
+
+    <h2>What a green check does not mean</h2>
+    <ul class="rule-list">
+      <li><span>x</span><div>The claim is true in every context.</div></li>
+      <li><span>x</span><div>The claim is safe to rely on.</div></li>
+      <li><span>x</span><div>The evidence covers the buyer's policy.</div></li>
+      <li><span>x</span><div>The result is reusable in a different decision.</div></li>
+      <li><span>x</span><div>The product or company should be trusted.</div></li>
+    </ul>
+
+    <p>
+      A green check is an input to review. It is not the review.
+    </p>
+
+    <div class="spine" aria-label="Assay evidence spine">
+      <div>
+        <b>Integrity is about bytes.</b>
+        <span>Was this artifact changed after signing?</span>
+      </div>
+      <div>
+        <b>Trust is about policy.</b>
+        <span>Is this signer or source acceptable for this profile?</span>
+      </div>
+      <div>
+        <b>Reliance is about context.</b>
+        <span>Can this evidence carry this claim for this decision?</span>
+      </div>
+    </div>
+
+    <p>
+      That distinction matters because consequential claims move. They leave a
+      terminal, a PR comment, a vendor questionnaire, a benchmark page, or a
+      security review packet and enter a decision.
+    </p>
+
+    <p>
+      Assay does not decide whether a claim is true. It decides whether the
+      available evidence is allowed to carry the claim under a declared policy
+      profile. When the claim is too broad, Assay should not pretend green.
+      It should show the gap.
+    </p>
+
+    <div class="callout">
+      <p>
+        See the static Claim Gap Report: one intact packet, one broad claim, one
+        buyer-owned proof floor, and the narrow claim the evidence can actually
+        support.
+      </p>
+      <a class="button" href="https://haserjian.github.io/assay/claim-gap-report/">Open the Claim Gap Report</a>
+    </div>
+
+    <p class="final-line">
+      Assay catches the moment evidence gets stretched into a promise.
+    </p>
+  </div>
+</article>
+
+<footer>
+  <div class="wrap">
+    <span>Assay</span>
+    <span aria-hidden="true"> &middot; </span>
+    <a href="../">Home</a>
+    <span aria-hidden="true"> &middot; </span>
+    <a href="../claim-gap-report/">Claim Gap Report</a>
+  </div>
+</footer>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -691,6 +691,7 @@
       <a href="#pr-gate">PR Gate</a>
       <a href="packet-viewer/">Packet Viewer</a>
       <a href="claim-gap-report/">Claim Gap Report</a>
+      <a href="a-green-check-is-not-a-trust-decision/">Green Check Post</a>
       <a href="#how-it-works">How It Works</a>
       <a href="#completeness">Coverage</a>
       <a href="#gap-map">Gap Map</a>
@@ -749,6 +750,7 @@
       A green check is not a trust decision. <strong>See the Claim Gap Report.</strong>
     </p>
     <a href="claim-gap-report/" style="display: inline-block; padding: 8px 20px; background: transparent; color: var(--text); border: 1px solid var(--border); font-weight: 600; font-size: 14px; border-radius: 6px; text-decoration: none;">Open static demo</a>
+    <a href="a-green-check-is-not-a-trust-decision/" style="display: inline-block; margin-left: 8px; padding: 8px 20px; background: transparent; color: var(--text); border: 1px solid var(--border); font-weight: 600; font-size: 14px; border-radius: 6px; text-decoration: none;">Read the post</a>
     <p style="margin: 8px 0 0; font-size: 12px; color: var(--text2);">
       One packet can be intact and still sit below the proof floor for customer security review.
     </p>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -16,6 +16,11 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://haserjian.github.io/assay/a-green-check-is-not-a-trust-decision/</loc>
+    <lastmod>2026-05-09</lastmod>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://haserjian.github.io/assay/decision-escrow.html</loc>
     <lastmod>2026-04-03</lastmod>
     <priority>0.8</priority>


### PR DESCRIPTION
Adds a short public thesis post explaining why verification status is not equivalent to trust or reliance. Links to the live Claim Gap Report demo as the proof artifact.

## Summary
- Adds `docs/a-green-check-is-not-a-trust-decision/index.html`.
- Links the post from the docs homepage navigation and Claim Gap callout.
- Adds the post URL to `docs/sitemap.xml`.

## Safety boundaries
- Does not accuse a real company or claimant.
- Does not overstate Assay engine capabilities.
- Uses the existing static Claim Gap Report as the concrete example.
- No engine, verifier, or policy runtime changes.

## Validation
```yaml
mode: checkpoint
verdict: "CONFIRMED static green-check thesis post added"
base_head_sha: "93194bea64761b19e36a4ec763774bd12b184ffb"
branch: "codex/green-check-post"
confirmed:
  - "HTML parsed locally."
  - "Post route rendered locally in browser."
  - "Homepage link rendered locally; two post links present."
  - "Post links to the live Claim Gap Report demo."
  - "No browser console errors observed."
  - "Temporary preview server stopped."
not_checked:
  - "Production GitHub Pages render was not verified."
  - "Repo test suite was not run; static docs only."
```

## Files changed
- `docs/a-green-check-is-not-a-trust-decision/index.html`
- `docs/index.html`
- `docs/sitemap.xml`

## Not included
- No engine changes.
- No verifier changes.
- No admissibility module.
- No production GitHub Pages verification yet.
