### PR TITLE
dogfood: embed claim_gate reports in PR Gate evidence

### DIFF
--- a/.github/workflows/assay-pr-gate.yml
+++ b/.github/workflows/assay-pr-gate.yml
@@ -21,6 +21,7 @@ jobs:
     env:
       ASSAY_PR_GATE_DIR: .assay/pr-gate
       ASSAY_PR_GATE_POLICY: docs/examples/pr-gate-v0/assay-dogfood-policy.yml
+      ASSAY_CLAIM_GATE_POLICY: docs/examples/claim-gate-v0/assay.claims.yml
       ASSAY_PR_GATE_EXPECTED_IDENTITY: https://github.com/Haserjian/assay/.github/workflows/assay-pr-gate.yml@refs/heads/main
       PR_NUMBER: ${{ github.event.pull_request.number }}
       PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -55,6 +56,24 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v4.0.0
 
+      - name: Run Claim Gate
+        run: |
+          set -euo pipefail
+          mkdir -p "$ASSAY_PR_GATE_DIR"
+          set +e
+          assay claim-gate diff \
+            --repo . \
+            --base "$PR_BASE_SHA" \
+            --head "$PR_HEAD_SHA" \
+            --policy "$ASSAY_CLAIM_GATE_POLICY" \
+            --out "$ASSAY_PR_GATE_DIR/claim_gate_report.json" \
+            --json
+          claim_gate_exit=$?
+          set -e
+          if [ "$claim_gate_exit" -ne 0 ] && [ "$claim_gate_exit" -ne 2 ]; then
+            exit "$claim_gate_exit"
+          fi
+
       - name: Capture PR evidence
         run: |
           set -euo pipefail
@@ -64,6 +83,7 @@ jobs:
             --pr "$PR_NUMBER" \
             --head-sha "$PR_HEAD_SHA" \
             --policy "$ASSAY_PR_GATE_POLICY" \
+            --claim-gate-report "$ASSAY_PR_GATE_DIR/claim_gate_report.json" \
             --out "$ASSAY_PR_GATE_DIR/evidence.json" \
             --git-cwd .
 

--- a/src/assay/commands.py
+++ b/src/assay/commands.py
@@ -8273,6 +8273,11 @@ def pr_gate_capture_cmd(
     policy: Optional[str] = typer.Option(
         None, "--policy", help="Optional PR Gate policy YAML to hash into evidence"
     ),
+    claim_gate_report: Optional[str] = typer.Option(
+        None,
+        "--claim-gate-report",
+        help="Optional claim_gate_report.json to embed in PR Gate evidence",
+    ),
     out: str = typer.Option(
         ..., "--out", help="Write PR Gate evidence JSON to this path"
     ),
@@ -8305,6 +8310,9 @@ def pr_gate_capture_cmd(
             head_sha=head_sha,
             out_path=P(out),
             policy_path=P(policy) if policy else None,
+            claim_gate_report_path=P(claim_gate_report)
+            if claim_gate_report
+            else None,
             env=os.environ,
             git_cwd=P(git_cwd),
             api_url=github_api_url,

--- a/src/assay/pr_gate/github_capture.py
+++ b/src/assay/pr_gate/github_capture.py
@@ -12,7 +12,12 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import quote, urlencode
 from urllib.request import Request, urlopen
 
-from assay.pr_gate.policy import compute_policy_sha256, load_policy
+from assay.pr_gate.policy import (
+    CLAIM_GATE_REPORT_COMMAND,
+    CLAIM_GATE_REPORT_SCHEMA_VERSION,
+    compute_policy_sha256,
+    load_policy,
+)
 
 DEFAULT_GITHUB_API_URL = "https://api.github.com"
 SCHEMA_VERSION = "assay.pr_gate.evidence.v0.1"
@@ -109,6 +114,7 @@ def capture_github_pr(
     github_client: Optional[GitHubClient] = None,
     api_url: Optional[str] = None,
     token: Optional[str] = None,
+    claim_gate_report_path: Optional[Path] = None,
 ) -> Dict[str, Any]:
     """Capture GitHub PR metadata, checks, and local content hashes."""
     if git_runner is None:
@@ -175,6 +181,11 @@ def capture_github_pr(
             "policy_sha256": compute_policy_sha256(policy),
         }
 
+    if claim_gate_report_path is not None:
+        evidence["claim_gate_report"] = _load_claim_gate_report(
+            claim_gate_report_path
+        )
+
     if out_path is not None:
         out_path.parent.mkdir(parents=True, exist_ok=True)
         out_path.write_text(
@@ -183,6 +194,26 @@ def capture_github_pr(
         )
 
     return evidence
+
+
+def _load_claim_gate_report(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        raise CaptureError(f"Claim Gate report not found: {path}")
+    if not path.is_file():
+        raise CaptureError(f"Claim Gate report path is not a file: {path}")
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise CaptureError(f"Claim Gate report is malformed JSON: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise CaptureError("Claim Gate report must be a JSON object")
+    if raw.get("schema_version") != CLAIM_GATE_REPORT_SCHEMA_VERSION:
+        raise CaptureError(
+            "Claim Gate report schema_version is not assay.claim_gate_report.v0"
+        )
+    if raw.get("command") != CLAIM_GATE_REPORT_COMMAND:
+        raise CaptureError("Claim Gate report command is not assay claim-gate diff")
+    return raw
 
 
 def run_git(args: Sequence[str], cwd: Path) -> bytes:

--- a/tests/assay/test_pr_gate_dogfood_workflow.py
+++ b/tests/assay/test_pr_gate_dogfood_workflow.py
@@ -40,6 +40,7 @@ def test_pr_gate_dogfood_workflow_runs_full_command_sequence() -> None:
     text = _workflow_text()
 
     for command in (
+        "assay claim-gate diff",
         "assay pr-gate capture",
         "assay pr-gate evaluate",
         "assay pr-gate pack",
@@ -56,7 +57,19 @@ def test_pr_gate_dogfood_workflow_uses_dogfood_policy() -> None:
     text = _workflow_text()
 
     assert "ASSAY_PR_GATE_POLICY: docs/examples/pr-gate-v0/assay-dogfood-policy.yml" in text
+    assert "ASSAY_CLAIM_GATE_POLICY: docs/examples/claim-gate-v0/assay.claims.yml" in text
     assert "docs/examples/pr-gate-v0/assay-policy.yml" not in text
+
+
+def test_pr_gate_dogfood_workflow_embeds_claim_gate_report() -> None:
+    text = _workflow_text()
+
+    assert '--out "$ASSAY_PR_GATE_DIR/claim_gate_report.json"' in text
+    assert (
+        '--claim-gate-report "$ASSAY_PR_GATE_DIR/claim_gate_report.json"'
+        in text
+    )
+    assert '"$claim_gate_exit" -ne 2' in text
 
 
 def test_pr_gate_dogfood_policy_does_not_require_named_checks() -> None:

--- a/tests/assay/test_pr_gate_github_capture.py
+++ b/tests/assay/test_pr_gate_github_capture.py
@@ -166,6 +166,45 @@ def test_capture_github_pr_builds_stable_evidence() -> None:
     assert ["show", "head-sha:old.py"] not in fake_git.calls
 
 
+def test_capture_github_pr_embeds_claim_gate_report(tmp_path: Path) -> None:
+    report_path = tmp_path / "claim_gate_report.json"
+    report = {
+        "schema_version": "assay.claim_gate_report.v0",
+        "command": "assay claim-gate diff",
+        "verdict": "BLOCK",
+        "summary": {"blocking_transitions": 1},
+        "transitions": [],
+        "non_claims": [],
+    }
+    report_path.write_text(json.dumps(report), encoding="utf-8")
+
+    evidence = capture_github_pr(
+        repo="Haserjian/assay",
+        pr_number=123,
+        git_cwd=Path("/repo"),
+        git_runner=FakeGit(),
+        github_client=FakeGitHubClient(),  # type: ignore[arg-type]
+        claim_gate_report_path=report_path,
+    )
+
+    assert evidence["claim_gate_report"] == report
+
+
+def test_capture_rejects_malformed_claim_gate_report(tmp_path: Path) -> None:
+    report_path = tmp_path / "claim_gate_report.json"
+    report_path.write_text('{"schema_version": "wrong"}\n', encoding="utf-8")
+
+    with pytest.raises(CaptureError, match="schema_version"):
+        capture_github_pr(
+            repo="Haserjian/assay",
+            pr_number=123,
+            git_cwd=Path("/repo"),
+            git_runner=FakeGit(),
+            github_client=FakeGitHubClient(),  # type: ignore[arg-type]
+            claim_gate_report_path=report_path,
+        )
+
+
 def test_capture_rejects_head_sha_mismatch() -> None:
     with pytest.raises(CaptureError, match="does not match"):
         capture_github_pr(
@@ -256,6 +295,7 @@ def test_capture_cli_writes_evidence(monkeypatch, tmp_path: Path) -> None:
         assert kwargs["repo"] == "Haserjian/assay"
         assert kwargs["pr_number"] == 123
         assert kwargs["head_sha"] == "head-sha"
+        assert kwargs["claim_gate_report_path"] == tmp_path / "claim_gate_report.json"
         kwargs["out_path"].write_text('{"ok": true}\n', encoding="utf-8")
         return {"ok": True}
 
@@ -272,6 +312,8 @@ def test_capture_cli_writes_evidence(monkeypatch, tmp_path: Path) -> None:
             "capture",
             "--head-sha",
             "head-sha",
+            "--claim-gate-report",
+            str(tmp_path / "claim_gate_report.json"),
             "--out",
             str(out_path),
         ],


### PR DESCRIPTION
## Summary
Make the PR Gate workflow produce and embed `claim_gate_report` evidence before policy evaluation.

This is the producer slice after #157. The workflow now runs `assay claim-gate diff`, writes `.assay/pr-gate/claim_gate_report.json`, and passes that report into `assay pr-gate capture` so future signed PR Gate evidence packets can surface the Claim channel from generated claim_gate output.

## Boundaries
- Runs trusted base-branch Assay code under the existing same-repo `pull_request_target` guard.
- Treats claim_gate `BLOCK` exit code as review evidence, not a workflow crash, so PR Gate can render the generated report.
- Still fails closed on Claim Gate execution errors other than the expected `BLOCK` exit code.
- Does not make `Claim: FAIL` control the PR Gate top-level decision.
- Does not add `NEEDS_SPLIT` or new verdict vocabulary.
- Does not claim PR Gate proves correctness, security, replay, production readiness, or model understanding.

## Live-workflow boundary
This PR changes `.github/workflows/assay-pr-gate.yml`, but `pull_request_target` executes the trusted workflow from the base branch. Therefore this PR's own live PR Gate comment is expected to remain on the pre-producer path and may still show Claim `NOT_EVALUATED`.

The producer becomes live only after this workflow change lands on `main`. The first live producer dogfood receipt should be captured on the next PR after merge.

## Local validation
- `.venv/bin/python -m pytest tests/assay/test_pr_gate_github_capture.py tests/assay/test_pr_gate_dogfood_workflow.py tests/assay/test_pr_gate_policy.py tests/assay/test_pr_gate_render_comment.py tests/claim_gate -q` -> 57 passed
- `.venv/bin/python -m pytest -k "pr_gate or claim" -q` -> 286 passed
- `git diff --check` clean
- `assay claim-gate diff --repo . --base main --head HEAD --policy docs/examples/claim-gate-v0/assay.claims.yml --out <tmp>/claim_gate_report.json --json` -> `PASS`, 5 files scanned, 0 transitions

## Expected live PR Gate behavior on this PR
Because this PR is changing the workflow itself, the live PR Gate comment is expected to remain boundary-honest rather than prove the new producer path. A `Claim: NOT_EVALUATED` comment on this PR is acceptable and expected. The next PR after merge should be the first live producer check.
