### PR TITLE
fix(test): isolate gate-compare tests from the operator's real Assay store

### DIFF
--- a/tests/assay/test_comparability.py
+++ b/tests/assay/test_comparability.py
@@ -1471,10 +1471,32 @@ class TestGateCompare:
     """assay gate compare is fail-closed. Only SATISFIED passes."""
 
     @pytest.fixture
-    def cli_env(self, tmp_path):
-        """Set up contract and bundle files for gate tests."""
+    def cli_env(self, tmp_path, monkeypatch):
+        """Set up contract and bundle files for gate tests.
+
+        Isolates the Assay store. `gate compare` emits a governance receipt via
+        assay.store.emit_receipt(), which writes through a process-level cached
+        singleton (get_default_store / _default_store) bound to
+        ``Path.home() / ".assay"`` at first use. Without isolation these tests
+        read/write the operator's real append-only store, so their verdict
+        depends on host state -- e.g. a legacy store without ``_store_seq`` makes
+        governance emission fail-close and the gate exits 3. Redirect HOME to a
+        per-test tmp dir AND drop the cached singleton so emit_receipt rebuilds
+        the store against the isolated HOME. monkeypatch restores both at
+        teardown, so the operator's real store is never touched.
+        """
         from typer.testing import CliRunner
+        import assay.store as _assay_store
         from assay.commands import assay_app
+
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("USERPROFILE", str(home))  # Path.home() on Windows
+        # The default store is a module-level singleton built once per process
+        # (store.py:_default_store). Reset it so the next get_default_store()
+        # picks up the patched HOME instead of a stale real-store handle.
+        monkeypatch.setattr(_assay_store, "_default_store", None)
 
         contract = tmp_path / "contract.json"
         contract.write_text(json.dumps({


### PR DESCRIPTION
## What
`TestGateCompare` invoked `assay gate compare` in-process, which emits a governance receipt via `store.emit_receipt()` → `get_default_store()` — a process-level singleton bound to `Path.home()/.assay` at first use. On a host whose real `~/.assay` holds legacy receipts (no `_store_seq`), governance emission fail-closes and the gate exits 3. So the suite verdict depended on host state: green on a clean CI runner, red on a populated dev machine.

## Fix
Test-only. `cli_env` redirects `HOME`/`USERPROFILE` to a per-test tmp dir **and** resets the `_default_store` singleton so `emit_receipt` rebuilds against the isolated HOME. `monkeypatch` restores both at teardown; the operator's real store is never read or written.

## Verification (environment-scoped)
- `tests/assay/test_comparability.py`: **136 passed** (was 130 passed / 6 failed) on macOS with a populated legacy `~/.assay`.
- Full suite from this branch: **3538 passed / 0 failed** on the same host.
- No `src/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
