### PR TITLE
feat(claim-gate): Claim Gate v0.1 — unsupported claim-boundary drift detection

### DIFF
--- a/docs/claim-gate-v0.md
+++ b/docs/claim-gate-v0.md
@@ -1,0 +1,80 @@
+# Assay Claim Gate v0
+
+Assay Claim Gate detects unsupported trust escalation across diffs.
+
+It does not determine truth, certify compliance, or approve production use. It
+turns ordinary repository and document diffs into a bounded report that says
+which configured claim-boundary transitions appeared, what evidence was
+required, what evidence was found, and whether the transition should pass,
+needs review, or block.
+
+```text
+unsupported claim drift is detectable, attributable, and gateable
+```
+
+## Command
+
+```bash
+assay claim-gate diff \
+  --base main \
+  --head HEAD \
+  --policy assay.claims.yml \
+  --out claim_gate_report.json
+```
+
+Advisory mode exits 0 for `PASS` and `NEEDS_REVIEW`, and exits 2 for `BLOCK`.
+Strict review mode exits 1 for `NEEDS_REVIEW`:
+
+```bash
+assay claim-gate diff \
+  --base main \
+  --head HEAD \
+  --policy assay.claims.yml \
+  --fail-on-review
+```
+
+## What It Catches
+
+V0 is rule-based and deterministic. It detects transitions such as:
+
+- `prototype_to_production`
+- `possible_to_guaranteed`
+- `may_might_could_to_does_will`
+- `local_to_general`
+- `demo_to_enterprise`
+- `experimental_to_reliable`
+- `suggestion_to_recommendation`
+- `recommendation_to_policy`
+- `partial_support_to_proven`
+- `risk_reduced_to_safe`
+- `observed_to_causal`
+
+The rule is:
+
+```text
+transition + missing required evidence => configured verdict
+```
+
+The rule is not:
+
+```text
+claim sounds false => verdict
+```
+
+## Non-Claims
+
+Claim Gate records bounded or aspirational language as `non_claims` when the
+changed text includes markers such as `draft`, `roadmap`, `future goal`, or
+`hypothesis`. This keeps roadmap language distinct from publishable claims.
+
+## Example Files
+
+The first cold-reader example lives in:
+
+```text
+docs/examples/claim-gate-v0/
+  assay.claims.yml
+  README_before.md
+  README_after.md
+  claim_gate_report.json
+```

--- a/docs/examples/claim-gate-v0/README_after.md
+++ b/docs/examples/claim-gate-v0/README_after.md
@@ -1,0 +1,3 @@
+# Demo Agent
+
+This production-ready framework guarantees safe autonomous agent execution.

--- a/docs/examples/claim-gate-v0/README_before.md
+++ b/docs/examples/claim-gate-v0/README_before.md
@@ -1,0 +1,3 @@
+# Demo Agent
+
+This experimental prototype may help evaluate agent workflows.

--- a/docs/examples/claim-gate-v0/assay.claims.yml
+++ b/docs/examples/claim-gate-v0/assay.claims.yml
@@ -1,0 +1,97 @@
+schema_version: assay.claim_policy.v0
+
+default_verdict: NEEDS_REVIEW
+
+blocked_transitions:
+  prototype_to_production:
+    severity: high
+    requires:
+      - production_deployment_receipt
+      - reproducible_test_suite
+  possible_to_guaranteed:
+    severity: high
+    requires:
+      - direct_evidence
+      - reviewer_acceptance
+  recommendation_to_policy:
+    severity: high
+    requires:
+      - human_acceptance
+      - policy_review_receipt
+  partial_support_to_proven:
+    severity: high
+    requires:
+      - direct_evidence
+      - reviewer_acceptance
+  risk_reduced_to_safe:
+    severity: high
+    requires:
+      - threat_model
+      - safety_evaluation
+
+review_transitions:
+  local_to_general:
+    severity: medium
+    requires:
+      - scope_evidence
+      - reproducibility_note
+  may_might_could_to_does_will:
+    severity: medium
+    requires:
+      - direct_evidence
+  observed_to_causal:
+    severity: medium
+    requires:
+      - causal_evidence
+  demo_to_enterprise:
+    severity: medium
+    requires:
+      - deployment_scope_receipt
+  experimental_to_reliable:
+    severity: medium
+    requires:
+      - reliability_evaluation
+  suggestion_to_recommendation:
+    severity: medium
+    requires:
+      - reviewer_acceptance
+
+allow_markers:
+  - prototype
+  - experimental
+  - draft
+  - roadmap
+  - future work
+  - future goal
+  - hypothesis
+  - exploring
+  - proposal
+
+evidence_paths:
+  production_deployment_receipt:
+    - receipts/production_deployment_receipt.json
+    - proof-pack/**/production_deployment_receipt.json
+  reproducible_test_suite:
+    - tests/**/test_*.py
+  direct_evidence:
+    - evidence/direct_evidence.*
+  reviewer_acceptance:
+    - receipts/reviewer_acceptance.*
+  human_acceptance:
+    - receipts/human_acceptance.*
+  policy_review_receipt:
+    - receipts/policy_review_receipt.*
+  threat_model:
+    - docs/threat-model.md
+  safety_evaluation:
+    - evidence/safety_evaluation.*
+  scope_evidence:
+    - evidence/scope_evidence.*
+  reproducibility_note:
+    - docs/reproducibility.md
+  causal_evidence:
+    - evidence/causal_evidence.*
+  deployment_scope_receipt:
+    - receipts/deployment_scope_receipt.*
+  reliability_evaluation:
+    - evidence/reliability_evaluation.*

--- a/docs/examples/claim-gate-v0/claim_gate_report.json
+++ b/docs/examples/claim-gate-v0/claim_gate_report.json
@@ -1,0 +1,78 @@
+{
+  "command": "assay claim-gate diff",
+  "non_claims": [],
+  "non_claims_global": [
+    "This report does not determine truth.",
+    "This report does not certify legal compliance.",
+    "This report does not approve production deployment.",
+    "This report only gates configured claim-boundary transitions."
+  ],
+  "schema_version": "assay.claim_gate_report.v0",
+  "subject": {
+    "base": "main",
+    "head": "HEAD",
+    "policy": "assay.claims.yml"
+  },
+  "summary": {
+    "blocking_transitions": 2,
+    "files_scanned": 1,
+    "needs_review": 0,
+    "non_claims": 0,
+    "transitions_detected": 2
+  },
+  "transitions": [
+    {
+      "after_span": {
+        "end_line": 3,
+        "start_line": 3,
+        "text": "This production-ready framework guarantees safe autonomous agent execution."
+      },
+      "before_span": {
+        "end_line": 3,
+        "start_line": 3,
+        "text": "This experimental prototype may help evaluate agent workflows."
+      },
+      "confidence": 0.9,
+      "evidence_found": [],
+      "evidence_required": [
+        "direct_evidence",
+        "reviewer_acceptance"
+      ],
+      "file": "README.md",
+      "id": "cgt_001",
+      "rationale": "The text moves from possibility language to a guarantee.",
+      "risk_class": "unsupported_claim_escalation",
+      "severity": "high",
+      "suggested_rewrite": "Use possibility language unless direct evidence supports the guarantee.",
+      "transition_class": "possible_to_guaranteed",
+      "verdict": "BLOCK"
+    },
+    {
+      "after_span": {
+        "end_line": 3,
+        "start_line": 3,
+        "text": "This production-ready framework guarantees safe autonomous agent execution."
+      },
+      "before_span": {
+        "end_line": 3,
+        "start_line": 3,
+        "text": "This experimental prototype may help evaluate agent workflows."
+      },
+      "confidence": 0.93,
+      "evidence_found": [],
+      "evidence_required": [
+        "production_deployment_receipt",
+        "reproducible_test_suite"
+      ],
+      "file": "README.md",
+      "id": "cgt_002",
+      "rationale": "The text moves from prototype or experimental language to production readiness.",
+      "risk_class": "unsupported_claim_escalation",
+      "severity": "high",
+      "suggested_rewrite": "Frame this as a prototype or production-oriented exploration until deployment evidence is present.",
+      "transition_class": "prototype_to_production",
+      "verdict": "BLOCK"
+    }
+  ],
+  "verdict": "BLOCK"
+}

--- a/src/assay/claim_gate/__init__.py
+++ b/src/assay/claim_gate/__init__.py
@@ -1,0 +1,19 @@
+"""Claim Gate: deterministic detection of unsupported claim drift."""
+
+from assay.claim_gate.cli import run_claim_gate_diff
+from assay.claim_gate.models import (
+    ClaimBoundaryTransition,
+    DiffCollection,
+    DiffPair,
+    NonClaim,
+    TextSpan,
+)
+
+__all__ = [
+    "ClaimBoundaryTransition",
+    "DiffCollection",
+    "DiffPair",
+    "NonClaim",
+    "TextSpan",
+    "run_claim_gate_diff",
+]

--- a/src/assay/claim_gate/cli.py
+++ b/src/assay/claim_gate/cli.py
@@ -1,0 +1,73 @@
+"""CLI helpers for Assay Claim Gate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Optional, Sequence, Tuple
+
+from assay.claim_gate.detectors import detect_collection
+from assay.claim_gate.diff_source import DiffSourceError, collect_diff
+from assay.claim_gate.evidence import build_evidence_index
+from assay.claim_gate.policy import ClaimGatePolicyError, apply_policy, load_policy
+from assay.claim_gate.report import build_report, exit_code_for_verdict, write_report
+
+
+class ClaimGateError(ValueError):
+    """Raised when Claim Gate cannot produce a report."""
+
+
+def run_claim_gate_diff(
+    *,
+    repo_root: Path,
+    base: str,
+    head: str,
+    policy_path: Path,
+    out_path: Optional[Path] = None,
+    fail_on_review: bool = False,
+    paths: Optional[Sequence[str]] = None,
+) -> Tuple[Dict[str, object], int]:
+    """Run Claim Gate over a Git diff and optionally write the report."""
+    try:
+        repo_root = repo_root.resolve()
+        policy_path = policy_path.resolve()
+        policy = load_policy(policy_path)
+        diff = collect_diff(repo_root=repo_root, base=base, head=head, paths=paths)
+        transitions, non_claims = detect_collection(
+            diff.pairs,
+            allow_markers=policy.allow_markers,
+        )
+        requirements = [
+            requirement
+            for transition in transitions
+            for requirement in policy.rule_for(transition.transition_class).requires
+        ]
+        evidence_index = build_evidence_index(
+            repo_root=repo_root,
+            head=head,
+            requirements=requirements,
+            policy=policy,
+        )
+        evaluated = apply_policy(transitions, policy, evidence_index)
+        report = build_report(
+            base=base,
+            head=head,
+            policy_path=_report_path(policy_path, repo_root),
+            files_scanned=diff.files_scanned,
+            transitions=evaluated,
+            non_claims=non_claims,
+        )
+        if out_path is not None:
+            write_report(report, out_path)
+        return report, exit_code_for_verdict(
+            str(report["verdict"]),
+            fail_on_review=fail_on_review,
+        )
+    except (ClaimGatePolicyError, DiffSourceError, OSError) as exc:
+        raise ClaimGateError(str(exc)) from exc
+
+
+def _report_path(path: Path, repo_root: Path) -> str:
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return str(path.resolve())

--- a/src/assay/claim_gate/detectors.py
+++ b/src/assay/claim_gate/detectors.py
@@ -1,0 +1,295 @@
+"""Rule-based claim-boundary transition detectors."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+from assay.claim_gate.models import (
+    ClaimBoundaryTransition,
+    DiffPair,
+    NonClaim,
+    TextSpan,
+)
+
+DEFAULT_ALLOW_MARKERS = (
+    "draft",
+    "future work",
+    "future goal",
+    "goal:",
+    "hypothesis",
+    "roadmap",
+    "exploring",
+    "proposal",
+    "aspiration",
+)
+
+
+GENERIC_BOUNDARY_MARKERS = {"prototype", "experimental"}
+
+HARD_CLAIM_TERMS = (
+    "approved",
+    "guarantee",
+    "guarantees",
+    "guaranteed",
+    "must",
+    "policy",
+    "production-ready",
+    "production ready",
+    "proven",
+    "proves",
+    "safe",
+    "validated",
+    "verified",
+)
+
+
+@dataclass(frozen=True)
+class DetectorSpec:
+    transition_class: str
+    before_terms: Tuple[str, ...]
+    after_terms: Tuple[str, ...]
+    severity: str
+    confidence: float
+    rationale: str
+    suggested_rewrite: str
+
+
+DETECTOR_SPECS: Tuple[DetectorSpec, ...] = (
+    DetectorSpec(
+        "prototype_to_production",
+        ("prototype", "experimental", "draft", "demo"),
+        (
+            "production-ready",
+            "production ready",
+            "production-grade",
+            "production grade",
+        ),
+        "high",
+        0.93,
+        "The text moves from prototype or experimental language to production readiness.",
+        "Frame this as a prototype or production-oriented exploration until deployment evidence is present.",
+    ),
+    DetectorSpec(
+        "experimental_to_reliable",
+        ("experimental", "prototype", "early"),
+        ("reliable", "robust", "stable", "dependable"),
+        "medium",
+        0.82,
+        "The text moves from experimental posture to reliability language.",
+        "Keep reliability claims scoped to the evidence actually present.",
+    ),
+    DetectorSpec(
+        "possible_to_guaranteed",
+        ("possible", "may", "might", "could", "potentially"),
+        ("guarantee", "guarantees", "guaranteed", "ensures", "always"),
+        "high",
+        0.9,
+        "The text moves from possibility language to a guarantee.",
+        "Use possibility language unless direct evidence supports the guarantee.",
+    ),
+    DetectorSpec(
+        "may_might_could_to_does_will",
+        ("may", "might", "could"),
+        ("does", "will", "is now", "now provides"),
+        "medium",
+        0.76,
+        "The text upgrades a conditional claim into an asserted behavior.",
+        "Keep the behavior conditional or cite evidence for the stronger assertion.",
+    ),
+    DetectorSpec(
+        "local_to_general",
+        ("local", "locally", "single", "one configured", "one test"),
+        ("all", "every", "general", "generally", "always", "any environment", "across"),
+        "medium",
+        0.82,
+        "The text generalizes a local observation beyond its observed scope.",
+        "State the local scope unless broader reproducibility evidence is present.",
+    ),
+    DetectorSpec(
+        "demo_to_enterprise",
+        ("demo", "sample", "toy"),
+        ("enterprise", "organization-wide", "company-wide", "production"),
+        "medium",
+        0.8,
+        "The text upgrades a demo or sample into enterprise or production scope.",
+        "Keep the claim in demo scope until deployment evidence exists.",
+    ),
+    DetectorSpec(
+        "suggestion_to_recommendation",
+        ("suggestion", "suggested", "idea", "option"),
+        ("recommend", "recommends", "recommendation", "should"),
+        "medium",
+        0.78,
+        "The text upgrades an idea or suggestion into a recommendation.",
+        "Keep the suggestion advisory unless review evidence supports recommending it.",
+    ),
+    DetectorSpec(
+        "recommendation_to_policy",
+        ("recommend", "recommendation", "guidance", "should"),
+        ("policy", "must", "required", "approved"),
+        "high",
+        0.86,
+        "The text upgrades guidance into policy or approval language.",
+        "Keep policy language out unless a policy review or human acceptance is present.",
+    ),
+    DetectorSpec(
+        "partial_support_to_proven",
+        ("partial", "limited", "supports", "some evidence", "early evidence"),
+        ("proves", "proven", "validated", "verified", "confirms"),
+        "high",
+        0.86,
+        "The text upgrades partial support into proof or validation.",
+        "Use bounded support language unless proof evidence is present.",
+    ),
+    DetectorSpec(
+        "risk_reduced_to_safe",
+        ("risk reduced", "reduced risk", "reduces risk", "safer", "mitigates"),
+        ("safe", "safety guarantee", "hazard-free", "risk-free"),
+        "high",
+        0.9,
+        "The text upgrades risk reduction into safety.",
+        "Say risk was reduced or mitigated, not that the system is safe.",
+    ),
+    DetectorSpec(
+        "observed_to_causal",
+        ("observed", "correlated", "appeared", "associated"),
+        ("caused", "causes", "because", "led to"),
+        "medium",
+        0.78,
+        "The text upgrades observation or correlation into causality.",
+        "Keep the observation descriptive unless causal evidence is present.",
+    ),
+)
+
+
+def detect_transitions(
+    pair: DiffPair, *, allow_markers: Sequence[str] = DEFAULT_ALLOW_MARKERS
+) -> Tuple[List[ClaimBoundaryTransition], List[NonClaim]]:
+    """Detect claim-boundary transitions for one before/after pair."""
+    before = pair.before_span.text
+    after = pair.after_span.text
+    if not after.strip():
+        return [], []
+
+    transitions: List[ClaimBoundaryTransition] = []
+    non_claims: List[NonClaim] = []
+
+    for after_line in _line_spans(pair.after_span):
+        non_claim = _non_claim(after_line, allow_markers)
+        if non_claim is not None:
+            non_claims.append(non_claim)
+            continue
+        for spec in DETECTOR_SPECS:
+            if _has_any(before, spec.before_terms) and _has_any(
+                after_line.text, spec.after_terms
+            ):
+                transitions.append(
+                    ClaimBoundaryTransition(
+                        transition_class=spec.transition_class,
+                        file=pair.file,
+                        before_span=pair.before_span,
+                        after_span=after_line,
+                        severity=spec.severity,
+                        confidence=spec.confidence,
+                        rationale=spec.rationale,
+                        suggested_rewrite=spec.suggested_rewrite,
+                    )
+                )
+    return _dedupe_transitions(transitions), _dedupe_non_claims(non_claims)
+
+
+def detect_collection(
+    pairs: Iterable[DiffPair], *, allow_markers: Sequence[str] = DEFAULT_ALLOW_MARKERS
+) -> Tuple[List[ClaimBoundaryTransition], List[NonClaim]]:
+    """Run every detector over a collection of changed text pairs."""
+    transitions: List[ClaimBoundaryTransition] = []
+    non_claims: List[NonClaim] = []
+    for pair in pairs:
+        pair_transitions, pair_non_claims = detect_transitions(
+            pair, allow_markers=allow_markers
+        )
+        transitions.extend(pair_transitions)
+        non_claims.extend(pair_non_claims)
+    return transitions, _dedupe_non_claims(non_claims)
+
+
+def _non_claim(span: TextSpan, allow_markers: Sequence[str]) -> Optional[NonClaim]:
+    after = _normalize(span.text)
+    for marker in allow_markers:
+        normalized_marker = _normalize(marker)
+        if normalized_marker in after:
+            if normalized_marker in GENERIC_BOUNDARY_MARKERS and _has_any(
+                span.text, HARD_CLAIM_TERMS
+            ):
+                continue
+            return NonClaim(
+                file=span.file,
+                span=span,
+                reason=f"bounded_or_aspirational_marker:{marker}",
+            )
+    return None
+
+
+def _line_spans(span: TextSpan) -> List[TextSpan]:
+    lines = span.text.splitlines()
+    return [
+        TextSpan(
+            file=span.file,
+            start_line=span.start_line + index,
+            end_line=span.start_line + index,
+            text=line,
+        )
+        for index, line in enumerate(lines)
+        if line.strip()
+    ]
+
+
+def _has_any(text: str, terms: Sequence[str]) -> bool:
+    normalized = _normalize(text)
+    return any(_contains_term(normalized, _normalize(term)) for term in terms)
+
+
+def _contains_term(text: str, term: str) -> bool:
+    if " " in term or "-" in term:
+        return term in text
+    return re.search(rf"(?<![a-z0-9]){re.escape(term)}(?![a-z0-9])", text) is not None
+
+
+def _normalize(text: str) -> str:
+    return " ".join(text.lower().replace("_", " ").split())
+
+
+def _dedupe_transitions(
+    transitions: List[ClaimBoundaryTransition],
+) -> List[ClaimBoundaryTransition]:
+    seen = set()
+    out: List[ClaimBoundaryTransition] = []
+    for transition in transitions:
+        key = (
+            transition.file,
+            transition.before_span.start_line,
+            transition.after_span.start_line,
+            transition.transition_class,
+        )
+        if key not in seen:
+            seen.add(key)
+            out.append(transition)
+    return out
+
+
+def _dedupe_non_claims(non_claims: List[NonClaim]) -> List[NonClaim]:
+    seen = set()
+    out: List[NonClaim] = []
+    for non_claim in non_claims:
+        key = (
+            non_claim.file,
+            non_claim.span.start_line,
+            non_claim.span.end_line,
+            non_claim.reason,
+        )
+        if key not in seen:
+            seen.add(key)
+            out.append(non_claim)
+    return out

--- a/src/assay/claim_gate/diff_source.py
+++ b/src/assay/claim_gate/diff_source.py
@@ -1,0 +1,315 @@
+"""Diff source readers for Assay Claim Gate."""
+
+from __future__ import annotations
+
+import difflib
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+from assay.claim_gate.models import DiffCollection, DiffPair, TextSpan
+
+TEXT_EXTENSIONS = {
+    ".adoc",
+    ".cfg",
+    ".csv",
+    ".ini",
+    ".json",
+    ".md",
+    ".py",
+    ".rst",
+    ".toml",
+    ".txt",
+    ".yaml",
+    ".yml",
+}
+
+
+PROBABLE_RENAME_MIN_SIMILARITY = 0.35
+
+
+class DiffSourceError(ValueError):
+    """Raised when Claim Gate cannot read the requested diff."""
+
+
+@dataclass(frozen=True)
+class DiffPathChange:
+    """One file-level change between two refs."""
+
+    before_path: Optional[str]
+    after_path: Optional[str]
+
+
+def collect_diff(
+    *,
+    repo_root: Path,
+    base: str,
+    head: str,
+    paths: Optional[Sequence[str]] = None,
+) -> DiffCollection:
+    """Collect changed text spans between two Git refs."""
+    repo_root = repo_root.resolve()
+    changes = (
+        [DiffPathChange(before_path=path, after_path=path) for path in paths]
+        if paths is not None
+        else _pair_probable_renames(
+            repo_root,
+            base,
+            head,
+            git_diff_changes(repo_root, base, head),
+        )
+    )
+    pairs: List[DiffPair] = []
+    files_scanned = 0
+    changed_paths: List[str] = []
+
+    for change in changes:
+        report_path = change.after_path or change.before_path
+        if report_path is None or not is_text_path(report_path):
+            continue
+        if change.after_path is None:
+            continue
+        before = (
+            git_show_text(repo_root, base, change.before_path)
+            if change.before_path is not None
+            else None
+        )
+        after = git_show_text(repo_root, head, change.after_path)
+        if before is None and after is None:
+            continue
+        before_text = before or ""
+        after_text = after or ""
+        if before_text == after_text:
+            continue
+        files_scanned += 1
+        changed_paths.append(change.after_path)
+        pairs.extend(
+            diff_pairs_from_texts(
+                report_path,
+                before_text,
+                after_text,
+                before_file_path=change.before_path or report_path,
+                after_file_path=change.after_path,
+            )
+        )
+
+    return DiffCollection(
+        base=base,
+        head=head,
+        changed_paths=sorted(dict.fromkeys(changed_paths)),
+        pairs=pairs,
+        files_scanned=files_scanned,
+    )
+
+
+def diff_pairs_from_texts(
+    file_path: str,
+    before_text: str,
+    after_text: str,
+    *,
+    before_file_path: Optional[str] = None,
+    after_file_path: Optional[str] = None,
+) -> List[DiffPair]:
+    """Return before/after changed spans for two text blobs."""
+    before_file = before_file_path or file_path
+    after_file = after_file_path or file_path
+    before_lines = before_text.splitlines()
+    after_lines = after_text.splitlines()
+    matcher = difflib.SequenceMatcher(a=before_lines, b=after_lines, autojunk=False)
+    pairs: List[DiffPair] = []
+
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == "equal":
+            continue
+        before_span = _span(before_file, before_lines, i1, i2)
+        after_span = _span(after_file, after_lines, j1, j2)
+        pairs.append(
+            DiffPair(file=after_file, before_span=before_span, after_span=after_span)
+        )
+    return pairs
+
+
+def git_changed_paths(repo_root: Path, base: str, head: str) -> List[str]:
+    """Return changed paths between two refs using git diff --name-status."""
+    return sorted(
+        dict.fromkeys(
+            change.after_path
+            for change in git_diff_changes(repo_root, base, head)
+            if change.after_path is not None
+        )
+    )
+
+
+def git_diff_changes(repo_root: Path, base: str, head: str) -> List[DiffPathChange]:
+    """Return file-level changes between two refs using git diff --name-status."""
+    output = _run_git(repo_root, ["diff", "-M1%", "--name-status", base, head])
+    changes: List[DiffPathChange] = []
+    for raw_line in output.splitlines():
+        if not raw_line.strip():
+            continue
+        parts = raw_line.split("\t")
+        status = parts[0]
+        if len(parts) < 2:
+            raise DiffSourceError(
+                f"Unexpected git diff --name-status line: {raw_line!r}"
+            )
+        if status.startswith("D"):
+            changes.append(DiffPathChange(before_path=parts[1], after_path=None))
+            continue
+        if status.startswith("R") and len(parts) >= 3:
+            changes.append(DiffPathChange(before_path=parts[1], after_path=parts[2]))
+            continue
+        after_path = parts[1]
+        before_path = None if status.startswith("A") else after_path
+        changes.append(DiffPathChange(before_path=before_path, after_path=after_path))
+    return changes
+
+
+def _pair_probable_renames(
+    repo_root: Path,
+    base: str,
+    head: str,
+    changes: List[DiffPathChange],
+) -> List[DiffPathChange]:
+    deleted = [
+        change
+        for change in changes
+        if change.before_path is not None
+        and change.after_path is None
+        and is_text_path(change.before_path)
+    ]
+    added = [
+        change
+        for change in changes
+        if change.before_path is None
+        and change.after_path is not None
+        and is_text_path(change.after_path)
+    ]
+    if not deleted or not added:
+        return changes
+
+    deleted_text = {
+        change.before_path: git_show_text(repo_root, base, change.before_path) or ""
+        for change in deleted
+        if change.before_path is not None
+    }
+    added_text = {
+        change.after_path: git_show_text(repo_root, head, change.after_path) or ""
+        for change in added
+        if change.after_path is not None
+    }
+
+    candidates = []
+    for deleted_change in deleted:
+        for added_change in added:
+            if deleted_change.before_path is None or added_change.after_path is None:
+                continue
+            if (
+                Path(deleted_change.before_path).suffix.lower()
+                != Path(added_change.after_path).suffix.lower()
+            ):
+                continue
+            similarity = difflib.SequenceMatcher(
+                a=deleted_text[deleted_change.before_path],
+                b=added_text[added_change.after_path],
+                autojunk=False,
+            ).ratio()
+            if similarity >= PROBABLE_RENAME_MIN_SIMILARITY:
+                candidates.append((similarity, deleted_change, added_change))
+
+    if not candidates:
+        return changes
+
+    matched_deletes = set()
+    matched_adds = set()
+    paired_targets = {}
+    for _, deleted_change, added_change in sorted(
+        candidates,
+        key=lambda item: (
+            -item[0],
+            item[1].before_path or "",
+            item[2].after_path or "",
+        ),
+    ):
+        delete_path = deleted_change.before_path
+        add_path = added_change.after_path
+        if delete_path is None or add_path is None:
+            continue
+        if delete_path in matched_deletes or add_path in matched_adds:
+            continue
+        matched_deletes.add(delete_path)
+        matched_adds.add(add_path)
+        paired_targets[delete_path] = DiffPathChange(
+            before_path=delete_path,
+            after_path=add_path,
+        )
+
+    if not paired_targets:
+        return changes
+
+    paired: List[DiffPathChange] = []
+    consumed_deletes = set()
+    consumed_adds = set()
+    for change in changes:
+        if change.before_path in paired_targets and change.after_path is None:
+            pair = paired_targets[change.before_path]
+            if pair.before_path not in consumed_deletes:
+                paired.append(pair)
+                consumed_deletes.add(pair.before_path)
+                if pair.after_path is not None:
+                    consumed_adds.add(pair.after_path)
+            continue
+        if change.before_path is None and change.after_path in consumed_adds:
+            continue
+        paired.append(change)
+    return paired
+
+
+def git_show_text(repo_root: Path, ref: str, file_path: str) -> Optional[str]:
+    """Read file text at a Git ref. Missing files return None."""
+    proc = subprocess.run(
+        ["git", "show", f"{ref}:{file_path}"],
+        cwd=str(repo_root),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return None
+    try:
+        return proc.stdout.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+
+
+def is_text_path(file_path: str) -> bool:
+    """Return whether a path is in Claim Gate's text scan surface."""
+    return Path(file_path).suffix.lower() in TEXT_EXTENSIONS
+
+
+def _span(file_path: str, lines: List[str], start: int, end: int) -> TextSpan:
+    if start == end:
+        line = start + 1 if lines else 0
+        return TextSpan(file=file_path, start_line=line, end_line=line, text="")
+    return TextSpan(
+        file=file_path,
+        start_line=start + 1,
+        end_line=end,
+        text="\n".join(lines[start:end]),
+    )
+
+
+def _run_git(repo_root: Path, args: Sequence[str]) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=str(repo_root),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip()
+        raise DiffSourceError(f"git {' '.join(args)} failed: {stderr[:400]}")
+    return proc.stdout

--- a/src/assay/claim_gate/evidence.py
+++ b/src/assay/claim_gate/evidence.py
@@ -1,0 +1,75 @@
+"""Conservative evidence discovery for Assay Claim Gate."""
+
+from __future__ import annotations
+
+import fnmatch
+import subprocess
+from pathlib import Path
+from typing import Dict, Iterable, List, Set
+
+from assay.claim_gate.policy import ClaimGatePolicy
+
+
+def build_evidence_index(
+    *,
+    repo_root: Path,
+    head: str,
+    requirements: Iterable[str],
+    policy: ClaimGatePolicy,
+) -> Dict[str, List[str]]:
+    """Find configured evidence paths for each requirement.
+
+    Claim Gate only accepts evidence from paths explicitly configured in the
+    policy and present at the inspected head ref.
+    """
+    repo_root = repo_root.resolve()
+    repo_paths = _git_repo_paths(repo_root, head)
+    index: Dict[str, List[str]] = {}
+    for requirement in sorted(set(requirements)):
+        found: List[str] = []
+        for pattern in policy.evidence_paths.get(requirement, []):
+            found.extend(_resolve_pattern(pattern, repo_paths))
+        if found:
+            index[requirement] = sorted(dict.fromkeys(found))
+    return index
+
+
+def _resolve_pattern(pattern: str, repo_paths: Set[str]) -> List[str]:
+    normalized_pattern = _normalize_relative_path(pattern)
+    if _has_glob(pattern):
+        return sorted(
+            path for path in repo_paths if fnmatch.fnmatchcase(path, normalized_pattern)
+        )
+    if normalized_pattern in repo_paths:
+        return [normalized_pattern]
+    return []
+
+
+def _git_repo_paths(repo_root: Path, ref: str) -> Set[str]:
+    output = _run_git(repo_root, ["ls-tree", "-r", "--name-only", ref])
+    return {
+        _normalize_relative_path(line) for line in output.splitlines() if line.strip()
+    }
+
+
+def _has_glob(pattern: str) -> bool:
+    return any(ch in pattern for ch in "*?[")
+
+
+def _normalize_relative_path(path: str) -> str:
+    return Path(path.replace("\\", "/")).as_posix().lstrip("./")
+
+
+def _run_git(repo_root: Path, args: List[str]) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=str(repo_root),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip()
+        raise OSError(f"git {' '.join(args)} failed: {stderr[:400]}")
+    return proc.stdout

--- a/src/assay/claim_gate/models.py
+++ b/src/assay/claim_gate/models.py
@@ -1,0 +1,142 @@
+"""Data models for Assay Claim Gate."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+PASS = "PASS"
+NEEDS_REVIEW = "NEEDS_REVIEW"
+BLOCK = "BLOCK"
+VERDICTS = {PASS, NEEDS_REVIEW, BLOCK}
+
+
+@dataclass(frozen=True)
+class TextSpan:
+    """A file-local text span used in claim drift reports."""
+
+    file: str
+    start_line: int
+    end_line: int
+    text: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "start_line": self.start_line,
+            "end_line": self.end_line,
+            "text": self.text,
+        }
+
+
+@dataclass(frozen=True)
+class DiffPair:
+    """One before/after text pair from a repository diff."""
+
+    file: str
+    before_span: TextSpan
+    after_span: TextSpan
+
+
+@dataclass(frozen=True)
+class DiffCollection:
+    """Changed text spans plus metadata about the diff source."""
+
+    base: str
+    head: str
+    changed_paths: List[str]
+    pairs: List[DiffPair]
+    files_scanned: int
+
+
+@dataclass(frozen=True)
+class NonClaim:
+    """A changed text span that is explicitly bounded or aspirational."""
+
+    file: str
+    span: TextSpan
+    reason: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "file": self.file,
+            "span": self.span.to_dict(),
+            "text": self.span.text,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class ClaimBoundaryTransition:
+    """A detected claim-boundary transition."""
+
+    transition_class: str
+    file: str
+    before_span: TextSpan
+    after_span: TextSpan
+    risk_class: str = "unsupported_claim_escalation"
+    severity: str = "medium"
+    confidence: float = 0.75
+    rationale: str = ""
+    evidence_required: List[str] = field(default_factory=list)
+    evidence_found: List[str] = field(default_factory=list)
+    verdict: str = NEEDS_REVIEW
+    suggested_rewrite: str = ""
+    transition_id: str = ""
+
+    def with_policy(
+        self,
+        *,
+        evidence_required: List[str],
+        evidence_found: List[str],
+        verdict: str,
+        severity: str,
+    ) -> "ClaimBoundaryTransition":
+        return ClaimBoundaryTransition(
+            transition_id=self.transition_id,
+            transition_class=self.transition_class,
+            file=self.file,
+            before_span=self.before_span,
+            after_span=self.after_span,
+            risk_class=self.risk_class,
+            severity=severity,
+            confidence=self.confidence,
+            rationale=self.rationale,
+            evidence_required=evidence_required,
+            evidence_found=evidence_found,
+            verdict=verdict,
+            suggested_rewrite=self.suggested_rewrite,
+        )
+
+    def with_id(self, transition_id: str) -> "ClaimBoundaryTransition":
+        return ClaimBoundaryTransition(
+            transition_id=transition_id,
+            transition_class=self.transition_class,
+            file=self.file,
+            before_span=self.before_span,
+            after_span=self.after_span,
+            risk_class=self.risk_class,
+            severity=self.severity,
+            confidence=self.confidence,
+            rationale=self.rationale,
+            evidence_required=list(self.evidence_required),
+            evidence_found=list(self.evidence_found),
+            verdict=self.verdict,
+            suggested_rewrite=self.suggested_rewrite,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.transition_id,
+            "file": self.file,
+            "before_span": self.before_span.to_dict(),
+            "after_span": self.after_span.to_dict(),
+            "transition_class": self.transition_class,
+            "risk_class": self.risk_class,
+            "severity": self.severity,
+            "confidence": self.confidence,
+            "evidence_required": list(self.evidence_required),
+            "evidence_found": list(self.evidence_found),
+            "verdict": self.verdict,
+            "rationale": self.rationale,
+            "suggested_rewrite": self.suggested_rewrite,
+        }

--- a/src/assay/claim_gate/policy.py
+++ b/src/assay/claim_gate/policy.py
@@ -1,0 +1,204 @@
+"""Policy loading and evaluation for Assay Claim Gate."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Mapping
+
+from assay.claim_gate.detectors import DEFAULT_ALLOW_MARKERS
+from assay.claim_gate.models import (
+    BLOCK,
+    NEEDS_REVIEW,
+    PASS,
+    VERDICTS,
+    ClaimBoundaryTransition,
+)
+
+
+SCHEMA_VERSION = "assay.claim_policy.v0"
+
+
+class ClaimGatePolicyError(ValueError):
+    """Raised when a Claim Gate policy is malformed."""
+
+
+@dataclass(frozen=True)
+class PolicyRule:
+    transition_class: str
+    verdict: str
+    severity: str = "medium"
+    requires: List[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ClaimGatePolicy:
+    schema_version: str
+    default_verdict: str
+    blocked_transitions: Dict[str, PolicyRule]
+    review_transitions: Dict[str, PolicyRule]
+    allow_markers: List[str]
+    evidence_paths: Dict[str, List[str]]
+
+    def rule_for(self, transition_class: str) -> PolicyRule:
+        if transition_class in self.blocked_transitions:
+            return self.blocked_transitions[transition_class]
+        if transition_class in self.review_transitions:
+            return self.review_transitions[transition_class]
+        return PolicyRule(
+            transition_class=transition_class,
+            verdict=self.default_verdict,
+            severity="medium",
+            requires=[],
+        )
+
+
+def load_policy(path: Path) -> ClaimGatePolicy:
+    """Load an assay.claims.yml policy file."""
+    try:
+        import yaml
+    except ImportError as exc:
+        raise ClaimGatePolicyError("PyYAML is required to load Claim Gate policy") from exc
+
+    if not path.exists():
+        raise ClaimGatePolicyError(f"Policy file not found: {path}")
+    if not path.is_file():
+        raise ClaimGatePolicyError(f"Policy path is not a file: {path}")
+
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise ClaimGatePolicyError(f"Failed to parse policy file: {exc}") from exc
+    if not isinstance(raw, Mapping):
+        raise ClaimGatePolicyError("Policy file must be a YAML mapping")
+    return parse_policy(raw)
+
+
+def parse_policy(raw: Mapping[str, Any]) -> ClaimGatePolicy:
+    """Parse and validate a Claim Gate policy mapping."""
+    schema_version = str(raw.get("schema_version", ""))
+    if schema_version != SCHEMA_VERSION:
+        raise ClaimGatePolicyError(
+            f"Unsupported Claim Gate policy schema_version: {schema_version!r}"
+        )
+
+    default_verdict = str(raw.get("default_verdict", NEEDS_REVIEW))
+    _validate_verdict(default_verdict, "default_verdict")
+
+    blocked = _parse_rules(raw.get("blocked_transitions") or {}, BLOCK)
+    review = _parse_rules(raw.get("review_transitions") or {}, NEEDS_REVIEW)
+    allow_markers = _string_list(
+        raw.get("allow_markers") or list(DEFAULT_ALLOW_MARKERS),
+        "allow_markers",
+    )
+    evidence_paths = _parse_evidence_paths(raw.get("evidence_paths") or {})
+
+    return ClaimGatePolicy(
+        schema_version=schema_version,
+        default_verdict=default_verdict,
+        blocked_transitions=blocked,
+        review_transitions=review,
+        allow_markers=allow_markers,
+        evidence_paths=evidence_paths,
+    )
+
+
+def apply_policy(
+    transitions: List[ClaimBoundaryTransition],
+    policy: ClaimGatePolicy,
+    evidence_index: Mapping[str, List[str]],
+) -> List[ClaimBoundaryTransition]:
+    """Attach policy verdicts and evidence findings to detected transitions."""
+    evaluated: List[ClaimBoundaryTransition] = []
+    for transition in transitions:
+        rule = policy.rule_for(transition.transition_class)
+        evidence_required = list(rule.requires)
+        evidence_found = _evidence_found_for(evidence_required, evidence_index)
+        verdict = _verdict_for(rule, evidence_required, evidence_found)
+        evaluated.append(
+            transition.with_policy(
+                evidence_required=evidence_required,
+                evidence_found=evidence_found,
+                verdict=verdict,
+                severity=rule.severity or transition.severity,
+            )
+        )
+    return evaluated
+
+
+def _verdict_for(
+    rule: PolicyRule, evidence_required: List[str], evidence_found: List[str]
+) -> str:
+    if not evidence_required:
+        return rule.verdict
+    found_requirements = {
+        item.split(":", 1)[0] for item in evidence_found if ":" in item
+    }
+    missing = [req for req in evidence_required if req not in found_requirements]
+    if missing:
+        return rule.verdict
+    return PASS
+
+
+def _evidence_found_for(
+    evidence_required: List[str], evidence_index: Mapping[str, List[str]]
+) -> List[str]:
+    found: List[str] = []
+    for requirement in evidence_required:
+        for path in evidence_index.get(requirement, []):
+            found.append(f"{requirement}:{path}")
+    return sorted(dict.fromkeys(found))
+
+
+def _parse_rules(raw: Any, default_verdict: str) -> Dict[str, PolicyRule]:
+    if not isinstance(raw, Mapping):
+        raise ClaimGatePolicyError("transition rules must be a mapping")
+    parsed: Dict[str, PolicyRule] = {}
+    for transition_class, spec in raw.items():
+        if not isinstance(transition_class, str) or not transition_class:
+            raise ClaimGatePolicyError("transition class names must be non-empty strings")
+        if not isinstance(spec, Mapping):
+            raise ClaimGatePolicyError(f"{transition_class} must be a mapping")
+        verdict = str(spec.get("verdict", default_verdict))
+        _validate_verdict(verdict, f"{transition_class}.verdict")
+        severity = str(spec.get("severity", "medium"))
+        requires = _string_list(
+            spec.get("requires") or [],
+            f"{transition_class}.requires",
+        )
+        parsed[transition_class] = PolicyRule(
+            transition_class=transition_class,
+            verdict=verdict,
+            severity=severity,
+            requires=requires,
+        )
+    return parsed
+
+
+def _parse_evidence_paths(raw: Any) -> Dict[str, List[str]]:
+    if not isinstance(raw, Mapping):
+        raise ClaimGatePolicyError("evidence_paths must be a mapping")
+    parsed: Dict[str, List[str]] = {}
+    for requirement, patterns in raw.items():
+        if not isinstance(requirement, str) or not requirement:
+            raise ClaimGatePolicyError("evidence requirement names must be strings")
+        if isinstance(patterns, str):
+            parsed[requirement] = [patterns]
+        else:
+            parsed[requirement] = _string_list(
+                patterns,
+                f"evidence_paths.{requirement}",
+            )
+    return parsed
+
+
+def _validate_verdict(value: str, label: str) -> None:
+    if value not in VERDICTS:
+        raise ClaimGatePolicyError(
+            f"{label} must be one of {sorted(VERDICTS)}, got {value!r}"
+        )
+
+
+def _string_list(raw: Any, label: str) -> List[str]:
+    if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
+        raise ClaimGatePolicyError(f"{label} must be a list of strings")
+    return list(raw)

--- a/src/assay/claim_gate/report.py
+++ b/src/assay/claim_gate/report.py
@@ -1,0 +1,112 @@
+"""JSON report rendering for Assay Claim Gate."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from assay.claim_gate.models import (
+    BLOCK,
+    NEEDS_REVIEW,
+    PASS,
+    ClaimBoundaryTransition,
+    NonClaim,
+)
+
+
+SCHEMA_VERSION = "assay.claim_gate_report.v0"
+
+
+def build_report(
+    *,
+    base: str,
+    head: str,
+    policy_path: str,
+    files_scanned: int,
+    transitions: List[ClaimBoundaryTransition],
+    non_claims: List[NonClaim],
+) -> Dict[str, Any]:
+    """Build a deterministic Claim Gate report dict."""
+    ordered = _with_ids(_sort_transitions(transitions))
+    verdict = overall_verdict(ordered)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "command": "assay claim-gate diff",
+        "verdict": verdict,
+        "subject": {
+            "base": base,
+            "head": head,
+            "policy": policy_path,
+        },
+        "summary": {
+            "files_scanned": files_scanned,
+            "transitions_detected": len(ordered),
+            "blocking_transitions": sum(1 for item in ordered if item.verdict == BLOCK),
+            "needs_review": sum(1 for item in ordered if item.verdict == NEEDS_REVIEW),
+            "non_claims": len(non_claims),
+        },
+        "transitions": [item.to_dict() for item in ordered],
+        "non_claims": [
+            item.to_dict()
+            for item in sorted(
+                non_claims,
+                key=lambda n: (n.file, n.span.start_line, n.reason),
+            )
+        ],
+        "non_claims_global": [
+            "This report does not determine truth.",
+            "This report does not certify legal compliance.",
+            "This report does not approve production deployment.",
+            "This report only gates configured claim-boundary transitions.",
+        ],
+    }
+
+
+def write_report(report: Dict[str, Any], path: Path) -> None:
+    """Write a deterministic JSON report."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(report_json(report) + "\n", encoding="utf-8")
+
+
+def report_json(report: Dict[str, Any]) -> str:
+    """Return canonical-ish JSON for stable snapshots and PR artifacts."""
+    return json.dumps(report, indent=2, sort_keys=True)
+
+
+def overall_verdict(transitions: List[ClaimBoundaryTransition]) -> str:
+    if any(item.verdict == BLOCK for item in transitions):
+        return BLOCK
+    if any(item.verdict == NEEDS_REVIEW for item in transitions):
+        return NEEDS_REVIEW
+    return PASS
+
+
+def exit_code_for_verdict(verdict: str, *, fail_on_review: bool = False) -> int:
+    if verdict == BLOCK:
+        return 2
+    if verdict == NEEDS_REVIEW and fail_on_review:
+        return 1
+    return 0
+
+
+def _sort_transitions(
+    transitions: List[ClaimBoundaryTransition],
+) -> List[ClaimBoundaryTransition]:
+    return sorted(
+        transitions,
+        key=lambda item: (
+            item.file,
+            item.after_span.start_line,
+            item.transition_class,
+            item.after_span.text,
+        ),
+    )
+
+
+def _with_ids(
+    transitions: List[ClaimBoundaryTransition],
+) -> List[ClaimBoundaryTransition]:
+    return [
+        transition.with_id(f"cgt_{index:03d}")
+        for index, transition in enumerate(transitions, 1)
+    ]

--- a/src/assay/commands.py
+++ b/src/assay/commands.py
@@ -45,6 +45,7 @@ Commands:
   assay start ci      - Set up CI evidence gating
   assay start mcp     - Set up MCP tool call auditing
   assay compare       - Contract-based comparability evaluation (denial engine)
+  assay claim-gate diff - Detect unsupported claim-boundary drift in diffs
   assay compliance report - Map evidence pack to regulatory framework controls
   assay version       - Show version info
 """
@@ -8568,6 +8569,114 @@ def pr_gate_upsert_comment_cmd(
         },
         exit_code=0,
     )
+
+
+# ---------------------------------------------------------------------------
+# claim-gate subcommands
+# ---------------------------------------------------------------------------
+
+claim_gate_app = typer.Typer(
+    name="claim-gate",
+    help="Detect unsupported claim-boundary drift in repository diffs",
+    no_args_is_help=True,
+)
+assay_app.add_typer(
+    claim_gate_app, name="claim-gate", hidden=True, rich_help_panel="Advanced"
+)
+
+
+@claim_gate_app.command("diff")
+def claim_gate_diff_cmd(
+    repo: str = typer.Option(".", "--repo", help="Repository root to inspect"),
+    base: str = typer.Option("main", "--base", help="Base Git ref"),
+    head: str = typer.Option("HEAD", "--head", help="Head Git ref"),
+    policy: str = typer.Option(
+        "assay.claims.yml", "--policy", help="Claim Gate policy YAML"
+    ),
+    out: Optional[str] = typer.Option(
+        None, "--out", help="Write claim_gate_report.json to this path"
+    ),
+    fail_on_review: bool = typer.Option(
+        False,
+        "--fail-on-review",
+        help="Exit 1 for NEEDS_REVIEW instead of advisory exit 0",
+    ),
+    output_json: bool = typer.Option(False, "--json", help="Output as JSON"),
+) -> None:
+    """Detect unsupported claim-boundary drift in ordinary repo/doc diffs."""
+    from pathlib import Path as P
+
+    from assay.claim_gate.cli import ClaimGateError, run_claim_gate_diff
+
+    repo_root = P(repo).resolve()
+    policy_path = P(policy)
+    if not policy_path.is_absolute():
+        policy_path = repo_root / policy_path
+    out_path = P(out) if out else None
+    if out_path is not None and not out_path.is_absolute():
+        out_path = repo_root / out_path
+
+    try:
+        report, exit_code = run_claim_gate_diff(
+            repo_root=repo_root,
+            base=base,
+            head=head,
+            policy_path=policy_path,
+            out_path=out_path,
+            fail_on_review=fail_on_review,
+        )
+    except ClaimGateError as exc:
+        if output_json:
+            _output_json(
+                {
+                    "command": "assay claim-gate diff",
+                    "status": "error",
+                    "error": str(exc),
+                },
+                exit_code=3,
+            )
+        console.print(f"[red]Error:[/] {exc}")
+        raise typer.Exit(3)
+
+    if output_json:
+        _output_json(report, exit_code=exit_code)
+
+    verdict = report["verdict"]
+    color = (
+        "green"
+        if verdict == "PASS"
+        else ("yellow" if verdict == "NEEDS_REVIEW" else "red")
+    )
+    summary = report["summary"]
+    lines = [
+        f"[bold {color}]{verdict}[/]",
+        "",
+        f"Files scanned: {summary['files_scanned']}",
+        f"Transitions:   {summary['transitions_detected']}",
+        f"Blocking:      {summary['blocking_transitions']}",
+        f"Needs review:  {summary['needs_review']}",
+        f"Non-claims:    {summary['non_claims']}",
+    ]
+    if out_path is not None:
+        lines.append("")
+        lines.append(f"Report: {out_path}")
+    console.print()
+    console.print(Panel.fit("\n".join(lines), title="assay claim-gate diff"))
+
+    for transition in report["transitions"][:5]:
+        t_color = "red" if transition["verdict"] == "BLOCK" else "yellow"
+        console.print(
+            f"  [{t_color}]{transition['verdict']}[/{t_color}] "
+            f"{transition['file']}:{transition['after_span']['start_line']} "
+            f"{transition['transition_class']}"
+        )
+    if len(report["transitions"]) > 5:
+        console.print(
+            f"  [dim]... {len(report['transitions']) - 5} more transition(s)[/]"
+        )
+
+    console.print()
+    raise typer.Exit(exit_code)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/claim_gate/test_cli.py
+++ b/tests/claim_gate/test_cli.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from assay.commands import assay_app
+
+runner = CliRunner()
+
+
+def test_claim_gate_diff_cli_blocks_unsupported_claim_escalation(
+    tmp_path: Path,
+) -> None:
+    _run(["git", "init"], tmp_path)
+    _run(["git", "checkout", "-b", "main"], tmp_path)
+    _run(["git", "config", "user.email", "test@example.com"], tmp_path)
+    _run(["git", "config", "user.name", "Assay Test"], tmp_path)
+
+    (tmp_path / "README.md").write_text(
+        "# Demo Agent\n\n"
+        "This experimental prototype may help evaluate agent workflows.\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "assay.claims.yml").write_text(
+        "schema_version: assay.claim_policy.v0\n"
+        "default_verdict: NEEDS_REVIEW\n"
+        "blocked_transitions:\n"
+        "  prototype_to_production:\n"
+        "    severity: high\n"
+        "    requires:\n"
+        "      - production_deployment_receipt\n"
+        "  possible_to_guaranteed:\n"
+        "    severity: high\n"
+        "    requires:\n"
+        "      - direct_evidence\n",
+        encoding="utf-8",
+    )
+    _run(["git", "add", "README.md", "assay.claims.yml"], tmp_path)
+    _run(["git", "commit", "-m", "initial"], tmp_path)
+
+    (tmp_path / "README.md").write_text(
+        "# Demo Agent\n\n"
+        "This production-ready framework guarantees safe autonomous agent execution.\n",
+        encoding="utf-8",
+    )
+    _run(["git", "add", "README.md"], tmp_path)
+    _run(["git", "commit", "-m", "claim escalation"], tmp_path)
+
+    result = runner.invoke(
+        assay_app,
+        [
+            "claim-gate",
+            "diff",
+            "--repo",
+            str(tmp_path),
+            "--base",
+            "HEAD~1",
+            "--head",
+            "HEAD",
+            "--policy",
+            "assay.claims.yml",
+            "--out",
+            "claim_gate_report.json",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 2
+    payload = json.loads(result.output)
+    assert payload["verdict"] == "BLOCK"
+    assert payload["summary"]["blocking_transitions"] == 2
+    assert (tmp_path / "claim_gate_report.json").exists()
+
+
+def test_claim_gate_diff_cli_does_not_accept_spoofed_evidence_filename(
+    tmp_path: Path,
+) -> None:
+    _init_repo(tmp_path)
+
+    (tmp_path / "README.md").write_text(
+        "This may help evaluate agent workflows.\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "assay.claims.yml").write_text(
+        "schema_version: assay.claim_policy.v0\n"
+        "default_verdict: NEEDS_REVIEW\n"
+        "blocked_transitions:\n"
+        "  possible_to_guaranteed:\n"
+        "    severity: high\n"
+        "    requires:\n"
+        "      - direct_evidence\n"
+        "evidence_paths:\n"
+        "  direct_evidence:\n"
+        "    - evidence/direct_evidence.json\n",
+        encoding="utf-8",
+    )
+    _run(["git", "add", "README.md", "assay.claims.yml"], tmp_path)
+    _run(["git", "commit", "-m", "initial"], tmp_path)
+
+    (tmp_path / "README.md").write_text(
+        "This guarantees safe autonomous agent execution.\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "notes_direct_evidence_placeholder.txt").write_text(
+        "not configured evidence\n",
+        encoding="utf-8",
+    )
+    _run(
+        [
+            "git",
+            "add",
+            "README.md",
+            "notes_direct_evidence_placeholder.txt",
+        ],
+        tmp_path,
+    )
+    _run(["git", "commit", "-m", "spoofed evidence filename"], tmp_path)
+
+    result = runner.invoke(
+        assay_app,
+        [
+            "claim-gate",
+            "diff",
+            "--repo",
+            str(tmp_path),
+            "--base",
+            "HEAD~1",
+            "--head",
+            "HEAD",
+            "--policy",
+            "assay.claims.yml",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 2
+    payload = json.loads(result.output)
+    assert payload["verdict"] == "BLOCK"
+    assert payload["transitions"][0]["evidence_found"] == []
+
+
+def test_claim_gate_diff_cli_detects_rename_plus_edit_transition(
+    tmp_path: Path,
+) -> None:
+    _init_repo(tmp_path)
+
+    (tmp_path / "old.md").write_text(
+        "This prototype may help evaluate agent workflows.\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "assay.claims.yml").write_text(
+        "schema_version: assay.claim_policy.v0\n"
+        "default_verdict: NEEDS_REVIEW\n"
+        "blocked_transitions:\n"
+        "  prototype_to_production:\n"
+        "    severity: high\n"
+        "    requires:\n"
+        "      - production_deployment_receipt\n",
+        encoding="utf-8",
+    )
+    _run(["git", "add", "old.md", "assay.claims.yml"], tmp_path)
+    _run(["git", "commit", "-m", "initial"], tmp_path)
+
+    _run(["git", "mv", "old.md", "README.md"], tmp_path)
+    (tmp_path / "README.md").write_text(
+        "This production-ready framework may help evaluate agent workflows.\n",
+        encoding="utf-8",
+    )
+    _run(["git", "add", "README.md"], tmp_path)
+    _run(["git", "commit", "-m", "rename and escalate"], tmp_path)
+
+    result = runner.invoke(
+        assay_app,
+        [
+            "claim-gate",
+            "diff",
+            "--repo",
+            str(tmp_path),
+            "--base",
+            "HEAD~1",
+            "--head",
+            "HEAD",
+            "--policy",
+            "assay.claims.yml",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 2
+    payload = json.loads(result.output)
+    assert payload["verdict"] == "BLOCK"
+    assert {item["transition_class"] for item in payload["transitions"]} == {
+        "prototype_to_production",
+    }
+    assert payload["transitions"][0]["file"] == "README.md"
+    assert payload["transitions"][0]["before_span"]["text"] == (
+        "This prototype may help evaluate agent workflows."
+    )
+
+
+def test_claim_gate_diff_cli_uses_repo_relative_policy_path_in_json(
+    tmp_path: Path,
+) -> None:
+    _init_repo(tmp_path)
+
+    (tmp_path / "README.md").write_text(
+        "This may help evaluate agent workflows.\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "assay.claims.yml").write_text(
+        "schema_version: assay.claim_policy.v0\n"
+        "default_verdict: NEEDS_REVIEW\n"
+        "blocked_transitions:\n"
+        "  possible_to_guaranteed:\n"
+        "    severity: high\n"
+        "    requires:\n"
+        "      - direct_evidence\n",
+        encoding="utf-8",
+    )
+    _run(["git", "add", "README.md", "assay.claims.yml"], tmp_path)
+    _run(["git", "commit", "-m", "initial"], tmp_path)
+
+    (tmp_path / "README.md").write_text(
+        "This guarantees safe autonomous agent execution.\n",
+        encoding="utf-8",
+    )
+    _run(["git", "add", "README.md"], tmp_path)
+    _run(["git", "commit", "-m", "claim escalation"], tmp_path)
+
+    result = runner.invoke(
+        assay_app,
+        [
+            "claim-gate",
+            "diff",
+            "--repo",
+            str(tmp_path),
+            "--base",
+            "HEAD~1",
+            "--head",
+            "HEAD",
+            "--policy",
+            str(tmp_path / "assay.claims.yml"),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 2
+    payload = json.loads(result.output)
+    assert payload["subject"]["policy"] == "assay.claims.yml"
+
+
+def _init_repo(cwd: Path) -> None:
+    _run(["git", "init"], cwd)
+    _run(["git", "checkout", "-b", "main"], cwd)
+    _run(["git", "config", "user.email", "test@example.com"], cwd)
+    _run(["git", "config", "user.name", "Assay Test"], cwd)
+
+
+def _run(args: list[str], cwd: Path) -> None:
+    proc = subprocess.run(
+        args,
+        cwd=str(cwd),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr

--- a/tests/claim_gate/test_detectors.py
+++ b/tests/claim_gate/test_detectors.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from assay.claim_gate.detectors import detect_collection
+from assay.claim_gate.diff_source import diff_pairs_from_texts
+
+
+def test_detects_prototype_to_production_and_guarantee_transition() -> None:
+    pairs = diff_pairs_from_texts(
+        "README.md",
+        "This experimental prototype may help evaluate agent workflows.\n",
+        "This production-ready framework guarantees safe autonomous agent execution.\n",
+    )
+
+    transitions, non_claims = detect_collection(pairs)
+
+    assert non_claims == []
+    assert {item.transition_class for item in transitions} == {
+        "prototype_to_production",
+        "possible_to_guaranteed",
+    }
+    first = transitions[0]
+    assert first.file == "README.md"
+    assert first.before_span.start_line == 1
+    assert first.after_span.text == (
+        "This production-ready framework guarantees safe autonomous agent execution."
+    )
+
+
+def test_future_goal_language_is_recorded_as_non_claim() -> None:
+    pairs = diff_pairs_from_texts(
+        "ROADMAP.md",
+        "",
+        "Future goal: production-grade execution safety.\n",
+    )
+
+    transitions, non_claims = detect_collection(pairs)
+
+    assert transitions == []
+    assert len(non_claims) == 1
+    assert non_claims[0].reason == "bounded_or_aspirational_marker:future goal"
+    assert non_claims[0].span.start_line == 1
+
+
+def test_generic_allow_marker_does_not_hide_hard_escalation() -> None:
+    pairs = diff_pairs_from_texts(
+        "README.md",
+        "This prototype may help evaluate agent workflows.\n",
+        "This experimental prototype guarantees safe autonomous execution.\n",
+    )
+
+    transitions, non_claims = detect_collection(
+        pairs,
+        allow_markers=("prototype", "experimental"),
+    )
+
+    assert non_claims == []
+    assert {item.transition_class for item in transitions} == {
+        "possible_to_guaranteed",
+    }
+
+
+def test_mixed_hunk_records_non_claim_without_hiding_transition() -> None:
+    pairs = diff_pairs_from_texts(
+        "README.md",
+        "This may help evaluate agent workflows.\n",
+        "Future work: improve docs.\nThis guarantees safe autonomous execution.\n",
+    )
+
+    transitions, non_claims = detect_collection(pairs)
+
+    assert {item.transition_class for item in transitions} == {
+        "possible_to_guaranteed",
+    }
+    assert len(non_claims) == 1
+    assert non_claims[0].reason == "bounded_or_aspirational_marker:future work"
+    assert non_claims[0].span.start_line == 1
+    assert transitions[0].after_span.start_line == 2

--- a/tests/claim_gate/test_policy.py
+++ b/tests/claim_gate/test_policy.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from assay.claim_gate.models import ClaimBoundaryTransition, TextSpan
+from assay.claim_gate.policy import apply_policy, parse_policy
+
+
+def _transition(transition_class: str) -> ClaimBoundaryTransition:
+    span_before = TextSpan(
+        file="README.md",
+        start_line=1,
+        end_line=1,
+        text="This experimental prototype may help.",
+    )
+    span_after = TextSpan(
+        file="README.md",
+        start_line=1,
+        end_line=1,
+        text="This production-ready framework guarantees outcomes.",
+    )
+    return ClaimBoundaryTransition(
+        transition_class=transition_class,
+        file="README.md",
+        before_span=span_before,
+        after_span=span_after,
+    )
+
+
+def test_blocked_transition_blocks_when_required_evidence_missing() -> None:
+    policy = parse_policy(
+        {
+            "schema_version": "assay.claim_policy.v0",
+            "default_verdict": "NEEDS_REVIEW",
+            "blocked_transitions": {
+                "prototype_to_production": {
+                    "severity": "high",
+                    "requires": ["production_deployment_receipt"],
+                }
+            },
+        }
+    )
+
+    [evaluated] = apply_policy([_transition("prototype_to_production")], policy, {})
+
+    assert evaluated.verdict == "BLOCK"
+    assert evaluated.severity == "high"
+    assert evaluated.evidence_required == ["production_deployment_receipt"]
+    assert evaluated.evidence_found == []
+
+
+def test_blocked_transition_passes_when_required_evidence_is_found() -> None:
+    policy = parse_policy(
+        {
+            "schema_version": "assay.claim_policy.v0",
+            "default_verdict": "NEEDS_REVIEW",
+            "blocked_transitions": {
+                "prototype_to_production": {
+                    "severity": "high",
+                    "requires": ["production_deployment_receipt"],
+                }
+            },
+        }
+    )
+
+    [evaluated] = apply_policy(
+        [_transition("prototype_to_production")],
+        policy,
+        {
+            "production_deployment_receipt": [
+                "receipts/production_deployment_receipt.json"
+            ]
+        },
+    )
+
+    assert evaluated.verdict == "PASS"
+    assert evaluated.evidence_found == [
+        "production_deployment_receipt:receipts/production_deployment_receipt.json"
+    ]
+
+
+def test_review_transition_defaults_to_needs_review_when_evidence_missing() -> None:
+    policy = parse_policy(
+        {
+            "schema_version": "assay.claim_policy.v0",
+            "default_verdict": "NEEDS_REVIEW",
+            "review_transitions": {
+                "local_to_general": {
+                    "severity": "medium",
+                    "requires": ["scope_evidence"],
+                }
+            },
+        }
+    )
+
+    [evaluated] = apply_policy([_transition("local_to_general")], policy, {})
+
+    assert evaluated.verdict == "NEEDS_REVIEW"
+    assert evaluated.evidence_required == ["scope_evidence"]

--- a/tests/claim_gate/test_report.py
+++ b/tests/claim_gate/test_report.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from assay.claim_gate.models import BLOCK, NEEDS_REVIEW, ClaimBoundaryTransition, TextSpan
+from assay.claim_gate.report import build_report, exit_code_for_verdict, report_json
+
+
+def _transition(verdict: str) -> ClaimBoundaryTransition:
+    before = TextSpan("README.md", 3, 3, "This experimental prototype may help.")
+    after = TextSpan("README.md", 3, 3, "This production-ready framework guarantees safety.")
+    return ClaimBoundaryTransition(
+        transition_class="prototype_to_production",
+        file="README.md",
+        before_span=before,
+        after_span=after,
+        severity="high",
+        evidence_required=["production_deployment_receipt"],
+        verdict=verdict,
+    )
+
+
+def test_report_assigns_ids_and_blocks_on_blocking_transition() -> None:
+    report = build_report(
+        base="main",
+        head="HEAD",
+        policy_path="assay.claims.yml",
+        files_scanned=1,
+        transitions=[_transition(BLOCK)],
+        non_claims=[],
+    )
+
+    assert report["verdict"] == "BLOCK"
+    assert report["summary"]["blocking_transitions"] == 1
+    assert report["transitions"][0]["id"] == "cgt_001"
+    assert "does not determine truth" in report_json(report)
+
+
+def test_exit_codes_keep_needs_review_advisory_by_default() -> None:
+    assert exit_code_for_verdict("PASS") == 0
+    assert exit_code_for_verdict(NEEDS_REVIEW) == 0
+    assert exit_code_for_verdict(NEEDS_REVIEW, fail_on_review=True) == 1
+    assert exit_code_for_verdict(BLOCK) == 2


### PR DESCRIPTION
Ports the Claim Gate v0.1 subsystem onto current `main` from the decomposed quarantine branch (orig commit `ebe0fdc`).

## Scope
- Adds `src/assay/claim_gate/` (cli, detectors, diff_source, evidence, models, policy, report) + `tests/claim_gate/`.
- New CLI: `assay claim-gate diff` — detects unsupported claim-boundary drift in repo/doc diffs.
- Docs: `docs/claim-gate-v0.md` + `docs/examples/claim-gate-v0/`.
- **Claim Gate only.** The Immunity cluster from the same quarantine branch is deliberately excluded (separate product-claim decision); the immunity help line was dropped during the lone `commands.py` conflict resolution.

## Validation
- `tests/claim_gate/`: 13 passed.
- Full suite: 3556 passed, 24 skipped, 1 xfailed.
- The single full-suite failure (`tests/assay/test_baseline.py::TestBaselineGetCmd::test_get_after_set`) is **pre-existing on `main`** and unrelated to this port: it asserts an unbroken substring against Rich-wrapped CLI output and fails only at narrow terminal width (long tmp path wraps mid-word); passes at COLUMNS>=200 and in CI. Tracked separately.

## Notes
- 18 files, +2091, no secret paths.
- This is an evaluation surface for the Claim Gate lane, not a commitment to ship.