### PR TITLE
feat(render): Scope & Caveats panel in verify-pack --html report

### DIFF
--- a/src/assay/commands.py
+++ b/src/assay/commands.py
@@ -3723,6 +3723,7 @@ def verify_pack_cmd(
 
         if html_out:
             from assay import __version__ as _assay_version
+            from assay.verify_report import build_scope
 
             html_str = render_verification_html(
                 verdict=_verdict,
@@ -3737,6 +3738,13 @@ def verify_pack_cmd(
                 warnings=result.warnings,
                 head_hash=result.head_hash,
                 version=_assay_version,
+                # Canonical scope derivation -- same inputs build_verify_report
+                # receives below, pinned identical by conformance test.
+                scope=build_scope(
+                    verify_result=result,
+                    claim_check=claim_check,
+                    trust_eval=trust_eval,
+                ),
             )
             html_path = Path(html_out)
             html_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/assay/verify_render.py
+++ b/src/assay/verify_render.py
@@ -16,6 +16,64 @@ from assay.verification_status import (
 )
 
 
+def _humanize(item: str) -> str:
+    """Render a scope vocabulary identifier as readable text."""
+    return item.replace("_", " ")
+
+
+def _render_scope_panel(scope: Optional[Dict[str, Any]]) -> str:
+    """Render the Scope & Caveats panel from a verify_report scope object.
+
+    Display-only: this renders what the verifier already computed. It must
+    never derive or adjust verdicts. Returns "" when no scope is provided
+    (older reports without the scope object).
+    """
+    if not scope:
+        return ""
+
+    proves = scope.get("proves") or []
+    does_not_prove = scope.get("does_not_prove") or []
+    channels = scope.get("channels") or {}
+    note = scope.get("note")
+
+    proves_items = "".join(
+        f'<li class="proves">{html.escape(_humanize(str(p)))}</li>' for p in proves
+    )
+    dnp_items = "".join(
+        f'<li class="does-not-prove">{html.escape(_humanize(str(d)))}</li>'
+        for d in does_not_prove
+    )
+    channel_rows = "".join(
+        f"<tr><td>{html.escape(str(name))}</td>"
+        f"<td>{html.escape(_humanize(str(status)))}</td></tr>"
+        for name, status in channels.items()
+    )
+    note_html = (
+        f'<p class="scope-note">{html.escape(str(note))}</p>' if note else ""
+    )
+
+    return f"""<h3>Scope &amp; Caveats</h3>
+<div class="scope-panel">
+{note_html}
+<div class="scope-cols">
+<div>
+<h4>This verification proves</h4>
+<ul>{proves_items}</ul>
+</div>
+<div>
+<h4>This verification does <em>not</em> prove</h4>
+<ul>{dnp_items}</ul>
+</div>
+</div>
+<h4>Verdict channels</h4>
+<table>
+<tr><th>Channel</th><th>Status</th></tr>
+{channel_rows}
+</table>
+</div>
+"""
+
+
 def render_verification_html(
     *,
     verdict: VerificationVerdict,
@@ -31,6 +89,7 @@ def render_verification_html(
     head_hash: Optional[str] = None,
     generated_at: Optional[str] = None,
     version: Optional[str] = None,
+    scope: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Render a self-contained HTML verification report.
 
@@ -74,6 +133,9 @@ def render_verification_html(
             warning_rows += f"<li>{html.escape(w)}</li>"
         warning_rows += "</ul>"
 
+    # Scope & Caveats panel (display-only; "" when scope absent)
+    scope_panel = _render_scope_panel(scope)
+
     return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -93,6 +155,13 @@ def render_verification_html(
   code {{ background: #f6f8fa; padding: 0.15rem 0.4rem; border-radius: 3px; font-size: 0.9em; }}
   pre {{ background: #f6f8fa; padding: 0.8rem; border-radius: 4px; overflow-x: auto; font-size: 0.85rem; }}
   .footer {{ margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #d0d7de; color: #57606a; font-size: 0.8rem; }}
+  .scope-panel {{ border: 1px solid #d0d7de; border-radius: 6px; padding: 0.8rem 1rem; margin-bottom: 1rem; }}
+  .scope-panel h4 {{ font-size: 0.9rem; margin: 0.6rem 0 0.3rem; }}
+  .scope-cols {{ display: flex; gap: 2rem; flex-wrap: wrap; }}
+  .scope-cols > div {{ flex: 1; min-width: 240px; }}
+  li.proves {{ color: #1a7f37; }}
+  li.does-not-prove {{ color: #57606a; }}
+  .scope-note {{ background: #fff8c5; border: 1px solid #d4a72c66; border-radius: 4px; padding: 0.5rem 0.8rem; font-size: 0.9rem; }}
 </style>
 </head>
 <body>
@@ -121,7 +190,7 @@ def render_verification_html(
 
 {error_rows}
 {warning_rows}
-
+{scope_panel}
 <h3>Reproduce</h3>
 <pre>assay verify-pack {e_pack_dir}</pre>
 

--- a/src/assay/verify_report.py
+++ b/src/assay/verify_report.py
@@ -180,6 +180,36 @@ def _scope(
     return scope
 
 
+def build_scope(
+    *,
+    verify_result: Any,
+    claim_check: Optional[str] = None,
+    claim_result: Optional[Any] = None,
+    replay_verdict: str = "NOT_RUN",
+    trust_eval: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """Public canonical scope derivation for renderers.
+
+    Resolves the channel verdicts through the same helpers
+    `build_verify_report` uses, then delegates to `_scope`. Renderers must
+    call this (or read `verify_report["scope"]` directly) rather than
+    deriving their own boundary — one scope truth, no parallel verdict
+    engine. A conformance test pins this against the report's scope.
+    """
+    if claim_result is not None:
+        claim_verdict = (
+            "PASS" if getattr(claim_result, "passed", False) else "HONEST_FAIL"
+        )
+    else:
+        claim_verdict = _legacy_claim_check(claim_check)
+    return _scope(
+        integrity_verdict="PASS" if verify_result.passed else "TAMPERED",
+        claim_verdict=claim_verdict,
+        replay_verdict=_replay_verdict(replay_verdict),
+        trust_verdict=_trust_verdict(trust_eval),
+    )
+
+
 def _pass_reason(*, unevaluated_channels: tuple[str, ...]) -> str:
     if not unevaluated_channels:
         return "required_channels_passed"

--- a/tests/assay/test_verify_render.py
+++ b/tests/assay/test_verify_render.py
@@ -19,6 +19,7 @@ from assay.verification_status import (
     classify_verdict,
 )
 from assay.verify_render import render_verification_badge, render_verification_html
+from assay.verify_report import build_scope, build_verify_report
 
 
 # ---------------------------------------------------------------------------
@@ -120,6 +121,100 @@ class TestRenderHtml:
     def test_html_includes_receipt_count(self):
         html = render_verification_html(**_HTML_DEFAULTS)
         assert "3" in html
+
+
+# ---------------------------------------------------------------------------
+# Scope & Caveats panel (display-only rendering of verify_report scope)
+# ---------------------------------------------------------------------------
+
+
+def _scope_for(*, passed: bool, claim_check: str = "N/A") -> Dict[str, Any]:
+    return build_scope(
+        verify_result=VerifyResult(passed=passed), claim_check=claim_check
+    )
+
+
+class TestScopePanel:
+    def test_no_scope_no_panel(self):
+        """Older reports without scope render no panel (backward compat)."""
+        html = render_verification_html(**_HTML_DEFAULTS)
+        assert "Scope &amp; Caveats" not in html
+
+    def test_pass_panel_shows_proves_and_boundaries(self):
+        html = render_verification_html(
+            **_HTML_DEFAULTS, scope=_scope_for(passed=True, claim_check="PASS")
+        )
+        assert "Scope &amp; Caveats" in html
+        # Proves (humanized from scope vocabulary)
+        assert "pack integrity" in html
+        assert "receipt sequence integrity" in html
+        assert "signature validity" in html
+        assert "claim set satisfied" in html
+        # Standing boundaries always render
+        assert "output safety" in html
+        assert "instrumentation completeness" in html
+        assert "signer authority beyond configured trust" in html
+        # Channels table
+        assert "Verdict channels" in html
+        assert "integrity" in html
+
+    def test_tampered_panel_collapses(self):
+        """The money shot: a tampered pack proves only tamper detection."""
+        scope = _scope_for(passed=False, claim_check="PASS")
+        html = render_verification_html(
+            **{**_HTML_DEFAULTS, "verdict": "TAMPERED", "integrity_passed": False},
+            scope=scope,
+        )
+        assert "tamper evidence detected" in html
+        # Integrity facts must appear ONLY in does-not-prove items, never as proves
+        assert html.count('<li class="proves">') == 1
+        assert '<li class="does-not-prove">pack integrity</li>' in html
+        assert '<li class="does-not-prove">signature validity</li>' in html
+        # The not-intact note renders
+        assert "not intact" in html
+
+    def test_panel_escapes_scope_content(self):
+        """Scope content is untrusted input to the renderer: escape it."""
+        hostile = {
+            "schema": "assay.verify.scope.v1",
+            "channels": {"integrity": "<script>x</script>"},
+            "proves": ["<img src=x onerror=alert(1)>"],
+            "does_not_prove": [],
+            "note": "<script>alert(1)</script>",
+            "extensions": {},
+        }
+        html = render_verification_html(**_HTML_DEFAULTS, scope=hostile)
+        assert "<script>" not in html
+        assert "<img" not in html
+
+    def test_build_scope_conforms_to_report_scope(self):
+        """The HTML panel and verify_report.json must share one scope truth.
+
+        build_scope (renderer path) must equal build_verify_report's scope
+        (report path) for identical inputs -- pinned mechanically, not by
+        convention.
+        """
+        for passed, claim_check in (
+            (True, "N/A"),
+            (True, "PASS"),
+            (True, "FAIL"),
+            (False, "N/A"),
+            (False, "PASS"),
+        ):
+            result = VerifyResult(passed=passed)
+            report = build_verify_report(
+                verify_result=result,
+                verified_at="2026-06-10T00:00:00+00:00",
+                verifier_name="t",
+                verifier_version="t",
+                claim_check=claim_check,
+                pack_root_sha256="a" * 64,
+                pack_manifest_sha256="a" * 64,
+            )
+            assert (
+                build_scope(verify_result=result, claim_check=claim_check)
+                == report["scope"]
+            ), f"scope drift for passed={passed} claim_check={claim_check}"
 
     def test_html_includes_head_hash_truncated(self):
         html = render_verification_html(**_HTML_DEFAULTS)


### PR DESCRIPTION
## What
`assay verify-pack --html` now renders a **Scope & Caveats** panel: `proves` (affirmed, green), `does_not_prove` (muted), a verdict-channels table, and on TAMPERED the collapse — exactly one `proves` item (`tamper_evidence_detected`) plus the not-intact note in a warning box. This is the static-report tier of the scope object merged in #165.

## Design — by construction, not convention
- New public `build_scope()` in `verify_report.py` is the **single legal scope derivation** for renderers, pinned to `build_verify_report`'s scope by a conformance test across five verdict combinations — the HTML and the JSON cannot drift without a test failing.
- The panel is **display-only** and `html.escape`s every scope item (scope is untrusted input to the renderer; a `<script>` in a `proves` item gets escaped).
- Omitted entirely when scope is absent — old reports still render.

## Scope / boundaries
- This is the **static `--html` report** tier only. The interactive client-side verifier (`assay-verify-ts` → Pages) is a separate, deferred project that requires a Python↔TS scope conformance gate — intentionally **not** in this PR.
- No verdict-logic changes; rendering plus one derivation helper only.

## Verification (environment-scoped)
- `tests/assay/test_verify_render.py`: **29 passed on macOS** with a populated real `~/.assay` (5 new: panel-on-PASS, TAMPERED collapse, no-scope compat, hostile-content escaping, `build_scope`↔report conformance).
- Reported green in the Linux sandbox (clean HOME) at full-suite 3,593 passed / 24 skipped / 1 xfailed; CI re-verifies across the matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
