### PR TITLE
dogfood: prove Assay PR Gate on a real PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,8 @@ artifacts/
 .assay-ci-smoke/
 assay_quickstart_report.html
 demo/constitutional_verification/demo_output/
+examples/T0-local-receipt-demo/acceptance/out/
+examples/T0-local-receipt-demo/acceptance/out/keys/ed25519.private.raw
 
 # Internal commercial docs (not public)
 docs/commercial/

--- a/docs/dogfood-pr-gate-real-pr-proof.md
+++ b/docs/dogfood-pr-gate-real-pr-proof.md
@@ -1,0 +1,12 @@
+# PR Gate Real PR Proof
+
+This file is a minimal same-repository pull request target for the Assay PR Gate
+dogfood workflow.
+
+It is intentionally doc-only and outside the dogfood policy risk paths. The
+pull request is meant to prove that the live workflow can produce, sign, verify,
+upload, and comment on a PR Gate packet without treating the PR contents as
+trusted executable code.
+
+This local commit does not prove CI signing. That claim requires the live PR
+run, downloaded artifact verification, and tamper checks.


### PR DESCRIPTION
Exercises the same-repo Assay PR Gate signing, artifact upload, verification, and comment path. This PR does not claim PR Gate is proven until the live workflow artifact verifies locally and tamper checks fail closed.