### PR TITLE
fix: link episode.settled receipts to predecessor

### DIFF
--- a/src/assay/episode.py
+++ b/src/assay/episode.py
@@ -1122,6 +1122,7 @@ class Episode:
                 "evidence_refs": list(payload["evidence_refs"]),
                 "directed": True,
             },
+            parent_receipt_id=self.receipts[-1].receipt_id if self.receipts else None,
             created_at=decision_time,
             enforce_state=False,
         )
@@ -1313,6 +1314,7 @@ class Episode:
                 "contradiction_ids": list(contradiction_ids),
                 "tampered": tampered,
             },
+            parent_receipt_id=self.receipts[-1].receipt_id if self.receipts else None,
             created_at=decision_time,
             enforce_state=False,
         )

--- a/tests/assay/test_episode.py
+++ b/tests/assay/test_episode.py
@@ -536,3 +536,55 @@ class TestImportSurface:
         import assay
 
         assert callable(assay.verify_checkpoint)
+
+
+# ---------------------------------------------------------------------------
+# episode.settled lineage (parent_receipt_id closure)
+# ---------------------------------------------------------------------------
+
+
+class TestSettledLineage:
+    """The terminal ``episode.settled`` receipt must assert its parent so the
+    causal chain closes at the source, with nothing left for a downstream
+    adapter to invent."""
+
+    def test_auto_settle_links_parent_to_immediate_predecessor(self, tmp_store):
+        ep = open_episode(episode_id="settled_auto", store=tmp_store)
+        ep.emit("model.invoked", {"model": "x"})
+        predecessor = ep.receipts[-1].receipt_id  # last receipt before settle()
+
+        ep.settle()
+
+        settled = [r for r in ep.receipts if r.receipt_type == "episode.settled"][-1]
+        assert settled.parent_receipt_id == predecessor
+        assert settled.to_trace_dict()["parent_receipt_id"] == predecessor
+
+    def test_degenerate_open_then_settle_links_to_opened(self, tmp_store):
+        """An episode with no work receipts still closes lineage: settled links
+        to the opened receipt (the only predecessor)."""
+        ep = open_episode(episode_id="settled_degenerate", store=tmp_store)
+        opened = ep.receipts[-1]
+        assert opened.receipt_type == "episode.opened"
+
+        ep.settle()
+
+        settled = [r for r in ep.receipts if r.receipt_type == "episode.settled"][-1]
+        assert settled.parent_receipt_id == opened.receipt_id
+
+    def test_proof_pack_still_verifies_with_settled_parent(self, tmp_store, tmp_path):
+        """Adding the parent changes the settled receipt's canonical hash; a
+        freshly built pack must remain self-consistent and verify."""
+        ks = AssayKeyStore(keys_dir=tmp_path / "keys")
+        ep = open_episode(episode_id="settled_pack", store=tmp_store)
+        r1 = ep.emit("model.invoked", {"model": "x"})
+        ep.emit("guardian.approved", {"ok": True}, parent_receipt_id=r1)
+        ep.settle()
+
+        artifact = ep.emit_proof_pack(output_dir=tmp_path / "pack", keystore=ks)
+        verdict = verify_pack(artifact.pack_dir)
+
+        assert verdict.ok is True
+        entries = tmp_store.read_trace(ep.trace_id)
+        settled = [e for e in entries if e.get("type") == "episode.settled"]
+        assert len(settled) == 1
+        assert settled[0].get("parent_receipt_id")  # present and non-null in the pack

--- a/tests/assay/test_episode_state_directive.py
+++ b/tests/assay/test_episode_state_directive.py
@@ -109,6 +109,29 @@ def test_close_as_tainted_settles_episode_as_tampered(tmp_store: AssayStore) -> 
     assert settled[-1].payload["directed"] is True
 
 
+def test_directed_terminal_settlement_links_parent_to_predecessor(
+    tmp_store: AssayStore,
+) -> None:
+    """The directed terminal path must also stamp lineage: the emitted
+    ``episode.settled`` receipt links to its immediate predecessor in the
+    trace (here the ``episode.state_directed`` receipt)."""
+    episode = open_episode(store=tmp_store)
+    episode.emit("model.invoked", {"model": "x"})
+    episode.mark_execution_complete()
+
+    apply_episode_state_directive(
+        episode,
+        _directive(episode.episode_id, EpisodeDirectiveCode.CLOSE_AS_TAINTED),
+    )
+
+    settled = _receipts(episode, "episode.settled")[-1]
+    idx = episode.receipts.index(settled)
+    predecessor = episode.receipts[idx - 1]
+    assert idx > 0
+    assert settled.parent_receipt_id == predecessor.receipt_id
+    assert settled.to_trace_dict()["parent_receipt_id"] == predecessor.receipt_id
+
+
 def test_close_as_refused_settles_episode_as_honest_fail(tmp_store: AssayStore) -> None:
     episode = open_episode(store=tmp_store)
     episode.start_execution()

--- a/tests/assay/test_episode_state_directive.py
+++ b/tests/assay/test_episode_state_directive.py
@@ -126,8 +126,9 @@ def test_directed_terminal_settlement_links_parent_to_predecessor(
 
     settled = _receipts(episode, "episode.settled")[-1]
     idx = episode.receipts.index(settled)
-    predecessor = episode.receipts[idx - 1]
     assert idx > 0
+    predecessor = episode.receipts[idx - 1]
+    assert predecessor.receipt_type == "episode.state_directed"
     assert settled.parent_receipt_id == predecessor.receipt_id
     assert settled.to_trace_dict()["parent_receipt_id"] == predecessor.receipt_id
 


### PR DESCRIPTION
## What
Adds explicit parent lineage to `episode.settled` receipts at both emit sites:
- `Episode.settle()` auto settlement path
- `_apply_terminal_directive()` directed settlement path

Each settlement receipt now links to the immediate predecessor:
```python
parent_receipt_id=self.receipts[-1].receipt_id if self.receipts else None
```

## Why
`episode.settled` receipts were emitted without parent lineage, creating orphan settlement rows in downstream corpus consumers. This made lineage-closure checks fail even when the episode trace itself was otherwise linear and intact.

This fix makes explicit what the episode emitter already assumes: `self.receipts[-1]` is the predecessor at settlement time.

## Scope
- Source-emitted lineage only.
- Single immediate-predecessor parent.
- No schema version change.
- No multi-parent receipt schema.
- No adapter-side derivation.
- No CCIO / LEM regeneration or wind-tunnel rerun in this PR.

## Compatibility
Old proof packs are unaffected: they simply lack `parent_receipt_id` on older `episode.settled` receipts.

New proof packs that include settlement receipts will produce a different canonical hash for those settlement receipts, because the parent field is now part of the canonical receipt. No in-repo frozen/golden hash fixture was found to depend on settled-inclusive hashes.

## Tests
Focused:
```
pytest tests/assay/test_episode.py tests/assay/test_episode_state_directive.py tests/assay/test_receipt_composition.py -q
```
Result: 85 passed.

Full suite:
```
pytest tests/ -q
```
Result: 3566 passed, 55 skipped, 1 xfailed, 0 failed.

Fresh proof-pack verification was also checked: pack generation including the settled receipt verifies successfully, and the settled row carries `parent_receipt_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMo6RBjdV2ZVjvkggV6wKE
