### PR TITLE
docs: add PR review proof card observed surface

### DIFF
--- a/docs/public_surfaces/pr-review-proof-card-v0/COLD_READ.md
+++ b/docs/public_surfaces/pr-review-proof-card-v0/COLD_READ.md
@@ -1,0 +1,64 @@
+# Cold Read
+
+Use this as a stranger test for PR Review Proof Card v0.
+
+A reader should be able to answer these questions without knowing Assay
+internals.
+
+## Reader Questions
+
+1. Who is this card for?
+2. What decision does it support?
+3. What is the canonical source of truth?
+4. What ran?
+5. What failed?
+6. What did not run?
+7. What evidence was unavailable or not derived?
+8. What should not be inferred?
+9. Did the card make a `NEEDS_REVIEW` result look like a badge?
+10. Did the card imply merge-readiness?
+
+## Passing Answer
+
+The reader should answer:
+
+- This is for a maintainer or tech lead reviewing an AI-assisted PR.
+- It supports deciding whether to proceed to review, require more evidence, or
+  block.
+- The signed Verification Report is the canonical source of truth.
+- Integrity passed and Trust policy passed.
+- Claim failed because Claim Gate blocked two trust-escalating transitions.
+- Replay was not run.
+- No required-check observations were recorded.
+- Some evidence-reference hashes were unavailable because the source report
+  recorded them as `null`.
+
+The reader should also say:
+
+```text
+The card shows which checks ran and where evidence stops.
+It does not assert truth, correctness, safety, security, or merge-readiness.
+```
+
+## Failing Answer
+
+The cold read fails if the reader infers that:
+
+- the code is secure;
+- all possible tests passed;
+- the AI made a good design decision;
+- replay was performed;
+- production approval was granted;
+- `NEEDS_REVIEW` is a green badge;
+- the card replaces the signed Verification Report;
+- the card is a generic Proof Card schema.
+
+## Non-Authority Check
+
+The reader must be able to identify `comment.md` as a rendered review surface,
+not as authority. The source precedence must be clear:
+
+1. signed Verification Report;
+2. decision object;
+3. pack manifest;
+4. rendered comment.

--- a/docs/public_surfaces/pr-review-proof-card-v0/DERIVATION.md
+++ b/docs/public_surfaces/pr-review-proof-card-v0/DERIVATION.md
@@ -1,0 +1,197 @@
+# Derivation
+
+`examples/pr_161_needs_review.observed.json` is generated from the downloaded
+`assay-pr-gate-report` artifact for GitHub Actions run `27047357238`.
+
+The card is an observed projection. It is not an independent authority, a
+schema, a verifier output, or canonical evidence. The signed Verification
+Report remains canonical.
+
+## Source Paths
+
+Assuming:
+
+```bash
+ARTIFACT_DIR=/tmp/assay-pr-review-proof-card-artifact.PfSInL
+```
+
+The derivation reads:
+
+- `$ARTIFACT_DIR/signed-report/verify_report.json`
+- `$ARTIFACT_DIR/decision.json`
+- `$ARTIFACT_DIR/proof-pack/pack_manifest.json`
+
+`$ARTIFACT_DIR/comment.md` is kept as rendered-output comparison only.
+
+## Field Mapping
+
+| Card field | Source field |
+|---|---|
+| `source_artifact.github_actions_run_id` | `verify_report.capture.run_id` |
+| `canonical_source_of_truth.report_id` | `verify_report.report_id` |
+| `canonical_source_of_truth.schema_version` | `verify_report.schema_version` |
+| `subject` | `verify_report.subject` |
+| `capture` | `verify_report.capture` |
+| `policy` | `verify_report.policy` |
+| `signature_policy` | `verify_report.signature_policy` |
+| `decision.overall_decision` | `verify_report.overall_decision` |
+| `decision.recommended_action` | `verify_report.recommended_action` |
+| `decision.reasons` | `verify_report.reasons` |
+| `verdict_channels` | `verify_report.channels` |
+| `failures.claim_gate_blocks` | `verify_report.reasons` |
+| `checks.check_observations` | `verify_report.check_observations` |
+| `evidence.pack_id` | `verify_report.pack_id` |
+| `evidence.pack_manifest_sha256` | `verify_report.pack_manifest_sha256` |
+| `evidence.pack_root_sha256` | `verify_report.pack_root_sha256` |
+| `evidence.evidence_refs` | `verify_report.evidence_refs` |
+| `evidence.pack_manifest.files` | `proof-pack/pack_manifest.json.files` |
+| `do_not_infer` | `verify_report.do_not_infer` |
+
+## Absence Handling
+
+Absence is represented directly:
+
+- `checks.check_observations` is an empty array, so the card records
+  `check_observations_status: NONE_RECORDED`.
+- `channels.replay` is `NOT_RUN`, so the card records replay as not run.
+- `evidence_refs[Verification Report].sha256` is `null` in the signed report,
+  so the card records it under `unavailable_or_not_derived`.
+- `evidence_refs[Signature Proof].sha256` is `null` in the signed report, so
+  the card records it under `unavailable_or_not_derived`.
+
+## Generation Command
+
+The observed JSON was generated with:
+
+```bash
+ARTIFACT_DIR=/tmp/assay-pr-review-proof-card-artifact.PfSInL
+mkdir -p docs/public_surfaces/pr-review-proof-card-v0/examples
+
+jq -n \
+  --slurpfile report "$ARTIFACT_DIR/signed-report/verify_report.json" \
+  --slurpfile decision "$ARTIFACT_DIR/decision.json" \
+  --slurpfile manifest "$ARTIFACT_DIR/proof-pack/pack_manifest.json" '
+  ($report[0]) as $r |
+  ($decision[0]) as $d |
+  ($manifest[0]) as $m |
+  {
+    card_version: "assay.pr_review_proof_card.observed.v0",
+    projection_status: "observed_projection",
+    consumer: {
+      role: "maintainer_or_tech_lead",
+      call_site: "github_pr_comment_or_pr_gate_artifact",
+      decision_supported: ["proceed_to_review", "require_more_evidence", "block"]
+    },
+    invariant: [
+      "A Proof Card displays which checks ran and where the evidence stops.",
+      "It does not assert truth, correctness, safety, security, or merge-readiness.",
+      "Absence of a check is shown, never hidden."
+    ],
+    non_authority: [
+      "This observed card is not canonical evidence.",
+      "The signed Verification Report remains canonical.",
+      "This card is a reader projection over PR Gate output, not a new proof substrate."
+    ],
+    source_artifact: {
+      github_actions_run_id: $r.capture.run_id,
+      artifact_name: "assay-pr-gate-report",
+      workflow_name: "Assay PR Gate",
+      artifact_files_used: [
+        "signed-report/verify_report.json",
+        "decision.json",
+        "proof-pack/pack_manifest.json",
+        "comment.md"
+      ],
+      source_precedence: [
+        {rank: 1, path: "signed-report/verify_report.json", role: "canonical_signed_report_source"},
+        {rank: 2, path: "decision.json", role: "local_pr_gate_decision_object"},
+        {rank: 3, path: "proof-pack/pack_manifest.json", role: "evidence_pack_structure"},
+        {rank: 4, path: "comment.md", role: "rendered_review_surface_not_authority"}
+      ]
+    },
+    canonical_source_of_truth: {
+      path: "signed-report/verify_report.json",
+      schema_version: $r.schema_version,
+      report_id: $r.report_id,
+      signed_by_expected_workflow: $r.signature_policy.expected_certificate_identity
+    },
+    rendered_surface_comparison: {
+      path: "comment.md",
+      role: "rendered review surface; not used as authority for this card"
+    },
+    subject: $r.subject,
+    capture: $r.capture,
+    policy: $r.policy,
+    signature_policy: $r.signature_policy,
+    decision: {
+      overall_decision: $r.overall_decision,
+      recommended_action: $r.recommended_action,
+      reasons: $r.reasons
+    },
+    verdict_channels: $r.channels,
+    failures: {
+      claim_channel_status: $r.channels.claim,
+      claim_gate_blocks: $r.reasons
+    },
+    checks: {
+      check_observations_status: (if ($r.check_observations | length) == 0 then "NONE_RECORDED" else "RECORDED" end),
+      check_observations: $r.check_observations,
+      absence_visibility: [
+        {
+          field: "check_observations",
+          observed_value: $r.check_observations,
+          meaning: "No required-check observations were recorded in this artifact."
+        },
+        {
+          field: "channels.replay",
+          observed_value: $r.channels.replay,
+          meaning: "Replay was not run for this PR Gate artifact."
+        }
+      ]
+    },
+    evidence: {
+      pack_id: $r.pack_id,
+      pack_manifest_sha256: $r.pack_manifest_sha256,
+      pack_root_sha256: $r.pack_root_sha256,
+      evidence_refs: $r.evidence_refs,
+      pack_manifest: {
+        schema_version: $m.schema_version,
+        files: $m.files
+      }
+    },
+    do_not_infer: $r.do_not_infer,
+    unavailable_or_not_derived: [
+      {
+        field: "evidence_refs[Verification Report].sha256",
+        observed_value: null,
+        reason: "The signed report evidence reference in the source report records this value as null."
+      },
+      {
+        field: "evidence_refs[Signature Proof].sha256",
+        observed_value: null,
+        reason: "The signature proof evidence reference in the source report records this value as null."
+      },
+      {
+        field: "proof-pack/pack_manifest.json.root_sha256",
+        observed_value: $m.root_sha256,
+        reason: "The manifest field is null; the report-level pack_root_sha256 is preserved separately."
+      }
+    ],
+    derivation_checks: {
+      decision_overall_matches_report: ($d.overall_decision == $r.overall_decision),
+      decision_recommended_action_matches_report: ($d.recommended_action == $r.recommended_action),
+      decision_channels_match_report: ($d.channels == $r.channels),
+      manifest_pack_root_matches_report: ($m.pack_root_sha256 == $r.pack_root_sha256)
+    }
+  }
+' > docs/public_surfaces/pr-review-proof-card-v0/examples/pr_161_needs_review.observed.json
+```
+
+## Derivation Checks
+
+The generated example records four consistency checks:
+
+- `decision_overall_matches_report: true`
+- `decision_recommended_action_matches_report: true`
+- `decision_channels_match_report: true`
+- `manifest_pack_root_matches_report: true`

--- a/docs/public_surfaces/pr-review-proof-card-v0/README.md
+++ b/docs/public_surfaces/pr-review-proof-card-v0/README.md
@@ -1,0 +1,94 @@
+# PR Review Proof Card v0
+
+PR Review Proof Card v0 is an observed reader projection over one real Assay
+PR Gate artifact.
+
+It is for a maintainer or tech lead reviewing an AI-assisted pull request at
+the review moment. It supports one decision:
+
+```text
+proceed to review, require more evidence, or block
+```
+
+Core invariant:
+
+```text
+A Proof Card displays which checks ran and where the evidence stops.
+It does not assert truth, correctness, safety, security, or merge-readiness.
+Absence of a check is shown, never hidden.
+```
+
+## Why This Is Not Generic Proof Card v0
+
+This packet names one consumer and one call site before defining a reusable
+shape:
+
+- Consumer: maintainer or tech lead.
+- Call site: GitHub PR comment or downloaded Assay PR Gate artifact.
+- Source: a real `assay-pr-gate-report` artifact.
+- Decision: proceed to review, require more evidence, or block.
+
+That keeps the surface tied to a deciding moment instead of turning Proof Card
+into an abstract badge.
+
+## Source Artifact
+
+The observed example is derived from GitHub Actions run `27047357238`, artifact
+`assay-pr-gate-report`, for PR `#161`.
+
+Source precedence:
+
+1. `signed-report/verify_report.json` is the canonical signed report source.
+2. `decision.json` may be used for matching PR Gate decision fields.
+3. `proof-pack/pack_manifest.json` may be used for evidence-pack structure.
+4. `comment.md` may be used only as rendered-output comparison, not as
+   authority.
+
+The signed Verification Report remains canonical. This card is a reader
+projection and is not independent evidence.
+
+## Files
+
+- `SOURCE_ARTIFACT.md` records the source run, artifact, subject, and local
+  convenience copy used for this derivation.
+- `DERIVATION.md` maps fields from the PR Gate artifact into the observed card.
+- `examples/pr_161_needs_review.observed.json` is the generated observed
+  projection.
+- `COLD_READ.md` is a skeptical-reader check for the surface.
+
+## What The Card Can Say
+
+This observed card can say:
+
+- the PR Gate decision was `NEEDS_REVIEW`;
+- the recommended action was `require_human_approval`;
+- Integrity passed;
+- Claim failed because Claim Gate blocked two trust-escalating transitions;
+- Replay was `NOT_RUN`;
+- Trust policy passed;
+- no required-check observations were recorded in the artifact;
+- the evidence pack and expected workflow identity are named by the signed
+  report.
+
+## What The Card Cannot Say
+
+This observed card must not claim:
+
+- the code is secure;
+- all possible tests passed;
+- the AI made a good design decision;
+- replay was performed;
+- production approval was granted;
+- the PR is ready to merge;
+- the underlying code change is correct.
+
+Those limits are part of the card. They are not footnotes.
+
+## Why There Is No Schema Yet
+
+No `proof_card.schema.json` is included in this slice.
+
+A schema would turn the observed shape into a contract before the projection is
+proven across more real artifacts. This packet records one observed shape from
+one real PR Gate artifact first. A future schema should be derived only after
+there is enough observed output and a clear generator or validation path.

--- a/docs/public_surfaces/pr-review-proof-card-v0/SOURCE_ARTIFACT.md
+++ b/docs/public_surfaces/pr-review-proof-card-v0/SOURCE_ARTIFACT.md
@@ -1,0 +1,89 @@
+# Source Artifact
+
+This packet uses a real Assay PR Gate artifact as its source.
+
+## Durable Source
+
+- GitHub Actions run id: `27047357238`
+- Workflow: `Assay PR Gate`
+- Workflow event: `pull_request_target`
+- Workflow conclusion: `success`
+- Artifact name: `assay-pr-gate-report`
+- PR: `#161`
+- Head branch: `dogfood/live-claim-gate-needs-review-v0`
+- Head commit: `87eb68c6f1e9afb16b380ba1d2ef9df90af9a758`
+- Run URL: `https://github.com/Haserjian/assay/actions/runs/27047357238`
+
+## Freshness Note
+
+A later PR Gate artifact was available during implementation:
+
+- GitHub Actions run id: `27047709710`
+- PR: `#162`
+- overall decision: `PASS`
+- recommended action: `proceed`
+
+This packet intentionally uses PR `#161` because this slice names
+`pr_161_needs_review.observed.json` and exercises the review-card behavior that
+matters most for the first public example: failure and absence are visible, not
+hidden.
+
+## Convenience Copy
+
+The artifact was downloaded locally for derivation at:
+
+```text
+/tmp/assay-pr-review-proof-card-artifact.PfSInL
+```
+
+That local path is only a convenience copy. It is not the canonical source of
+truth.
+
+## Source Files Used
+
+Source precedence:
+
+1. `signed-report/verify_report.json` - canonical signed report source.
+2. `decision.json` - local PR Gate decision object.
+3. `proof-pack/pack_manifest.json` - evidence-pack structure.
+4. `comment.md` - rendered review surface, not authority.
+
+Expected downloaded artifact files:
+
+```text
+claim_gate_report.json
+comment.md
+decision.json
+evidence.json
+proof-pack/changed_files.json
+proof-pack/observed_checks.json
+proof-pack/pack_manifest.json
+proof-pack/policy.yml
+proof-pack/pr_gate_decision.json
+proof-pack/pr_gate_evidence.json
+proof-pack/verify_transcript.md
+signed-report/verify_report.json
+signed-report/verify_report.sigstore.json
+```
+
+## Canonical Report Fields
+
+From `signed-report/verify_report.json`:
+
+- report id: `vr_292c223cecdf60f2cd31`
+- report schema: `assay.pr_gate.verify_report.v0.1`
+- pack id: `prgate_pack_0659bcbd9ca2cdb7`
+- subject repo: `Haserjian/assay`
+- subject PR: `#161`
+- base commit: `21aa7b8c8cfbd2d04ad8e1560b111a9ed9b45ed2`
+- head commit: `87eb68c6f1e9afb16b380ba1d2ef9df90af9a758`
+- diff hash: `sha256:d64768533af7e6742ccbceae35064d7f84980e62f05b2d7a91c3cb257c506cea`
+- overall decision: `NEEDS_REVIEW`
+- recommended action: `require_human_approval`
+- channels: Integrity `PASS`, Claim `FAIL`, Replay `NOT_RUN`, Trust policy
+  `PASS`
+
+## Canonical Source Of Truth
+
+The signed Verification Report is canonical. This packet is only an observed
+projection for a reader at the PR review moment.

--- a/docs/public_surfaces/pr-review-proof-card-v0/examples/pr_161_needs_review.observed.json
+++ b/docs/public_surfaces/pr-review-proof-card-v0/examples/pr_161_needs_review.observed.json
@@ -1,0 +1,266 @@
+{
+  "card_version": "assay.pr_review_proof_card.observed.v0",
+  "projection_status": "observed_projection",
+  "consumer": {
+    "role": "maintainer_or_tech_lead",
+    "call_site": "github_pr_comment_or_pr_gate_artifact",
+    "decision_supported": [
+      "proceed_to_review",
+      "require_more_evidence",
+      "block"
+    ]
+  },
+  "invariant": [
+    "A Proof Card displays which checks ran and where the evidence stops.",
+    "It does not assert truth, correctness, safety, security, or merge-readiness.",
+    "Absence of a check is shown, never hidden."
+  ],
+  "non_authority": [
+    "This observed card is not canonical evidence.",
+    "The signed Verification Report remains canonical.",
+    "This card is a reader projection over PR Gate output, not a new proof substrate."
+  ],
+  "source_artifact": {
+    "github_actions_run_id": "27047357238",
+    "artifact_name": "assay-pr-gate-report",
+    "workflow_name": "Assay PR Gate",
+    "artifact_files_used": [
+      "signed-report/verify_report.json",
+      "decision.json",
+      "proof-pack/pack_manifest.json",
+      "comment.md"
+    ],
+    "source_precedence": [
+      {
+        "rank": 1,
+        "path": "signed-report/verify_report.json",
+        "role": "canonical_signed_report_source"
+      },
+      {
+        "rank": 2,
+        "path": "decision.json",
+        "role": "local_pr_gate_decision_object"
+      },
+      {
+        "rank": 3,
+        "path": "proof-pack/pack_manifest.json",
+        "role": "evidence_pack_structure"
+      },
+      {
+        "rank": 4,
+        "path": "comment.md",
+        "role": "rendered_review_surface_not_authority"
+      }
+    ]
+  },
+  "canonical_source_of_truth": {
+    "path": "signed-report/verify_report.json",
+    "schema_version": "assay.pr_gate.verify_report.v0.1",
+    "report_id": "vr_292c223cecdf60f2cd31",
+    "signed_by_expected_workflow": "https://github.com/Haserjian/assay/.github/workflows/assay-pr-gate.yml@refs/heads/main"
+  },
+  "rendered_surface_comparison": {
+    "path": "comment.md",
+    "role": "rendered review surface; not used as authority for this card"
+  },
+  "subject": {
+    "base_sha": "21aa7b8c8cfbd2d04ad8e1560b111a9ed9b45ed2",
+    "diff_sha256": "sha256:d64768533af7e6742ccbceae35064d7f84980e62f05b2d7a91c3cb257c506cea",
+    "diff_source": "git diff --binary --full-index <base_sha> <head_sha>",
+    "head_sha": "87eb68c6f1e9afb16b380ba1d2ef9df90af9a758",
+    "pr_number": 161,
+    "repo": "Haserjian/assay"
+  },
+  "capture": {
+    "actor": "Haserjian",
+    "event_name": "pull_request_target",
+    "github_sha": "21aa7b8c8cfbd2d04ad8e1560b111a9ed9b45ed2",
+    "provider": "github_actions",
+    "run_attempt": "1",
+    "run_id": "27047357238",
+    "workflow_ref": "Haserjian/assay/.github/workflows/assay-pr-gate.yml@refs/heads/main",
+    "workflow_sha": "21aa7b8c8cfbd2d04ad8e1560b111a9ed9b45ed2"
+  },
+  "policy": {
+    "policy_sha256": "sha256:f4c3d96a81252fe1c2c96127218b2e3c3828c7acc44f4b8e4a6f1d49459087c5",
+    "profile": "coding_pr_v0"
+  },
+  "signature_policy": {
+    "certificate_oidc_issuer": "https://token.actions.githubusercontent.com",
+    "expected_certificate_identity": "https://github.com/Haserjian/assay/.github/workflows/assay-pr-gate.yml@refs/heads/main",
+    "required": true,
+    "scheme": "sigstore_keyless"
+  },
+  "decision": {
+    "overall_decision": "NEEDS_REVIEW",
+    "recommended_action": "require_human_approval",
+    "reasons": [
+      {
+        "claim_gate_verdict": "BLOCK",
+        "file": "docs/examples/claim-gate-v0/README_before.md",
+        "id": "cgt_001",
+        "missing_evidence": [
+          "direct_evidence",
+          "reviewer_acceptance"
+        ],
+        "rule": "claim_gate_block",
+        "severity": "high",
+        "transition_class": "possible_to_guaranteed",
+        "transition_verdict": "BLOCK"
+      },
+      {
+        "claim_gate_verdict": "BLOCK",
+        "file": "docs/examples/claim-gate-v0/README_before.md",
+        "id": "cgt_002",
+        "missing_evidence": [
+          "production_deployment_receipt",
+          "reproducible_test_suite"
+        ],
+        "rule": "claim_gate_block",
+        "severity": "high",
+        "transition_class": "prototype_to_production",
+        "transition_verdict": "BLOCK"
+      }
+    ]
+  },
+  "verdict_channels": {
+    "claim": "FAIL",
+    "integrity": "PASS",
+    "replay": "NOT_RUN",
+    "trust_policy": "PASS"
+  },
+  "failures": {
+    "claim_channel_status": "FAIL",
+    "claim_gate_blocks": [
+      {
+        "claim_gate_verdict": "BLOCK",
+        "file": "docs/examples/claim-gate-v0/README_before.md",
+        "id": "cgt_001",
+        "missing_evidence": [
+          "direct_evidence",
+          "reviewer_acceptance"
+        ],
+        "rule": "claim_gate_block",
+        "severity": "high",
+        "transition_class": "possible_to_guaranteed",
+        "transition_verdict": "BLOCK"
+      },
+      {
+        "claim_gate_verdict": "BLOCK",
+        "file": "docs/examples/claim-gate-v0/README_before.md",
+        "id": "cgt_002",
+        "missing_evidence": [
+          "production_deployment_receipt",
+          "reproducible_test_suite"
+        ],
+        "rule": "claim_gate_block",
+        "severity": "high",
+        "transition_class": "prototype_to_production",
+        "transition_verdict": "BLOCK"
+      }
+    ]
+  },
+  "checks": {
+    "check_observations_status": "NONE_RECORDED",
+    "check_observations": [],
+    "absence_visibility": [
+      {
+        "field": "check_observations",
+        "observed_value": [],
+        "meaning": "No required-check observations were recorded in this artifact."
+      },
+      {
+        "field": "channels.replay",
+        "observed_value": "NOT_RUN",
+        "meaning": "Replay was not run for this PR Gate artifact."
+      }
+    ]
+  },
+  "evidence": {
+    "pack_id": "prgate_pack_0659bcbd9ca2cdb7",
+    "pack_manifest_sha256": "sha256:b752cdd27a3370b1b15238571fbccef1aaa3edc3a7e01b4176680f77a47f104f",
+    "pack_root_sha256": "sha256:8cf5b64706a015c7eb9840d316f6592277ebdc7eead3594b61f585a80551aa94",
+    "evidence_refs": [
+      {
+        "kind": "Evidence Box",
+        "path": "proof-pack/pack_manifest.json",
+        "sha256": "sha256:b752cdd27a3370b1b15238571fbccef1aaa3edc3a7e01b4176680f77a47f104f"
+      },
+      {
+        "kind": "Verification Report",
+        "path": "signed-report/verify_report.json",
+        "sha256": null
+      },
+      {
+        "kind": "Signature Proof",
+        "path": "signed-report/verify_report.sigstore.json",
+        "sha256": null
+      }
+    ],
+    "pack_manifest": {
+      "schema_version": "assay.pr_gate.pack_manifest.v0.1",
+      "files": [
+        {
+          "bytes": 17797,
+          "path": "pr_gate_evidence.json",
+          "sha256": "sha256:ec957c49eedcdcd047f01d8de11e1ec024ee185f4d4b7a6cdeaaadd407e38fbc"
+        },
+        {
+          "bytes": 1030,
+          "path": "pr_gate_decision.json",
+          "sha256": "sha256:654b4ff9e607475a52fc9a824a1ab61cce6e9fde1d02b616bcc4777ce5859b76"
+        },
+        {
+          "bytes": 192,
+          "path": "changed_files.json",
+          "sha256": "sha256:7ad6603e0bb8a37f649d9f411daf7c03b84d6b7d88af280113958f1583fac340"
+        },
+        {
+          "bytes": 2052,
+          "path": "observed_checks.json",
+          "sha256": "sha256:6be835beb9af781a77d26a8196a81c40e6160a899ef6ea12df61c01aaebd2029"
+        },
+        {
+          "bytes": 715,
+          "path": "policy.yml",
+          "sha256": "sha256:17e6cd6a5c43a2201f11c1c438189e97fcbd1c26e7075c3c285751c0cf16417c"
+        },
+        {
+          "bytes": 1143,
+          "path": "verify_transcript.md",
+          "sha256": "sha256:18990f6f739d7b077dcb54e6a8227878bbf0c1d1031d299e5f4a1c33e48a689d"
+        }
+      ]
+    }
+  },
+  "do_not_infer": [
+    "code is secure",
+    "all possible tests passed",
+    "AI made a good design decision",
+    "replay was performed",
+    "production approval was granted"
+  ],
+  "unavailable_or_not_derived": [
+    {
+      "field": "evidence_refs[Verification Report].sha256",
+      "observed_value": null,
+      "reason": "The signed report evidence reference in the source report records this value as null."
+    },
+    {
+      "field": "evidence_refs[Signature Proof].sha256",
+      "observed_value": null,
+      "reason": "The signature proof evidence reference in the source report records this value as null."
+    },
+    {
+      "field": "proof-pack/pack_manifest.json.root_sha256",
+      "observed_value": null,
+      "reason": "The manifest field is null; the report-level pack_root_sha256 is preserved separately."
+    }
+  ],
+  "derivation_checks": {
+    "decision_overall_matches_report": true,
+    "decision_recommended_action_matches_report": true,
+    "decision_channels_match_report": true,
+    "manifest_pack_root_matches_report": true
+  }
+}


### PR DESCRIPTION
## Summary

Adds a docs-only PR Review Proof Card v0 observed surface under `docs/public_surfaces/pr-review-proof-card-v0/`.

This is not a generic Proof Card schema and not a new verifier. It is one consumer-specific reader projection for a maintainer or tech lead reviewing an AI-assisted pull request at the PR review moment.

## Why

Assay already emits signed PR Gate review packets and PR comments that show verdict channels, evidence boundaries, and what must not be inferred. The missing public surface was a grounded, reader-facing example that shows how a real PR Gate artifact can be projected into a compact review card without turning the card into independent authority.

This slice uses a `NEEDS_REVIEW` example rather than a green pass because it keeps the important behavior visible: failure and absence are first-class outputs.

## Source Artifact

Primary source:

- GitHub Actions run: `27047357238`
- Artifact: `assay-pr-gate-report`
- PR: `#161`
- Signed report: `signed-report/verify_report.json`

Source precedence is documented in `SOURCE_ARTIFACT.md`:

1. `signed-report/verify_report.json` is canonical.
2. `decision.json` is used for matching PR Gate decision fields.
3. `proof-pack/pack_manifest.json` is used for evidence-pack structure.
4. `comment.md` is rendered-output comparison only, not authority.

The signed Verification Report remains the canonical source of truth.

## What Changed

- Added `README.md` to define the consumer, call site, decision, and non-authority boundary.
- Added `SOURCE_ARTIFACT.md` to record the source run, artifact, PR, subject, and freshness note.
- Added `DERIVATION.md` with field mappings and the exact `jq` derivation command.
- Added `examples/pr_161_needs_review.observed.json`, derived from the real PR Gate artifact.
- Added `COLD_READ.md` to test whether a stranger can identify what ran, what failed, what did not run, and what must not be inferred.

## Non-Goals

- No `proof_card.schema.json`.
- No `assay proof-card verify` command.
- No dashboard.
- No generic Proof Card v0 surface.
- No claim that the card proves truth, correctness, safety, security, or merge-readiness.

## Validation

- `python3 -m json.tool docs/public_surfaces/pr-review-proof-card-v0/examples/pr_161_needs_review.observed.json`
- `git diff --check`
- Staged diff whitespace check with `git diff --cached --check`
- Untracked-file whitespace check with `git diff --no-index --check`
- Overclaim grep for forbidden phrases; hits were limited to explicit non-claim / do-not-infer sections.

Note: `python` is not available on this machine's PATH, so JSON validation used `python3`.
