### PR TITLE
docs: add unaudited delegation public surface

### DIFF
--- a/docs/product/assay-pr-gate-dogfood-v0.md
+++ b/docs/product/assay-pr-gate-dogfood-v0.md
@@ -9,6 +9,12 @@ signed review packet and posts a single marked PR comment. The comment is the
 review surface. The product object is the signed review decision bound to the
 evidence pack, policy, verdict channels, caveats, and PR commit.
 
+Related public surfaces include
+`docs/public_surfaces/agent-operating-policy-v0/` for the agent-policy packet
+and `docs/public_surfaces/unaudited-delegation-v0/` for the broader
+delegation-governance frame. Those surfaces are docs-only read models; this
+document describes the live PR Gate dogfood loop.
+
 ## Workflow
 
 The workflow is `.github/workflows/assay-pr-gate.yml`.

--- a/docs/public_surfaces/agent-operating-policy-v0/README.md
+++ b/docs/public_surfaces/agent-operating-policy-v0/README.md
@@ -50,6 +50,8 @@ It does not evaluate hidden agent intent, unobserved runtime activity, productio
 
 This draft follows the PR Gate boundary described in `docs/product/assay-pr-gate-dogfood-v0.md` and the bounded-evaluation and caveat discipline of `docs/product/assay-pr-gate-policy-v0.md`: captured evidence, bounded policy evaluation, signed review material, caveats, and human review.
 
+`docs/public_surfaces/unaudited-delegation-v0/` is the adjacent public surface for the broader delegation-governance frame: claim firewalls, review boundaries, and proof-card examples for AI-generated changes. It is a docs-only read model and does not add engine behavior.
+
 ## Example Verdicts
 
 The fixtures use two top-level verdicts:

--- a/docs/public_surfaces/unaudited-delegation-v0/CLAIM_FIREWALL.md
+++ b/docs/public_surfaces/unaudited-delegation-v0/CLAIM_FIREWALL.md
@@ -1,0 +1,59 @@
+# Claim Firewall
+
+A claim firewall prevents delegated work from escalating beyond the evidence captured for it.
+
+It is not a static analyzer, a code-quality oracle, or a merge bot. It is a policy-bound claim/evidence gate.
+
+## Primitive
+
+```text
+claim -> scope -> evidence -> policy -> verdict -> receipt
+```
+
+Each delegated change must make a claim small enough to review:
+
+- what changed
+- why it changed
+- where it was allowed to change
+- where it was not allowed to change
+- which evidence supports the claim
+- which evidence is missing
+- what a reviewer must not infer
+
+The firewall blocks claim escalation. It does not block useful work merely because it came from an AI agent.
+
+## Claim Escalation
+
+Claim escalation happens when a change says or implies more than its evidence supports.
+
+Examples:
+
+| Declared or implied claim | Required control |
+|---|---|
+| "Refactor only" | behavioral-equivalence evidence or clear `NEEDS_SPLIT` |
+| "Makes auth secure" | security-specific evidence, ownership review, and narrow threat boundary |
+| "All tests pass" | observed check evidence for the named checks and commit |
+| "Safe to merge" | blocked wording in this surface; merge remains a human/process decision |
+| "Agent followed policy" | captured policy evidence only; hidden intent is not evaluated |
+
+## Review Verdicts
+
+The firewall should prefer boring verdicts with reasons:
+
+- `PASS`: no policy reason found to stop normal review for evaluated channels
+- `PASS_WITH_CAVEATS`: review can proceed, but unevaluated channels or non-claims remain
+- `NEEDS_SPLIT`: change is too broad for the declared claim or review boundary
+- `INSUFFICIENT_EVIDENCE`: claim may be valid, but required evidence is absent
+- `FAIL`: captured evidence contradicts the claim or violates policy
+
+These verdicts are review evidence. They are not merge approvals.
+
+## Invariant
+
+The invariant across this surface:
+
+```text
+verified change evidence, not verified understanding
+```
+
+Assay does not prove that a model understood the codebase. It makes delegated change claims visible enough for bounded review.

--- a/docs/public_surfaces/unaudited-delegation-v0/COLD_READ.md
+++ b/docs/public_surfaces/unaudited-delegation-v0/COLD_READ.md
@@ -1,0 +1,39 @@
+# Cold Read
+
+Use this checklist with a reader who has not helped write the packet.
+
+The packet passes the cold read only if the reader understands that it is about:
+
+```text
+verified change evidence, not verified understanding
+```
+
+## Reader Questions
+
+1. Does this packet claim that Assay proves an AI agent understood the codebase?
+2. Does a `PASS_WITH_CAVEATS` verdict mean the PR is ready for merge?
+3. Why is `NEEDS_SPLIT` a valuable verdict?
+4. What evidence would a refactor-only claim need before review can proceed?
+5. What should a reviewer refuse to infer from these examples?
+6. Did an Assay tool emit these proof-card examples, or did a human write them?
+
+## Expected Answers
+
+1. No. It says Assay checks bounded claims and captured evidence under policy.
+2. No. It means review can proceed with named caveats; merge remains outside the verdict.
+3. It protects reviewer attention when a delegated change is too broad to approve honestly.
+4. At minimum, scoped diff evidence, tests or replay evidence tied to the changed behavior, and a policy reason to believe public behavior did not change.
+5. The reviewer should not infer correctness, security, production approval, general agent obedience, or model understanding.
+6. A human wrote them as illustrative read models. The current engine does not emit this full verdict vocabulary.
+
+## Failure Modes
+
+The packet fails the cold read if the reader concludes:
+
+- Assay establishes correctness
+- Assay proves code security
+- Assay proves model understanding
+- PR Gate verdicts are merge approvals
+- bigger AI diffs are acceptable as long as tests exist
+- the proof-card examples are generated verifier output
+- `NEEDS_SPLIT` is a failure rather than a review-protection outcome

--- a/docs/public_surfaces/unaudited-delegation-v0/COMPLEXITY_CEILING.md
+++ b/docs/public_surfaces/unaudited-delegation-v0/COMPLEXITY_CEILING.md
@@ -1,0 +1,66 @@
+# Complexity Ceiling
+
+Complexity is not the ceiling on AI coding. Complexity is the ceiling on unaudited delegation.
+
+That distinction matters. It avoids two errors:
+
+- treating AI coding as permanently capped by today's tools
+- claiming that Assay solves software complexity
+
+Assay's narrower position is that a model alone cannot safely absorb arbitrary system complexity. A governed change system can raise the delegation boundary by making each change smaller, claimed, evidenced, checked, and reviewable.
+
+## The Bottleneck
+
+Writing code is only one cost in software work. The harder cost is understanding a system well enough to change it without breaking adjacent behavior.
+
+AI can reduce the cost of generating code while increasing the amount of code and review surface that teams must understand. That turns reviewability into a control problem:
+
+```text
+messy codebase
+-> repo map
+-> explicit invariants
+-> bounded agent task
+-> patch
+-> receipt
+-> verifier report
+-> proof card
+-> human review
+```
+
+The model may still write the patch. It does not get to silently smuggle design decisions, scope expansion, or unsupported claims into the repository.
+
+## Assay's Boundary
+
+Assay does not prove understanding. Assay checks whether a delegated change makes bounded claims supported by captured evidence under an explicit policy.
+
+The review surface should answer:
+
+- What claim did the delegated change make?
+- What files and modules were allowed?
+- What files and modules were forbidden?
+- Which invariants were supposed to hold?
+- Which evidence was captured?
+- Which policy made the verdict?
+- Which caveats and non-claims remain?
+
+The useful output is not only `PASS`. The high-value output is often:
+
+```text
+NEEDS_SPLIT
+```
+
+`NEEDS_SPLIT` means the change may contain useful work, but it crosses too many review boundaries to approve honestly as one unit.
+
+## Design Implication
+
+The system should reward small, legible delegation:
+
+- one declared claim
+- one bounded scope
+- clear forbidden scope
+- explicit invariants
+- evidence paths
+- deterministic review signals
+- a proof card with caveats
+
+The public wedge is AI-generated pull requests. The reusable category is delegation governance.

--- a/docs/public_surfaces/unaudited-delegation-v0/COMPLEXITY_SIGNALS.md
+++ b/docs/public_surfaces/unaudited-delegation-v0/COMPLEXITY_SIGNALS.md
@@ -1,0 +1,47 @@
+# Complexity Signals
+
+Complexity signals are reviewability signals, not truth metrics.
+
+They help decide whether a delegated change is small enough, evidenced enough, and bounded enough for honest review.
+
+## Signals
+
+| Signal | What it asks | Example use |
+|---|---|---|
+| `files_touched` | How much review surface exists? | large count can raise `review_load` |
+| `modules_crossed` | How many ownership or design areas changed? | auth plus billing plus config may trigger `NEEDS_SPLIT` |
+| `public_api_changed` | Did external contracts move? | requires API evidence or owner review |
+| `test_delta_present` | Did tests change with behavior? | missing tests can become `INSUFFICIENT_EVIDENCE` |
+| `behavioral_equivalence_evidence` | Is a refactor-only claim supported? | absent evidence can block a "no behavior change" claim |
+| `diff_size` | How much changed text must be reviewed? | large diffs can raise review load even in one module |
+| `claim_scope_match` | Does the diff match the declared claim? | "cleanup" touching runtime policy may fail |
+| `dependency_boundary_crossing` | Did the change alter dependency direction or coupling? | broad dependency changes often need splitting |
+| `reviewer_cognitive_load_estimate` | Can one reviewer honestly approve this unit? | bucketed as `low`, `medium`, `high`, or `too_high` |
+
+## Review Load Buckets
+
+Use buckets instead of fake precision:
+
+```text
+low        small local change with direct evidence
+medium     bounded change with clear owner and tests
+high       broad change requiring careful cross-module review
+too_high   cannot be reviewed honestly as one PR
+```
+
+`reviewer_cognitive_load_estimate` is a policy signal. It is not a measurement of reviewer competence.
+
+## NEEDS_SPLIT Triggers
+
+A policy may return `NEEDS_SPLIT` when:
+
+- one PR crosses unrelated product boundaries
+- a refactor claim includes runtime behavior changes
+- a diff modifies public API and internals together
+- tests are updated in a way that masks behavior changes
+- generated code changes too many files for one accountable review
+- ownership boundaries are crossed without owner evidence
+
+## Caveats
+
+These signals do not prove correctness or design quality. They make review burden visible so a human does not have to infer it from a large, plausible diff.

--- a/docs/public_surfaces/unaudited-delegation-v0/PR_GATE_POLICY.md
+++ b/docs/public_surfaces/unaudited-delegation-v0/PR_GATE_POLICY.md
@@ -1,0 +1,90 @@
+# PR Gate Policy Layer
+
+This document sketches a delegation-review layer that can sit above captured PR Gate evidence.
+
+It is docs-only. It does not change the existing Assay PR Gate engine, command-line interface, workflow, or decision enum.
+
+## Inputs
+
+A Complexity Ceiling PR Gate policy needs:
+
+- PR diff
+- declared claim
+- allowed scope
+- forbidden scope
+- invariant list
+- test or replay evidence
+- dependency boundary map
+- code owner or review boundary hints
+
+## Outputs
+
+Draft-local verdict vocabulary:
+
+```text
+PASS
+PASS_WITH_CAVEATS
+NEEDS_SPLIT
+INSUFFICIENT_EVIDENCE
+FAIL
+```
+
+`PASS` means no policy reason was found to stop normal review for the evaluated channels. It does not mean automatic merge.
+
+`PASS_WITH_CAVEATS` means the captured evidence supports a bounded review path, but named caveats or unevaluated channels remain.
+
+`NEEDS_SPLIT` means the change should be divided before review because its scope, risk boundaries, or claim/evidence mismatch make one approval too expensive or ambiguous.
+
+`INSUFFICIENT_EVIDENCE` means the declared claim may be narrow enough, but required receipts, checks, replay, or owner evidence are missing.
+
+`FAIL` means captured evidence contradicts the declared claim or violates policy.
+
+## Policy Questions
+
+The policy should ask:
+
+- Is the claim narrow enough to review?
+- Does the diff stay inside allowed scope?
+- Did it touch forbidden or risk-sensitive scope?
+- Did it cross ownership, dependency, or public API boundaries?
+- Are the named invariants represented by evidence?
+- Does the evidence support the claim as written?
+- Would an honest reviewer need the PR split before approval?
+
+## Example Rule Shape
+
+```json
+{
+  "rule_id": "claim_scope_mismatch",
+  "if": {
+    "declared_claim_type": "refactor_only",
+    "runtime_behavior_changed": true
+  },
+  "then": {
+    "verdict": "NEEDS_SPLIT",
+    "reason": "claim says refactor-only but captured evidence shows runtime behavior changed"
+  }
+}
+```
+
+## Relation To Existing PR Gate
+
+Existing Assay PR Gate already binds captured PR evidence to a signed review packet. This surface is a policy-story layer over delegated change review. It should preserve the existing PR Gate discipline:
+
+- captured evidence first
+- policy identity and hash
+- explicit channels
+- caveats
+- `do_not_infer` boundaries
+- human review remains outside the verdict
+
+## Do Not Infer
+
+A delegation-review verdict does not show that:
+
+- code is correct
+- code is secure
+- the agent understood the system
+- all tests passed unless named check evidence says so
+- production approval was granted
+- the PR should be merged automatically

--- a/docs/public_surfaces/unaudited-delegation-v0/README.md
+++ b/docs/public_surfaces/unaudited-delegation-v0/README.md
@@ -1,0 +1,70 @@
+# Unaudited Delegation v0
+
+Why AI-generated change needs claim firewalls, receipts, and review boundaries.
+
+AI made code cheap. Assay protects the scarce resource: trusted review.
+
+This packet is a docs-only public surface. It explains how Assay frames the AI coding complexity ceiling as a delegation-governance problem, not as a claim that AI coding has a permanent cap.
+
+Core boundary:
+
+```text
+verified change evidence, not verified understanding
+```
+
+Assay does not prove that an agent understood a codebase. Assay checks whether a delegated change made bounded claims supported by captured evidence under an explicit policy.
+
+## Why This Exists
+
+AI coding tools can produce plausible diffs faster than human reviewers can safely absorb them. The hard question is no longer only "can the model write code?" It is:
+
+```text
+Can a reviewer tell what was delegated, what changed, what evidence exists,
+and what must not be inferred?
+```
+
+Unaudited Delegation v0 gives that question a small review surface.
+
+## Delegation Ladder
+
+```text
+Level 0: AI writes code.
+Level 1: AI writes code with tests.
+Level 2: AI writes code with declared claims and scope.
+Level 3: AI writes code with receipts and policy-bound evidence.
+Level 4: AI-generated change becomes reviewable, replayable, and governable.
+```
+
+Assay lives at levels 2-4. AI pull requests are the first painful surface where this primitive is easy to see, but the underlying shape is more general:
+
+```text
+claim -> scope -> evidence -> policy -> verdict -> receipt
+```
+
+## Packet Files
+
+- `COMPLEXITY_CEILING.md` explains why complexity is the ceiling on unaudited delegation.
+- `CLAIM_FIREWALL.md` defines the claim-control primitive.
+- `PR_GATE_POLICY.md` sketches a draft delegation-review policy layer for AI-generated changes.
+- `COMPLEXITY_SIGNALS.md` lists reviewability signals and their limits.
+- `examples/` contains illustrative proof-card examples.
+- `COLD_READ.md` is a skeptical-reader check for the packet's boundaries.
+
+## Related Assay Surfaces
+
+- `docs/public_surfaces/agent-operating-policy-v0/` shows the adjacent agent-policy packet: human-readable policy, machine-readable projection, examples, and a PR Gate dogfood record.
+- `docs/product/assay-pr-gate-dogfood-v0.md` describes the signed PR Gate loop this packet relies on as captured evidence, not as a merge decision.
+
+## Non-Claims
+
+This packet does not claim that Assay:
+
+- proves software correctness
+- proves code security
+- proves a model or agent understood a repository
+- replaces human review
+- grants production approval
+- turns PR Gate verdicts into merge decisions
+- evaluates all architectural risk
+
+It claims only a narrower thing: delegated changes should be made legible as bounded claims with captured evidence, explicit policy, caveats, and reviewable verdicts.

--- a/docs/public_surfaces/unaudited-delegation-v0/examples/broad_refactor.needs-split.proof-card.json
+++ b/docs/public_surfaces/unaudited-delegation-v0/examples/broad_refactor.needs-split.proof-card.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": "assay.delegation_proof_card.v0",
+  "example_status": "illustrative_synthetic_fixture",
+  "surface": "unaudited-delegation-v0",
+  "principle": "verified change evidence, not verified understanding",
+  "subject": {
+    "kind": "pull_request",
+    "repo": "example/service",
+    "pr_number": 418,
+    "branch": "agent/refactor-core-services",
+    "base_branch": "main"
+  },
+  "declared_claim": {
+    "text": "Refactor core services without behavior changes.",
+    "claim_type": "refactor_only"
+  },
+  "scope": {
+    "allowed": [
+      "services/catalog/**"
+    ],
+    "forbidden": [
+      "services/auth/**",
+      "services/billing/**",
+      ".github/workflows/**"
+    ]
+  },
+  "evidence": {
+    "diff_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "observed_checks": [
+      {
+        "name": "unit tests",
+        "conclusion": "success"
+      }
+    ],
+    "missing_evidence": [
+      "behavioral equivalence replay",
+      "dependency boundary map",
+      "auth owner review",
+      "billing owner review"
+    ]
+  },
+  "signals": {
+    "files_touched": 47,
+    "modules_crossed": 4,
+    "public_api_changed": true,
+    "test_delta_present": true,
+    "behavioral_equivalence_evidence": "missing",
+    "claim_scope_match": "mismatch",
+    "dependency_boundary_crossing": true,
+    "reviewer_cognitive_load_estimate": "too_high"
+  },
+  "policy_verdict": {
+    "policy_id": "assay.unaudited_delegation.v0",
+    "verdict": "NEEDS_SPLIT",
+    "reasons": [
+      "declared claim says refactor-only but public API changed",
+      "diff touched forbidden auth and billing boundaries",
+      "review load is too high for one accountable approval",
+      "behavioral-equivalence evidence is missing"
+    ],
+    "required_next_steps": [
+      "split auth, billing, catalog, and workflow changes into separate PRs",
+      "attach behavioral-equivalence evidence for each refactor-only claim",
+      "request owner review for each crossed boundary"
+    ]
+  },
+  "non_claims": [
+    "does not say the patch is useless",
+    "does not prove the model lacked understanding",
+    "does not prove the code is incorrect",
+    "does not replace reviewer judgment"
+  ],
+  "do_not_infer": [
+    "unit tests are enough for a broad refactor claim",
+    "a plausible AI diff is reviewable as one PR",
+    "NEEDS_SPLIT is a code-quality failure"
+  ]
+}

--- a/docs/public_surfaces/unaudited-delegation-v0/examples/overclaimed_ai_pr.rejected.proof-card.json
+++ b/docs/public_surfaces/unaudited-delegation-v0/examples/overclaimed_ai_pr.rejected.proof-card.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": "assay.delegation_proof_card.v0",
+  "example_status": "illustrative_synthetic_fixture",
+  "surface": "unaudited-delegation-v0",
+  "principle": "verified change evidence, not verified understanding",
+  "subject": {
+    "kind": "pull_request",
+    "repo": "example/webapp",
+    "pr_number": 77,
+    "branch": "agent/secure-login",
+    "base_branch": "main"
+  },
+  "declared_claim": {
+    "text": "This AI PR makes login secure and production-ready.",
+    "claim_type": "security_and_production_readiness"
+  },
+  "scope": {
+    "allowed": [
+      "web/login/**"
+    ],
+    "forbidden": [
+      "security/policies/**",
+      "infra/**",
+      ".github/workflows/**"
+    ]
+  },
+  "evidence": {
+    "diff_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "observed_checks": [
+      {
+        "name": "generated unit tests",
+        "conclusion": "success"
+      }
+    ],
+    "missing_evidence": [
+      "threat model",
+      "security review",
+      "dependency audit",
+      "production approval",
+      "replay or integration evidence"
+    ]
+  },
+  "signals": {
+    "files_touched": 12,
+    "modules_crossed": 2,
+    "public_api_changed": false,
+    "test_delta_present": true,
+    "behavioral_equivalence_evidence": "missing",
+    "claim_scope_match": "unsupported_claim",
+    "dependency_boundary_crossing": true,
+    "reviewer_cognitive_load_estimate": "high"
+  },
+  "policy_verdict": {
+    "policy_id": "assay.unaudited_delegation.v0",
+    "verdict": "FAIL",
+    "reasons": [
+      "security and production-readiness claims exceed captured evidence",
+      "generated unit tests do not support the declared security claim",
+      "production approval is outside the review evidence"
+    ],
+    "blocked_claims": [
+      "makes login secure",
+      "production-ready"
+    ],
+    "allowed_rewording": [
+      "updates login code and generated unit tests under the captured diff",
+      "requires security review before any security or production-readiness claim"
+    ]
+  },
+  "non_claims": [
+    "does not prove the patch is insecure",
+    "does not prove the agent understood or failed to understand the login system",
+    "does not evaluate runtime exploitability",
+    "does not grant production approval"
+  ],
+  "do_not_infer": [
+    "passing generated tests establish security",
+    "security claims can be made without security evidence",
+    "AI generation alone establishes production readiness"
+  ]
+}

--- a/docs/public_surfaces/unaudited-delegation-v0/examples/safe_local_patch.pass-with-caveats.proof-card.json
+++ b/docs/public_surfaces/unaudited-delegation-v0/examples/safe_local_patch.pass-with-caveats.proof-card.json
@@ -1,0 +1,86 @@
+{
+  "schema_version": "assay.delegation_proof_card.v0",
+  "example_status": "illustrative_from_existing_dogfood_record",
+  "surface": "unaudited-delegation-v0",
+  "principle": "verified change evidence, not verified understanding",
+  "subject": {
+    "kind": "pull_request",
+    "repo": "Haserjian/assay",
+    "pr_number": 152,
+    "branch": "docs/agent-operating-policy-v0",
+    "base_branch": "main",
+    "head_commit": "0d7c367dee2e7885e715bc0cc2c08e243265f3c3"
+  },
+  "declared_claim": {
+    "text": "Add a docs-only Agent Operating Policy public surface.",
+    "claim_type": "docs_only_public_surface"
+  },
+  "scope": {
+    "allowed": [
+      "docs/public_surfaces/agent-operating-policy-v0/**"
+    ],
+    "forbidden": [
+      "src/**",
+      ".github/workflows/**",
+      "tests/**"
+    ]
+  },
+  "evidence": {
+    "diff_hash": "sha256:127d663b92469c5eeaa8233f854cedec87f1c624aca6b5006b046e5010dd82b7",
+    "pr_gate_verdict": "PASS",
+    "recommended_action": "proceed",
+    "channels": {
+      "integrity": "PASS",
+      "claim": "NOT_EVALUATED",
+      "replay": "NOT_RUN",
+      "trust_policy": "PASS"
+    },
+    "dogfood_record": "docs/public_surfaces/agent-operating-policy-v0/DOGFOOD.md"
+  },
+  "signals": {
+    "status": "illustrative_not_computed_from_pr_gate_artifact",
+    "captured_by_dogfood_record": [
+      "diff_hash",
+      "pr_gate_verdict",
+      "recommended_action",
+      "verdict_channels",
+      "dogfood_record_path"
+    ],
+    "not_computed_from_dogfood_record": [
+      "files_touched",
+      "modules_crossed",
+      "public_api_changed",
+      "test_delta_present",
+      "behavioral_equivalence_evidence",
+      "claim_scope_match",
+      "dependency_boundary_crossing",
+      "reviewer_cognitive_load_estimate"
+    ]
+  },
+  "policy_verdict": {
+    "policy_id": "assay.unaudited_delegation.v0",
+    "verdict": "PASS_WITH_CAVEATS",
+    "reasons": [
+      "captured PR Gate evidence verified integrity and trust policy for a docs-only packet",
+      "changed scope was bounded to a public-surface docs directory"
+    ],
+    "caveats": [
+      "claim channel was NOT_EVALUATED",
+      "replay was NOT_RUN",
+      "this example is a public-surface read model, not a generated verifier output"
+    ]
+  },
+  "non_claims": [
+    "does not prove the agent understood the repository",
+    "does not prove code correctness",
+    "does not prove code security",
+    "does not grant merge approval",
+    "does not evaluate hidden agent intent"
+  ],
+  "do_not_infer": [
+    "all possible tests passed",
+    "the docs are complete",
+    "the agent followed every instruction outside captured evidence",
+    "the PR was risk-free"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a docs-only public surface for Unaudited Delegation v0: claim firewalls, complexity ceiling framing, reviewability signals, cold-read checks, and illustrative proof-card examples.

Also adds minimal cross-links to the Agent Operating Policy v0 packet and PR Gate dogfood docs so the live PR Gate loop remains distinct from docs-only read models.

## Boundaries

- Docs only.
- No engine, CLI, workflow, or test changes.
- Proof-card examples are illustrative human-authored read models.
- This does not claim Assay emits the full delegation verdict vocabulary yet.
- This does not prove correctness, security, model understanding, or merge readiness.

## Validation

- JSON examples parse.
- Proof-card required fields checked.
- ASCII and trailing whitespace checks clean.
- Targeted overclaim scan clean.
- `git diff --check` clean.
