### PR TITLE
docs: Agent Operating Policy v0 public surface

### DIFF
--- a/docs/public_surfaces/agent-operating-policy-v0/AGENTS.md
+++ b/docs/public_surfaces/agent-operating-policy-v0/AGENTS.md
@@ -1,0 +1,63 @@
+# Agent Operating Policy
+
+This file is the human-readable operating guide for coding agents working in this example repository.
+
+## Allowed Scope
+
+Agents may edit:
+
+- `src/**`
+- `tests/**`
+- `docs/**`
+
+Agents may create proof packs and review artifacts under:
+
+- `.assay/pr-gate/**`
+
+## Forbidden Scope
+
+Agents must not edit:
+
+- `.env`
+- `secrets/**`
+- `billing/**`
+- `deploy/**`
+- `.github/workflows/**`
+
+Agents must not create, stage, or publish private keys, credentials, tokens, or generated secret material.
+
+## Required Evidence
+
+Every agent-authored PR should leave reviewable evidence for:
+
+- changed paths
+- required check results
+- task receipt
+- diff receipt
+- test receipt
+- claim receipt
+- proof-pack verification result
+
+## Claim Boundaries
+
+Agents may claim only what the captured evidence supports.
+
+Allowed claims include:
+
+- a named check was observed with a specific conclusion for a specific commit
+- the captured diff did not touch forbidden paths
+- required receipts were present in the captured evidence
+- the proof pack or review packet verified under the stated verifier inputs
+
+Agents must not claim:
+
+- all possible tests passed
+- the code is secure
+- production approval was granted
+- hidden runtime behavior was reviewed
+- the agent fully followed this file
+
+## Human Approval
+
+Policy review is not a merge decision. Human approval remains required wherever repository rules require it.
+

--- a/docs/public_surfaces/agent-operating-policy-v0/README.md
+++ b/docs/public_surfaces/agent-operating-policy-v0/README.md
@@ -1,0 +1,61 @@
+# Agent Operating Policy v0
+
+Assay checks observed PR evidence against an explicit agent operating policy and emits a signed, reviewable verdict about whether the captured evidence satisfies that policy.
+
+This packet is a public-surface draft. It shows the intended shape of an Agent Operating Policy without adding a new engine, CLI command, or workflow.
+
+## Stack
+
+```text
+AGENTS.md                  = human-readable operating guide
+assay.agent_policy.json    = machine-checkable policy
+Assay PR Gate              = evaluator + signer + proof pack
+Proof Card / PR comment    = public review surface
+```
+
+`AGENTS.md` tells coding agents and reviewers what the repository expects. `assay.agent_policy.json` projects the enforceable parts into a small policy file. Assay PR Gate evaluates captured PR evidence against that policy, packages the evidence into a proof pack, signs the review verdict, and displays the result in a review surface.
+
+The review question is narrow:
+
+```text
+Did the captured PR evidence satisfy the declared agent operating policy?
+```
+
+## What AGENTS.md Alone Does Not Provide
+
+AGENTS.md gives coding agents instructions. It does not prove which files changed, which checks ran, which claims were made, whether evidence supported those claims, or whether a review verdict was signed. Assay adds the review layer over captured PR evidence.
+
+## Evidence Boundary
+
+Agent Operating Policy v0 is about observed PR evidence:
+
+- diff paths and hashes
+- check names and conclusions
+- required receipts and proof-pack material
+- stated PR claims and claim-support results
+- policy hashes and signed verdict status
+
+It does not evaluate hidden agent intent, unobserved runtime activity, production approval, or the underlying correctness of code beyond the captured evidence.
+
+## Files
+
+- `AGENTS.md` is the human-readable policy.
+- `assay.agent_policy.json` is the minimal machine-checkable projection.
+- `assay.agent_policy.schema.json` describes the draft policy shape.
+- `examples/` contains illustrative verdict fixtures for one pass and three rejection modes.
+- `VERIFY_OUTPUT.txt` shows example draft verifier output.
+
+## Related Assay Surfaces
+
+This draft follows the PR Gate boundary described in `docs/product/assay-pr-gate-dogfood-v0.md` and the bounded-evaluation and caveat discipline of `docs/product/assay-pr-gate-policy-v0.md`: captured evidence, bounded policy evaluation, signed review material, caveats, and human review.
+
+## Example Verdicts
+
+The fixtures use two top-level verdicts:
+
+- `POLICY_SATISFIED` means the captured evidence satisfied the declared policy.
+- `REJECTED` means the captured evidence failed at least one declared policy rule.
+
+These are a draft-local vocabulary for the agent-policy layer. They map onto the PR Gate recommendation vocabulary — `POLICY_SATISFIED` aligns with PR Gate `PASS` (`proceed`), `REJECTED` aligns with PR Gate `BLOCK` — and are not a second source of truth for the PR Gate recommendation.
+
+These verdicts are not merge decisions. They are review evidence for a human reviewer or a higher-level gate.

--- a/docs/public_surfaces/agent-operating-policy-v0/VERIFY_OUTPUT.txt
+++ b/docs/public_surfaces/agent-operating-policy-v0/VERIFY_OUTPUT.txt
@@ -1,0 +1,41 @@
+Example draft output. No live command produces this transcript yet.
+
+$ assay agent-policy verify --policy assay.agent_policy.json --evidence examples/passing_agent_pr.json
+AGENT POLICY: POLICY_SATISFIED
+Policy: agent-operating-policy-v0-example
+AGENTS.md hash: sha256:418d0366bc29d824b7a6747eebff04a475a1bad33c127320a8fcf6ea4f0aa55e
+Machine policy hash: sha256:f636952f799bd230470de8f96afaaa584f8408066b5fa4822cdd6a5c76845e08
+Evidence pack hash: sha256:1111111111111111111111111111111111111111111111111111111111111111
+Signature status: SIGNED_EXAMPLE
+
+Result:
+Captured evidence satisfied the declared agent operating policy.
+
+Caveats:
+- Example draft output only.
+- Verdict is about captured PR evidence.
+- Verdict is not a merge decision.
+- Verdict is not production approval.
+
+$ assay agent-policy verify --policy assay.agent_policy.json --evidence examples/unsupported_claim_rejected.json
+AGENT POLICY: REJECTED
+Policy: agent-operating-policy-v0-example
+AGENTS.md hash: sha256:418d0366bc29d824b7a6747eebff04a475a1bad33c127320a8fcf6ea4f0aa55e
+Machine policy hash: sha256:f636952f799bd230470de8f96afaaa584f8408066b5fa4822cdd6a5c76845e08
+Evidence pack hash: sha256:4444444444444444444444444444444444444444444444444444444444444444
+Signature status: SIGNED_EXAMPLE
+
+Result:
+Captured evidence failed the declared agent operating policy.
+
+Reason:
+- unsupported_claim: "All possible tests passed and the code is secure."
+
+Supported rewrite:
+- "The tests check concluded success for commit bcd2468."
+
+Caveats:
+- Example draft output only.
+- Verdict is about captured PR evidence.
+- Verdict does not evaluate hidden runtime behavior.
+- Verdict is not a merge decision.

--- a/docs/public_surfaces/agent-operating-policy-v0/assay.agent_policy.json
+++ b/docs/public_surfaces/agent-operating-policy-v0/assay.agent_policy.json
@@ -1,0 +1,89 @@
+{
+  "schema_version": "agent_operating_policy.v0.draft",
+  "policy_id": "agent-operating-policy-v0-example",
+  "status": "draft_example",
+  "scope": {
+    "evaluates": [
+      "captured PR diff paths",
+      "observed check conclusions",
+      "required receipt presence",
+      "proof-pack or review-packet verification status",
+      "declared claims compared with captured evidence"
+    ],
+    "does_not_evaluate": [
+      "hidden agent intent",
+      "unobserved runtime activity",
+      "production approval",
+      "underlying code correctness beyond captured evidence"
+    ]
+  },
+  "bindings": {
+    "hash_method": "sha256:file-bytes",
+    "agents_doc_sha256": "sha256:418d0366bc29d824b7a6747eebff04a475a1bad33c127320a8fcf6ea4f0aa55e",
+    "machine_policy_schema_sha256": "sha256:1d60f827d7d33cccc80a4e65628eccb685fb637c01d3d71210f6a47b57f63b08"
+  },
+  "allowed_paths": [
+    "src/**",
+    "tests/**",
+    "docs/**",
+    ".assay/pr-gate/**"
+  ],
+  "forbidden_paths": [
+    ".env",
+    "secrets/**",
+    "billing/**",
+    "deploy/**",
+    ".github/workflows/**"
+  ],
+  "required_receipts": [
+    "task_receipt",
+    "diff_receipt",
+    "test_receipt",
+    "claim_receipt",
+    "proof_pack_verification_result"
+  ],
+  "required_checks": [
+    "tests"
+  ],
+  "claim_boundaries": {
+    "supported_claims": [
+      "observed check name and conclusion for a specific commit",
+      "captured diff path classification",
+      "required receipt presence in captured evidence",
+      "proof-pack or review-packet verification under stated verifier inputs"
+    ],
+    "unsupported_claims": [
+      "all possible tests passed",
+      "the code is secure",
+      "production approval was granted",
+      "hidden runtime behavior was reviewed",
+      "the agent fully followed AGENTS.md"
+    ]
+  },
+  "rejection_rules": [
+    {
+      "id": "forbidden_path_touched",
+      "verdict": "REJECTED",
+      "reason": "Captured diff touched a forbidden path.",
+      "evidence_field": "diff.changed_paths"
+    },
+    {
+      "id": "required_receipt_missing",
+      "verdict": "REJECTED",
+      "reason": "Captured evidence did not include a required receipt.",
+      "evidence_field": "receipts.present"
+    },
+    {
+      "id": "unsupported_claim",
+      "verdict": "REJECTED",
+      "reason": "A stated claim was stronger than the captured evidence supports.",
+      "evidence_field": "claims.support"
+    }
+  ],
+  "non_claims": [
+    "This policy does not decide whether a PR should be merged.",
+    "This policy does not approve production deployment.",
+    "This policy does not prove hidden agent behavior.",
+    "This policy does not prove general code safety."
+  ]
+}

--- a/docs/public_surfaces/agent-operating-policy-v0/assay.agent_policy.schema.json
+++ b/docs/public_surfaces/agent-operating-policy-v0/assay.agent_policy.schema.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://assay.dev/schemas/agent-operating-policy-v0-draft.json",
+  "title": "Assay Agent Operating Policy v0 Draft",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "policy_id",
+    "status",
+    "scope",
+    "bindings",
+    "allowed_paths",
+    "forbidden_paths",
+    "required_receipts",
+    "required_checks",
+    "claim_boundaries",
+    "rejection_rules",
+    "non_claims"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "agent_operating_policy.v0.draft"
+    },
+    "policy_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "status": {
+      "enum": ["draft_example"]
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["evaluates", "does_not_evaluate"],
+      "properties": {
+        "evaluates": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1
+        },
+        "does_not_evaluate": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1
+        }
+      }
+    },
+    "bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "hash_method",
+        "agents_doc_sha256",
+        "machine_policy_schema_sha256"
+      ],
+      "properties": {
+        "hash_method": {
+          "const": "sha256:file-bytes"
+        },
+        "agents_doc_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "machine_policy_schema_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "allowed_paths": {
+      "$ref": "#/$defs/non_empty_string_array"
+    },
+    "forbidden_paths": {
+      "$ref": "#/$defs/non_empty_string_array"
+    },
+    "required_receipts": {
+      "$ref": "#/$defs/non_empty_string_array"
+    },
+    "required_checks": {
+      "$ref": "#/$defs/non_empty_string_array"
+    },
+    "claim_boundaries": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["supported_claims", "unsupported_claims"],
+      "properties": {
+        "supported_claims": {
+          "$ref": "#/$defs/non_empty_string_array"
+        },
+        "unsupported_claims": {
+          "$ref": "#/$defs/non_empty_string_array"
+        }
+      }
+    },
+    "rejection_rules": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "verdict", "reason", "evidence_field"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "verdict": {
+            "const": "REJECTED"
+          },
+          "reason": {
+            "type": "string",
+            "minLength": 1
+          },
+          "evidence_field": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "non_claims": {
+      "$ref": "#/$defs/non_empty_string_array"
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "non_empty_string_array": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}
+

--- a/docs/public_surfaces/agent-operating-policy-v0/examples/forbidden_path_rejected.json
+++ b/docs/public_surfaces/agent-operating-policy-v0/examples/forbidden_path_rejected.json
@@ -1,0 +1,55 @@
+{
+  "fixture_id": "forbidden_path_rejected",
+  "fixture_status": "illustrative_draft",
+  "hash_bindings": {
+    "hash_method": "sha256:file-bytes",
+    "agents_doc_sha256": "sha256:418d0366bc29d824b7a6747eebff04a475a1bad33c127320a8fcf6ea4f0aa55e",
+    "machine_policy_sha256": "sha256:f636952f799bd230470de8f96afaaa584f8408066b5fa4822cdd6a5c76845e08",
+    "evidence_pack_sha256": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+    "evidence_pack_hash_status": "illustrative_placeholder"
+  },
+  "captured_evidence": {
+    "changed_paths": [
+      "src/example.py",
+      ".github/workflows/deploy.yml"
+    ],
+    "forbidden_paths_touched": [
+      {
+        "path": ".github/workflows/deploy.yml",
+        "matched_pattern": ".github/workflows/**"
+      }
+    ],
+    "required_checks": [
+      {
+        "name": "tests",
+        "conclusion": "success",
+        "commit": "def5678"
+      }
+    ],
+    "required_receipts_present": [
+      "task_receipt",
+      "diff_receipt",
+      "test_receipt",
+      "claim_receipt",
+      "proof_pack_verification_result"
+    ],
+    "claims": []
+  },
+  "policy_verdict": "REJECTED",
+  "verdict_signature_status": "SIGNED_EXAMPLE",
+  "reasons": [
+    {
+      "rule": "forbidden_path_touched",
+      "path": ".github/workflows/deploy.yml",
+      "matched_pattern": ".github/workflows/**"
+    }
+  ],
+  "caveats": [
+    "This fixture is illustrative and not produced by a live verifier.",
+    "The verdict is based on captured diff paths."
+  ],
+  "non_claims": [
+    "Does not decide whether a human may approve a separate workflow change.",
+    "Does not evaluate hidden agent intent."
+  ]
+}

--- a/docs/public_surfaces/agent-operating-policy-v0/examples/missing_receipt_rejected.json
+++ b/docs/public_surfaces/agent-operating-policy-v0/examples/missing_receipt_rejected.json
@@ -1,0 +1,54 @@
+{
+  "fixture_id": "missing_receipt_rejected",
+  "fixture_status": "illustrative_draft",
+  "hash_bindings": {
+    "hash_method": "sha256:file-bytes",
+    "agents_doc_sha256": "sha256:418d0366bc29d824b7a6747eebff04a475a1bad33c127320a8fcf6ea4f0aa55e",
+    "machine_policy_sha256": "sha256:f636952f799bd230470de8f96afaaa584f8408066b5fa4822cdd6a5c76845e08",
+    "evidence_pack_sha256": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+    "evidence_pack_hash_status": "illustrative_placeholder"
+  },
+  "captured_evidence": {
+    "changed_paths": [
+      "src/example.py",
+      "tests/test_example.py"
+    ],
+    "forbidden_paths_touched": [],
+    "required_checks": [
+      {
+        "name": "tests",
+        "conclusion": "success",
+        "commit": "fed9876"
+      }
+    ],
+    "required_receipts_present": [
+      "task_receipt",
+      "diff_receipt",
+      "claim_receipt"
+    ],
+    "required_receipts_missing": [
+      "test_receipt",
+      "proof_pack_verification_result"
+    ],
+    "claims": []
+  },
+  "policy_verdict": "REJECTED",
+  "verdict_signature_status": "SIGNED_EXAMPLE",
+  "reasons": [
+    {
+      "rule": "required_receipt_missing",
+      "missing": [
+        "test_receipt",
+        "proof_pack_verification_result"
+      ]
+    }
+  ],
+  "caveats": [
+    "This fixture is illustrative and not produced by a live verifier.",
+    "An observed check conclusion is not a substitute for the required receipt evidence."
+  ],
+  "non_claims": [
+    "Does not infer missing evidence from a successful check.",
+    "Does not decide merge approval."
+  ]
+}

--- a/docs/public_surfaces/agent-operating-policy-v0/examples/passing_agent_pr.json
+++ b/docs/public_surfaces/agent-operating-policy-v0/examples/passing_agent_pr.json
@@ -1,0 +1,51 @@
+{
+  "fixture_id": "passing_agent_pr",
+  "fixture_status": "illustrative_draft",
+  "hash_bindings": {
+    "hash_method": "sha256:file-bytes",
+    "agents_doc_sha256": "sha256:418d0366bc29d824b7a6747eebff04a475a1bad33c127320a8fcf6ea4f0aa55e",
+    "machine_policy_sha256": "sha256:f636952f799bd230470de8f96afaaa584f8408066b5fa4822cdd6a5c76845e08",
+    "evidence_pack_sha256": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+    "evidence_pack_hash_status": "illustrative_placeholder"
+  },
+  "captured_evidence": {
+    "changed_paths": [
+      "src/example.py",
+      "tests/test_example.py",
+      "docs/example.md"
+    ],
+    "forbidden_paths_touched": [],
+    "required_checks": [
+      {
+        "name": "tests",
+        "conclusion": "success",
+        "commit": "abc1234"
+      }
+    ],
+    "required_receipts_present": [
+      "task_receipt",
+      "diff_receipt",
+      "test_receipt",
+      "claim_receipt",
+      "proof_pack_verification_result"
+    ],
+    "claims": [
+      {
+        "text": "The tests check concluded success for commit abc1234.",
+        "support": "SUPPORTED_BY_CAPTURED_EVIDENCE"
+      }
+    ]
+  },
+  "policy_verdict": "POLICY_SATISFIED",
+  "verdict_signature_status": "SIGNED_EXAMPLE",
+  "reasons": [],
+  "caveats": [
+    "This fixture is illustrative and not produced by a live verifier.",
+    "The verdict is about captured PR evidence, not production approval."
+  ],
+  "non_claims": [
+    "Does not decide merge approval.",
+    "Does not review hidden runtime activity.",
+    "Does not prove general code correctness."
+  ]
+}

--- a/docs/public_surfaces/agent-operating-policy-v0/examples/unsupported_claim_rejected.json
+++ b/docs/public_surfaces/agent-operating-policy-v0/examples/unsupported_claim_rejected.json
@@ -1,0 +1,56 @@
+{
+  "fixture_id": "unsupported_claim_rejected",
+  "fixture_status": "illustrative_draft",
+  "hash_bindings": {
+    "hash_method": "sha256:file-bytes",
+    "agents_doc_sha256": "sha256:418d0366bc29d824b7a6747eebff04a475a1bad33c127320a8fcf6ea4f0aa55e",
+    "machine_policy_sha256": "sha256:f636952f799bd230470de8f96afaaa584f8408066b5fa4822cdd6a5c76845e08",
+    "evidence_pack_sha256": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+    "evidence_pack_hash_status": "illustrative_placeholder"
+  },
+  "captured_evidence": {
+    "changed_paths": [
+      "src/example.py",
+      "tests/test_example.py"
+    ],
+    "forbidden_paths_touched": [],
+    "required_checks": [
+      {
+        "name": "tests",
+        "conclusion": "success",
+        "commit": "bcd2468"
+      }
+    ],
+    "required_receipts_present": [
+      "task_receipt",
+      "diff_receipt",
+      "test_receipt",
+      "claim_receipt",
+      "proof_pack_verification_result"
+    ],
+    "claims": [
+      {
+        "text": "All possible tests passed and the code is secure.",
+        "support": "UNSUPPORTED_BY_CAPTURED_EVIDENCE",
+        "supported_rewrite": "The tests check concluded success for commit bcd2468."
+      }
+    ]
+  },
+  "policy_verdict": "REJECTED",
+  "verdict_signature_status": "SIGNED_EXAMPLE",
+  "reasons": [
+    {
+      "rule": "unsupported_claim",
+      "claim": "All possible tests passed and the code is secure.",
+      "supported_rewrite": "The tests check concluded success for commit bcd2468."
+    }
+  ],
+  "caveats": [
+    "This fixture is illustrative and not produced by a live verifier.",
+    "The rejection is about claim support, not about hidden runtime behavior."
+  ],
+  "non_claims": [
+    "Does not evaluate whether the code is secure.",
+    "Does not prove all possible tests were run."
+  ]
+}


### PR DESCRIPTION
Docs-only public-surface draft for **Agent Operating Policy v0** — the wedge that turns AGENTS.md from agent *instruction* into accountable *review*.

## Thesis
`AGENTS.md` (human-readable authority) + `assay.agent_policy.json` (machine-checkable policy) + Assay PR Gate (evaluator/signer/proof pack) + Proof Card/PR comment (review surface).

Narrow claim: **Assay checks observed PR evidence against an explicit agent operating policy and emits a signed, reviewable verdict about whether the captured evidence satisfies that policy.** It does not claim agent obedience, runtime surveillance, or merge/production approval.

## Contents
- `README.md`, sample `AGENTS.md`, `assay.agent_policy.json` + `assay.agent_policy.schema.json`
- 4 illustrative verdict fixtures: 1 pass + 3 rejection modes (forbidden path / missing receipt / unsupported claim)
- `VERIFY_OUTPUT.txt` (explicitly labeled draft/example output)

## Boundaries
- **Docs-only**: no engine, CLI command, or workflow added (`assay agent-policy` does not exist yet — VERIFY_OUTPUT says so).
- Hash-bindings (`agents_doc_sha256`, `machine_policy_sha256`) are real and self-consistent; `evidence_pack_sha256` is a labeled placeholder.
- Verdict nouns (`POLICY_SATISFIED`/`REJECTED`) mapped to PR Gate `PASS`/`BLOCK` to avoid a shadow vocabulary.
- Aligns with `docs/product/assay-pr-gate-dogfood-v0.md` and `assay-pr-gate-policy-v0.md`.

Also serves as a low-risk dogfood of the signed PR Gate path.