### PR TITLE
fix: pin Typer before receipt runner drift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,8 @@ artifacts/
 .assay-ci-smoke/
 assay_quickstart_report.html
 demo/constitutional_verification/demo_output/
+examples/T0-local-receipt-demo/acceptance/out/
+examples/T0-local-receipt-demo/acceptance/out/keys/ed25519.private.raw
 
 # Internal commercial docs (not public)
 docs/commercial/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "typer>=0.9.0",
+    # Typer 0.26.x replaced the Click-backed test runner used by CLI tests.
+    "typer>=0.9.0,<0.26.0",
     "rich>=13.0.0",
     "pydantic>=2.0.0",
     "PyNaCl>=1.5.0,<2",


### PR DESCRIPTION
Fixes assay-receipt CI drift caused by Typer 0.26.x replacing the Click-backed CliRunner used by the CLI tests.

Validation:
- Fresh Python 3.11 install resolved typer 0.25.1 and click 8.4.1
- tests/assay/test_analyze.py + tests/assay/test_assay_receipt_workflow.py: 49 passed
- Full receipt-shaped run with isolated HOME and venv-first PATH: 3544 passed, 24 skipped, 1 xfailed

Notes:
- This is an immediate compatibility pin, not a migration to Typer 0.26+
- Follow-up debt: migrate CLI tests away from runner.isolated_filesystem()
- Also preserves the T0 demo output/private-key ignore guard