### PR TITLE
dogfood: escalate claim_gate failures to PR Gate review

### DIFF
--- a/docs/product/assay-pr-gate-policy-v0.md
+++ b/docs/product/assay-pr-gate-policy-v0.md
@@ -89,9 +89,10 @@ claim_gate BLOCK        -> Claim FAIL
 claim_gate absent       -> Claim NOT_EVALUATED
 ```
 
-A claim_gate FAIL also escalates the top-level decision so the gate never
-recommends `proceed` while the Claim channel reads `FAIL`. The escalation is
-conservative and only applies when no rule already fired:
+A claim_gate `NEEDS_REVIEW` or `BLOCK` verdict also escalates the top-level
+decision so the gate never recommends `proceed` while the Claim channel reads
+`FAIL`. The escalation is conservative and only applies when no rule already
+fired:
 
 ```text
 claim_gate NEEDS_REVIEW -> overall NEEDS_REVIEW (require_human_approval)

--- a/docs/product/assay-pr-gate-policy-v0.md
+++ b/docs/product/assay-pr-gate-policy-v0.md
@@ -89,6 +89,19 @@ claim_gate BLOCK        -> Claim FAIL
 claim_gate absent       -> Claim NOT_EVALUATED
 ```
 
+A claim_gate FAIL also escalates the top-level decision so the gate never
+recommends `proceed` while the Claim channel reads `FAIL`. The escalation is
+conservative and only applies when no rule already fired:
+
+```text
+claim_gate NEEDS_REVIEW -> overall NEEDS_REVIEW (require_human_approval)
+claim_gate BLOCK        -> overall NEEDS_REVIEW (require_human_approval)
+```
+
+Rule-based outcomes take priority. A real `BLOCK` rule (for example a failed
+required check) is never downgraded by claim_gate, and v0 does not let
+claim_gate `BLOCK` hard-block a merge on its own; it routes to human review.
+
 Required check observations are still captured and can drive policy decisions,
 but they do not by themselves make the Claim channel `PASS`. It is not:
 

--- a/docs/product/assay-pr-gate-v0.md
+++ b/docs/product/assay-pr-gate-v0.md
@@ -155,6 +155,12 @@ claim_gate absent       -> Claim NOT_EVALUATED
 separate `NEEDS_REVIEW` value. The reason must say that claim evidence requires
 human review; it must not imply the code is permanently rejected.
 
+A claim_gate `FAIL` also escalates the top-level decision to `NEEDS_REVIEW`
+(`require_human_approval`) when no rule already fired, so the gate never
+recommends `proceed` while the Claim channel reads `FAIL`. v0 does not let
+claim_gate `BLOCK` hard-block a merge on its own, and a real `BLOCK` rule is
+never downgraded by claim_gate.
+
 The bounded claim is not "tests passed." Required check observations remain
 available as `check_observations` and can drive trust-policy or top-level
 review decisions. They do not by themselves make the Claim channel `PASS`.

--- a/docs/product/assay-pr-gate-v0.md
+++ b/docs/product/assay-pr-gate-v0.md
@@ -155,11 +155,11 @@ claim_gate absent       -> Claim NOT_EVALUATED
 separate `NEEDS_REVIEW` value. The reason must say that claim evidence requires
 human review; it must not imply the code is permanently rejected.
 
-A claim_gate `FAIL` also escalates the top-level decision to `NEEDS_REVIEW`
-(`require_human_approval`) when no rule already fired, so the gate never
-recommends `proceed` while the Claim channel reads `FAIL`. v0 does not let
-claim_gate `BLOCK` hard-block a merge on its own, and a real `BLOCK` rule is
-never downgraded by claim_gate.
+A claim_gate `NEEDS_REVIEW` or `BLOCK` verdict also escalates the top-level
+decision to `NEEDS_REVIEW` (`require_human_approval`) when no rule already
+fired, so the gate never recommends `proceed` while the Claim channel reads
+`FAIL`. v0 does not let claim_gate `BLOCK` hard-block a merge on its own, and a
+real `BLOCK` rule is never downgraded by claim_gate.
 
 The bounded claim is not "tests passed." Required check observations remain
 available as `check_observations` and can drive trust-policy or top-level

--- a/src/assay/pr_gate/policy.py
+++ b/src/assay/pr_gate/policy.py
@@ -203,18 +203,25 @@ def evaluate_policy(
     reasons = _ordered_reasons(reasons_by_rule, claim_gate_reasons)
     selected_rule = _selected_rule(reasons_by_rule)
 
-    # Adapter slice: claim_gate reflects into the Claim channel only. It does
-    # not drive the top-level decision here. Whether a claim_gate FAIL should
-    # escalate overall_decision is deferred to the producer slice, where the
-    # behavior becomes live (CI embeds the report).
-    if selected_rule is None:
-        default = _mapping(policy["default"], "default")
-        overall_decision = str(default["decision"])
-        recommended_action = str(default["recommended_action"])
-    else:
+    # Rule-based outcomes take priority: they cover every BLOCK case and the
+    # existing NEEDS_REVIEW cases. A claim_gate FAIL only escalates the
+    # top-level decision when no rule already fired, so the gate never
+    # recommends "proceed" while the Claim channel reads FAIL.
+    #
+    # v0 escalation: claim_gate BLOCK and NEEDS_REVIEW both route to
+    # NEEDS_REVIEW (human review), not a hard merge block. Whether claim_gate
+    # BLOCK should hard-BLOCK is a separate, later decision.
+    if selected_rule is not None:
         spec = _mapping(rules[selected_rule], f"rules.{selected_rule}")
         overall_decision = str(spec["decision"])
         recommended_action = str(spec["recommended_action"])
+    elif claim_gate_verdict in {"BLOCK", "NEEDS_REVIEW"}:
+        overall_decision = "NEEDS_REVIEW"
+        recommended_action = "require_human_approval"
+    else:
+        default = _mapping(policy["default"], "default")
+        overall_decision = str(default["decision"])
+        recommended_action = str(default["recommended_action"])
 
     return {
         "overall_decision": overall_decision,

--- a/src/assay/pr_gate/policy.py
+++ b/src/assay/pr_gate/policy.py
@@ -204,9 +204,9 @@ def evaluate_policy(
     selected_rule = _selected_rule(reasons_by_rule)
 
     # Rule-based outcomes take priority: they cover every BLOCK case and the
-    # existing NEEDS_REVIEW cases. A claim_gate FAIL only escalates the
-    # top-level decision when no rule already fired, so the gate never
-    # recommends "proceed" while the Claim channel reads FAIL.
+    # existing NEEDS_REVIEW cases. A claim_gate NEEDS_REVIEW or BLOCK verdict
+    # only escalates the top-level decision when no rule already fired, so the
+    # gate never recommends "proceed" while the Claim channel reads FAIL.
     #
     # v0 escalation: claim_gate BLOCK and NEEDS_REVIEW both route to
     # NEEDS_REVIEW (human review), not a hard merge block. Whether claim_gate

--- a/tests/assay/test_pr_gate_policy.py
+++ b/tests/assay/test_pr_gate_policy.py
@@ -359,10 +359,11 @@ class TestPrGatePolicyEvaluator:
             _policy(),
         )
 
-        # Adapter slice: claim_gate BLOCK surfaces in the Claim channel as FAIL
-        # but does NOT drive the top-level decision (deferred to producer slice).
-        assert decision["overall_decision"] == "PASS"
-        assert decision["recommended_action"] == "proceed"
+        # Producer is live: claim_gate BLOCK surfaces as Claim FAIL and
+        # escalates the top-level decision to NEEDS_REVIEW (human review),
+        # not a hard BLOCK in v0.
+        assert decision["overall_decision"] == "NEEDS_REVIEW"
+        assert decision["recommended_action"] == "require_human_approval"
         assert decision["channels"]["claim"] == "FAIL"
         assert decision["channels"]["trust_policy"] == "PASS"
         assert [reason["rule"] for reason in decision["reasons"]] == [
@@ -403,10 +404,10 @@ class TestPrGatePolicyEvaluator:
             _policy(),
         )
 
-        # Adapter slice: claim_gate NEEDS_REVIEW surfaces in the Claim channel
-        # as FAIL but does NOT drive the top-level decision.
-        assert decision["overall_decision"] == "PASS"
-        assert decision["recommended_action"] == "proceed"
+        # Producer is live: claim_gate NEEDS_REVIEW surfaces as Claim FAIL and
+        # escalates the top-level decision to NEEDS_REVIEW.
+        assert decision["overall_decision"] == "NEEDS_REVIEW"
+        assert decision["recommended_action"] == "require_human_approval"
         assert decision["channels"]["claim"] == "FAIL"
         assert decision["reasons"] == [
             {
@@ -420,6 +421,31 @@ class TestPrGatePolicyEvaluator:
                 "severity": "medium",
             }
         ]
+
+    def test_hard_block_rule_wins_over_claim_gate_block(self) -> None:
+        # A real BLOCK rule (failed required check) must not be downgraded by
+        # claim_gate escalation: claim_gate v0 escalates to NEEDS_REVIEW only
+        # when no rule already fired.
+        decision = evaluate_policy(
+            _evidence(
+                observed_checks=[
+                    {
+                        "name": "tests",
+                        "provider": "github_checks",
+                        "head_sha": "head",
+                        "conclusion": "failure",
+                        "observed_at": "2026-05-08T12:00:00Z",
+                    }
+                ],
+                claim_gate_report=_dogfood_claim_gate_report(),
+            ),
+            _policy(),
+        )
+
+        assert decision["overall_decision"] == "BLOCK"
+        assert decision["recommended_action"] == "block_required_check_failed"
+        assert decision["channels"]["claim"] == "FAIL"
+        assert decision["channels"]["trust_policy"] == "BLOCK"
 
     def test_claim_gate_report_rejects_wrong_schema_version(self) -> None:
         report = _claim_gate_report("PASS")

--- a/tests/assay/test_pr_gate_render_comment.py
+++ b/tests/assay/test_pr_gate_render_comment.py
@@ -262,10 +262,10 @@ def test_render_comment_claim_gate_block_reports_claim_fail(tmp_path: Path) -> N
         ),
     )
 
-    # Adapter slice: claim_gate BLOCK surfaces only in the Claim channel.
-    # The top-level header stays PASS; escalation is deferred to the producer slice.
-    assert "Assay PR Gate: PASS - proceed to normal review" in comment
-    assert "Recommended action: proceed" in comment
+    # Producer is live: claim_gate BLOCK surfaces as Claim FAIL and escalates
+    # the top-level decision to NEEDS_REVIEW (human review), not a hard BLOCK.
+    assert "Assay PR Gate: NEEDS_REVIEW" in comment
+    assert "Recommended action: require_human_approval" in comment
     assert (
         "Claim: FAIL - claim_gate BLOCK: possible_to_guaranteed, "
         "prototype_to_production"


### PR DESCRIPTION
## Summary
Escalates claim_gate Claim-channel failures to the PR Gate top-level `NEEDS_REVIEW` decision when no existing PR Gate rule already fired.

This removes the live-surface contradiction exposed by #159, where PR Gate showed `PASS - proceed` while the Claim channel showed `FAIL`.

## Behavior
- claim_gate `PASS` -> top-level unchanged
- claim_gate `NEEDS_REVIEW` -> `overall_decision: NEEDS_REVIEW`, `recommended_action: require_human_approval`
- claim_gate `BLOCK` -> `overall_decision: NEEDS_REVIEW`, `recommended_action: require_human_approval`

Rule-based outcomes still take priority. A real `BLOCK` rule, such as a failed required check, is not downgraded by claim_gate escalation.

## Boundaries
- Does not make claim_gate `BLOCK` hard-block merges in v0.
- Does not add `NEEDS_SPLIT` or any new verdict vocabulary.
- Does not change Claim channel mapping.
- Does not claim PR Gate proves correctness, security, replay, production readiness, or model understanding.

## Validation
- `.venv/bin/python -m pytest -k "pr_gate or claim" -q` -> 287 passed
- `.venv/bin/python -m pytest tests/claim_gate -q` -> 13 passed
- `git diff --check` clean
- stale channel-only wording scan clean

## Expected live PR Gate behavior on a future overclaim dogfood PR
A generated claim_gate `BLOCK` should now surface as:

- top-level: `NEEDS_REVIEW`
- recommended action: `require_human_approval`
- Claim channel: `FAIL - claim_gate BLOCK: ...`
