### PR TITLE
feat: add OpenClaw session evidence check

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ See:
 - [PR Gate comment contract](docs/product/assay-pr-gate-comment-v0.md)
 - [PR Gate policy profile](docs/product/assay-pr-gate-policy-v0.md)
 - [PR Gate trust root](docs/adr/ADR-pr-gate-trust-root.md)
+- [Provenance crosswalk](docs/public_surfaces/provenance-crosswalk-v0/README.md)
 
 ## Evidence Sprint
 
@@ -864,6 +865,15 @@ or main product.
 
 - **OpenClaw demo:** `assay try-openclaw` — deterministic subprocess-membrane demo + receipt adapter + signed proof pack
 - [OpenClaw v1 Claim Sheet](docs/openclaw-v1-claim-sheet.md) -- tight public claim: proofs, non-proofs, trust assumptions, and required artifacts
+
+**How this sits next to OpenClaw observability plugins.** For live OpenClaw
+observability and dashboards, see [ClawMetry](https://clawhub.ai/vivekchand/clawmetry) —
+OpenClaw keeps that kind of telemetry ingestion in plugin/community territory rather than
+core ([#7783](https://github.com/openclaw/openclaw/issues/7783), closed *not planned*).
+Assay's OpenClaw support is narrower: it acts as an **evidence membrane** for selected
+session-log traces, importing supported rows with skipped-row accounting and emitting
+**offline-verifiable proof packs**. It does not claim complete runtime capture, live
+Gateway interception, or planner/browser truth.
 
 ## Common Issues
 

--- a/clawhub/assay-openclaw-evidence-check/SKILL.md
+++ b/clawhub/assay-openclaw-evidence-check/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: assay-openclaw-evidence-check
+description: >-
+  Turn a selected OpenClaw session-log trace into offline-verifiable Assay
+  evidence. Reports which rows imported, which were skipped (with reasons), and
+  which tool calls were surfaced, then fails closed when there is nothing real to
+  import. Read-only. Not a dashboard. For live telemetry, use ClawMetry.
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - assay
+    homepage: https://github.com/Haserjian/assay
+---
+
+# Assay OpenClaw Evidence Check
+
+Assay is an **evidence membrane**, not an observability dashboard. For live
+cost/token/health telemetry and event-flow visualization, use
+[ClawMetry](https://clawhub.ai/vivekchand/clawmetry) — OpenClaw keeps that kind
+of ingestion in plugin/community territory
+([#7783](https://github.com/openclaw/openclaw/issues/7783), closed *not planned*).
+
+Use Assay for the narrower, complementary job: when someone needs to **review or
+prove** what a *selected* agent action did — to a reviewer who does not trust the
+operator — with evidence that can be verified offline and cannot be quietly
+edited after the fact.
+
+## When to use this skill
+
+- You have an exported OpenClaw session log (`~/.openclaw/agents/<id>/sessions/*.jsonl`)
+  and you want a scoped, honest record of what it contains.
+- You want imported-vs-skipped accounting and surfaced tool calls, not a live dashboard.
+- You want a signed, offline-verifiable proof pack for the deterministic demo path.
+
+## Two modes
+
+### Real OpenClaw session check
+
+Use this for an existing OpenClaw `sessions/*.jsonl` file:
+
+```bash
+pip install assay-ai
+assay openclaw verify /path/to/session.jsonl
+```
+
+This performs import, attribution, skipped-row accounting, and fail-closed
+validation, reporting per log:
+
+- imported vs skipped rows, with skip reasons (invalid JSON, unsupported tool, invalid row)
+- a `clean` vs `partial` import status
+- recognized entry types and message roles
+- which tool calls were surfaced and attributed
+
+If the file is missing or nothing importable is found, it exits non-zero and
+reports a blocked result instead of inventing confidence (add `--json` for
+machine-readable output). **It does not mint a signed proof pack from arbitrary
+session logs yet** — for that, use the deterministic demo below.
+
+### Deterministic proof-pack demo
+
+Use this to see Assay's signed proof-pack path:
+
+```bash
+assay try-openclaw
+assay verify-pack ./assay_openclaw_demo/proof_pack
+```
+
+`try-openclaw` builds a signed proof pack from a deterministic, synthetic
+OpenClaw path (no live OpenClaw process required); `verify-pack` verifies it
+offline. A failed underlying run still yields an honest, verifiable receipt;
+only broken or tampered evidence counts as a real failure.
+
+## What this does NOT prove
+
+- complete runtime capture of all OpenClaw activity
+- live OpenClaw Gateway or WebSocket interception
+- planner correctness or browser-page semantic truth
+- that the imported session log was complete or honest before Assay read it
+- a hostile multi-tenant security boundary
+
+`assay openclaw verify` reports import + attribution over the session log you
+give it; it does not itself mint a signed proof pack from an arbitrary session.
+The signed proof-pack path is the deterministic `try-openclaw` demo above.
+
+## Safety
+
+This skill runs only two things: `pip install assay-ai` and the `assay` CLI. No
+install scripts, no piped shell, no network fetch of code. That boringness is the
+point — it is the anti-chaos layer.

--- a/src/assay/commands.py
+++ b/src/assay/commands.py
@@ -2436,6 +2436,102 @@ def try_openclaw_cmd(
     )
 
 
+openclaw_app = typer.Typer(
+    name="openclaw",
+    help="Verify real exported OpenClaw session logs.",
+    no_args_is_help=True,
+)
+
+
+@openclaw_app.command("verify")
+def openclaw_verify_cmd(
+    session_logs: List[str] = typer.Argument(
+        ...,
+        metavar="SESSION_LOG...",
+        help="One or more exported OpenClaw session .jsonl files to verify.",
+    ),
+    allowlist: str = typer.Option(
+        "*",
+        "--allowlist",
+        help="Browser allowlist pattern used during import (default: '*').",
+    ),
+    output_json: bool = typer.Option(False, "--json", help="Structured output"),
+):
+    """Import selected exported OpenClaw session logs and report what was found.
+
+    Read-only and fail-closed. It records which rows imported, which were
+    skipped (with reasons), which tool calls were surfaced, and a clean/partial
+    status. If a file is missing or nothing importable is found, it returns a
+    blocked result instead of inventing confidence.
+
+    It does NOT claim complete runtime capture, live OpenClaw Gateway
+    interception, planner correctness, browser-page truth, or that the imported
+    log was complete or honest before Assay read it. For a signed,
+    offline-verifiable proof pack, see: assay try-openclaw.
+    """
+    from pathlib import Path
+
+    from assay.openclaw_validation import (
+        render_openclaw_live_validation,
+        validate_openclaw_session_logs,
+    )
+
+    # Fail closed on missing or unreadable inputs before importing anything.
+    paths = [Path(raw).expanduser() for raw in session_logs]
+    missing = [str(path) for path in paths if not path.is_file()]
+    if missing:
+        if output_json:
+            _output_json(
+                {
+                    "command": "openclaw verify",
+                    "status": "blocked",
+                    "reason": "session_log_missing",
+                    "missing": missing,
+                },
+                exit_code=3,
+            )
+        console.print(f"[red]No readable session log at:[/] {', '.join(missing)}")
+        console.print(
+            "[dim]Fail-closed: nothing imported, no confidence invented.[/]"
+        )
+        raise typer.Exit(3)
+
+    result = validate_openclaw_session_logs(
+        session_log_paths=paths,
+        allowlist=[allowlist],
+    )
+
+    # Fail closed when no importable rows were recognized in any provided log.
+    nothing_imported = result.status != "ok" or result.imported_count == 0
+
+    if output_json:
+        payload = result.to_dict()
+        payload["command"] = "openclaw verify"
+        if nothing_imported and result.status == "ok":
+            payload["status"] = "blocked"
+            payload["reason"] = "no_rows_imported"
+        _output_json(payload, exit_code=1 if nothing_imported else 0)
+        return
+
+    console.print(render_openclaw_live_validation(result))
+    console.print()
+    if nothing_imported:
+        console.print(
+            "[yellow]Fail-closed:[/] no importable rows found; not reporting success."
+        )
+        raise typer.Exit(1)
+    console.print(
+        "[dim]Scope: import + attribution only. Not complete runtime capture, "
+        "live Gateway interception, or planner/browser truth.[/]"
+    )
+    console.print(
+        "[dim]For a signed, offline-verifiable proof pack, see: [green]assay try-openclaw[/][/]"
+    )
+
+
+assay_app.add_typer(openclaw_app, name="openclaw", rich_help_panel=_TRY_PANEL)
+
+
 # --- End of early Start Here registration ---
 
 

--- a/tests/assay/test_openclaw_verify_cmd.py
+++ b/tests/assay/test_openclaw_verify_cmd.py
@@ -1,0 +1,116 @@
+"""Tests for the `assay openclaw verify` command.
+
+These exercise the read-only session-log verify path against the committed
+OpenClaw fixtures and confirm the fail-closed contract for missing/empty input.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from assay.commands import assay_app
+
+runner = CliRunner()
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "openclaw"
+LIVE_EXEC = (
+    FIXTURES
+    / "live_validation_home"
+    / "agents"
+    / "main"
+    / "sessions"
+    / "assay-openai-live-1.jsonl"
+)
+LIVE_WEB_FETCH = (
+    FIXTURES
+    / "live_validation_web_fetch_home"
+    / "agents"
+    / "main"
+    / "sessions"
+    / "assay-openai-live-2.jsonl"
+)
+
+
+def test_verify_reports_imported_rows_and_tools() -> None:
+    result = runner.invoke(
+        assay_app,
+        ["openclaw", "verify", str(LIVE_EXEC), str(LIVE_WEB_FETCH)],
+    )
+    assert result.exit_code == 0, result.stdout
+    assert "2 log(s), 16 imported row(s)" in result.stdout
+    assert "exec=1" in result.stdout
+    assert "web_fetch=1" in result.stdout
+    # Scope discipline must be visible in the human output.
+    assert "Not complete runtime capture" in result.stdout
+
+
+def test_verify_json_surfaces_counts_and_tools() -> None:
+    result = runner.invoke(
+        assay_app,
+        ["openclaw", "verify", "--json", str(LIVE_EXEC), str(LIVE_WEB_FETCH)],
+    )
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["command"] == "openclaw verify"
+    assert payload["status"] == "ok"
+    assert payload["imported_count"] == 16
+    assert payload["skipped_count"] == 0
+    observed_tools: dict[str, int] = {}
+    for log in payload["validated_logs"]:
+        for tool, count in log["imported_tools"].items():
+            observed_tools[tool] = observed_tools.get(tool, 0) + count
+    assert observed_tools.get("exec") == 1
+    assert observed_tools.get("web_fetch") == 1
+
+
+def test_verify_fails_closed_on_missing_file() -> None:
+    result = runner.invoke(
+        assay_app,
+        ["openclaw", "verify", "./definitely_not_here.jsonl"],
+    )
+    assert result.exit_code == 3, result.stdout
+    assert "No readable session log" in result.stdout
+
+
+def test_verify_json_blocked_on_missing_file() -> None:
+    result = runner.invoke(
+        assay_app,
+        ["openclaw", "verify", "--json", "./definitely_not_here.jsonl"],
+    )
+    assert result.exit_code == 3, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "blocked"
+    assert payload["reason"] == "session_log_missing"
+
+
+def test_verify_fails_closed_on_empty_file(tmp_path: Path) -> None:
+    empty = tmp_path / "empty.jsonl"
+    empty.write_text("", encoding="utf-8")
+    result = runner.invoke(assay_app, ["openclaw", "verify", str(empty)])
+    assert result.exit_code == 1, result.stdout
+    assert "Fail-closed" in result.stdout
+
+
+def test_verify_reports_skipped_rows(tmp_path: Path) -> None:
+    """A malformed row must be surfaced as skipped, not silently dropped."""
+    log = tmp_path / "mixed.jsonl"
+    log.write_text(
+        "\n".join(
+            [
+                json.dumps({"type": "session"}),
+                "{not valid json",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    result = runner.invoke(assay_app, ["openclaw", "verify", "--json", str(log)])
+    payload = json.loads(result.stdout)
+    log_report = payload["validated_logs"][0]
+    assert log_report["imported_count"] == 1
+    assert log_report["skipped_count"] == 1
+    assert log_report["completeness"] == "partial"
+    assert "invalid_json" in log_report["skipped_reasons"]


### PR DESCRIPTION
## What
Adds `assay openclaw verify <session.jsonl>` — a read-only, fail-closed importer for
real exported OpenClaw session logs. Reports imported vs skipped rows (with reasons),
surfaced tool calls, and clean/partial status; returns a blocked (non-zero) result
instead of inventing confidence when nothing importable is found.

## Why
OpenClaw session logs are the read-only slice of the observability need the OpenClaw
team declined to build in-core (openclaw/openclaw#7783, closed not planned → ClawHub/
community plugins). Live telemetry/dashboards are already covered by ClawMetry; this is
the complementary verification/evidence side.

## Scope (honest)
- Thin wrapper over the existing `validate_openclaw_session_logs`; no new importer.
- Does NOT mint a signed proof pack from arbitrary sessions — the signed path stays the
  deterministic `assay try-openclaw` demo (real sessions carry `exec`, not a pack tool type).
- No live Gateway interception, no complete-runtime-capture claim, no planner/browser truth.

## Changes
- `src/assay/commands.py`: `openclaw` sub-app + `verify` command.
- `tests/assay/test_openclaw_verify_cmd.py`: 6 tests (happy path on committed fixtures,
  `--json`, missing-file, empty-file fail-closed).
- `README.md`: positions Assay's OpenClaw support beside observability plugins (ClawMetry, #7783).
- `clawhub/assay-openclaw-evidence-check/SKILL.md`: draft standalone ClawHub skill
  (not published) declaring `requires.bins: [assay]`; read-only, fail-closed.

## Tests
`pytest tests/assay/test_openclaw_verify_cmd.py tests/assay/test_openclaw_demo.py -q` -> 10 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
